### PR TITLE
Resolved problem with $Features due to Contains method being case sensit...

### DIFF
--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -342,6 +342,9 @@ function Set-TargetResource
     $SQLData = Get-TargetResource -SourcePath $SourcePath -SourceFolder $SourceFolder -SetupCredential $SetupCredential -Features $Features -InstanceName $InstanceName
     $InstanceName = $InstanceName.ToUpper()
 
+    #@mikefrobbins: The contains method is case sensitive so the specified features have to be in upper case to match the case specified in this function.
+    $Features = $Features.ToUpper()
+
     Import-Module $PSScriptRoot\..\..\xPDT.psm1
 
     $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "setup.exe"


### PR DESCRIPTION
...ive

The Contains method that is used throughout the Set-TargetResource
function is case sensitive. This caused a configuration to fail if the
features were specified in a case other than upper case which is how
they are specified in the function. The easiest way to resolve this
issue was to add a line to convert $Features to upper case.