### PR TITLE
Make UpdateSource parameter conditional upon UpdateEnabled being 'True'

### DIFF
--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -423,7 +423,6 @@ function Set-TargetResource
         "InstanceName",
         "InstanceID",
         "UpdateEnabled",
-        "UpdateSource",
         "Features",
         "PID",
         "SQMReporting",
@@ -432,6 +431,12 @@ function Set-TargetResource
         "InstallSharedWOWDir",
         "InstanceDir"
     )
+    if($UpdateEnabled -eq 'True')
+    {
+        $ArgumentVars += @(
+            "UpdateSource"
+        )
+    }
     if($Features.Contains("SQLENGINE"))
     {
         $ArgumentVars += @(

--- a/xPDT.psm1
+++ b/xPDT.psm1
@@ -695,11 +695,11 @@ function NetUse
 
         if ($Ensure -eq "Absent")
         {
-            $cmd = "net.exe use $SourcePath /del"
+            $cmd = "net.exe use `"$SourcePath`" /del"
         }
         else 
         {
-            $cmd = "net.exe use $SourcePath $($Credential.GetNetworkCredential().Password) /user:$($Credential.GetNetworkCredential().Domain)\$($Credential.GetNetworkCredential().UserName)"
+            $cmd = "net.exe use `"$SourcePath`" `"$($Credential.GetNetworkCredential().Password)`" /user:`"$($Credential.GetNetworkCredential().Domain)\$($Credential.GetNetworkCredential().UserName)`""
         }
         Invoke-Expression $cmd
     }


### PR DESCRIPTION
If UpdateEnabled is 'False', the UpdateSource is still passed to setup.exe. This causes an installation failure if the folder does not exist.