### PR TITLE
Test-TargetResource failing without explanation

### DIFF
--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -936,12 +936,18 @@ function Test-TargetResource
     )
 
     $SQLData = Get-TargetResource @PSBoundParameters
+    Write-Verbose "Features found: '$($SQLData.Features)'"
 
     $result = $true
     foreach($Feature in $Features.Split(","))
     {
+        # given that all the returned features are uppercase, make sure that the feature to search for
+        # is also uppercase
+        $Feature = $Feature.ToUpperInvariant();
+
         if(!($SQLData.Features.Contains($Feature)))
         {
+            Write-Verbose "Unable to find feature '$Feature' in '$($SQLData.Features)'"
             $result = $false
         }
     }


### PR DESCRIPTION
Had an issue where the module installed SQL correctly, but when testing after the installation (`Test-TargetResource`), an exception would be thrown.

The configuration I'm currently using:

    xSQLServerSetup InstallSqlServer
    {
        InstanceName = "SQLExpress"
        SourcePath = $destinationPath
        SourceFolder = ""
        Features= "SQLEngine,LocalDB"
        UpdateSource = "MU" # set this to windows update, otherwise it will use the default and cause the setup to crash
        SetupCredential = $credential
        DependsOn = "[WindowsFeature]NetFramework35Core","[WindowsFeature]NetFramework45Core","[File]CopySqlServerInstaller"
    }

After looking into the module's source code, I noticed the features' check was failing because the testing code expects the features to be in upper-case format (also noted by another user, #38).

Furthermore, `Test-TargetResource` failed without providing an explanation to why (and made even more baffling given that SQL was correctly installed).

So I added a bit more logging to `Test-TargetResource` and normalised the feature to upper-case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/46)
<!-- Reviewable:end -->