### PR TITLE
Fix for GetFirstItemPropertyValue to correctly handle registry keys with only one value. Fixes #21

### DIFF
--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -780,7 +780,7 @@ function GetFirstItemPropertyValue
 
     if(Get-ItemProperty -Path "$Path\$Name" -ErrorAction SilentlyContinue)
     {
-        $FirstName = ((Get-ItemProperty -Path "$Path\$Name") | Get-Member -MemberType NoteProperty | Where-Object {$_.Name.Substring(0,2) -ne "PS"}).Name[0]
+        $FirstName = @(((Get-ItemProperty -Path "$Path\$Name") | Get-Member -MemberType NoteProperty | Where-Object {$_.Name.Substring(0,2) -ne "PS"}).Name)[0]
         (Get-ItemProperty -Path "$Path\$Name" -Name $FirstName).$FirstName.TrimEnd("\")
     }
 }

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ## Versions
 
+### Unreleased
+
+* xSQLServerSetup:
+	- Corrected bug in GetFirstItemPropertyValue to correctly handle registry keys with only one value.
+
 ### 1.3.0.0
 
 * xSqlServerSetup: 


### PR DESCRIPTION
Updated line 783 of MSFT_xSQLServerSetup.psm1 to fix issue #21.