### PR TITLE
Changes to xSQLServerMemory part:

### DIFF
--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -57,7 +57,7 @@ function Get-TargetResource
         $DynamicAlloc,
 
         [System.Int32]
-        $MinMemory,
+        $MinMemory = -1,
 
         [System.Int32]
         $MaxMemory,

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -65,8 +65,9 @@ function Get-TargetResource
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
+        [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName= "MSSQLSERVER"
+        $SQLInstanceName #= "MSSQLSERVER"
     )
 
         if(!$SQL)
@@ -114,7 +115,7 @@ function Set-TargetResource
         $DynamicAlloc,
 
         [System.Int32]
-        $MinMemory,
+        $MinMemory = -1,
 
         [System.Int32]
         $MaxMemory,
@@ -122,8 +123,9 @@ function Set-TargetResource
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
+        [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName= "MSSQLSERVER"
+        $SQLInstanceName #= "MSSQLSERVER"
     )
 
     if(!$SQL)
@@ -171,7 +173,7 @@ function Set-TargetResource
                 }
                 else
                 {
-                    if (!$MaxMemory -xor !$MinMemory)
+                    if (!$MaxMemory)
                     {
                         Throw "Dynamic Allocation is not set and Min and Max memory were not passed."
                         Exit
@@ -184,8 +186,9 @@ function Set-TargetResource
             Write-Verbose -message "Dynamic Alloc is $DynamicAlloc. MaxMem will be set to $MaxMemory."
             Write-Verbose -message "Server Memory is $serverMem and should be capped."
             $sql.Configuration.MaxServerMemory.ConfigValue = $MaxMemory
-            if($MinMemory)
+            if($MinMemory -ge 0)
             {
+                Write-Verbose -message "MinMem will be set to $MinMemory."
                 $sql.Configuration.MinServerMemory.ConfigValue = $MinMemory
             }
             $sql.alter()
@@ -213,16 +216,17 @@ function Test-TargetResource
         $DynamicAlloc,
 
         [System.Int32]
-        $MinMemory,
+        $MinMemory = -1,
 
         [System.Int32]
         $MaxMemory,
 
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
-
+        
+        [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName= "MSSQLSERVER"
+        $SQLInstanceName #= "MSSQLSERVER"
     )
 
     if(!$SQL)
@@ -269,7 +273,7 @@ function Test-TargetResource
              }
              else
              {
-                 If($MinMemory -ne $GetMinMemory -or $MaxMemory -ne $GetMaxMemory)
+                 If(($MinMemory -ge 0 -and $MinMemory -ne $GetMinMemory) -or $MaxMemory -ne $GetMaxMemory)
                  {
                     Write-Verbose -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
                     return $false

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -67,7 +67,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName #= "MSSQLSERVER"
+        $SQLInstanceName
     )
 
         if(!$SQL)
@@ -125,7 +125,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName #= "MSSQLSERVER"
+        $SQLInstanceName
     )
 
     if(!$SQL)
@@ -140,11 +140,11 @@ function Set-TargetResource
         {
             "Absent"
             {
-                If($Ensure -eq "Absent")
-                {
+                #If($Ensure -eq "Absent")
+                #{
                    $MaxMemory =2147483647
                    $MinMemory = 128
-                } 
+                #} 
             }
             "Present"
             {       
@@ -173,9 +173,9 @@ function Set-TargetResource
                 }
                 else
                 {
-                    if (!$MaxMemory)
+                    if (!$MaxMemory -or ($MinMemory -gt $MaxMemory))
                     {
-                        Throw "Dynamic Allocation is not set and Min and Max memory were not passed."
+                        Throw "Dynamic Allocation is not set, Max memory was not passed or Min memory value is greater than Max memory."
                         Exit
                     } 
                 }
@@ -226,7 +226,7 @@ function Test-TargetResource
         
         [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName #= "MSSQLSERVER"
+        $SQLInstanceName
     )
 
     if(!$SQL)

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -170,11 +170,13 @@ function Set-TargetResource
                 }
                 else
                 {
-                    if (!$MaxMemory -or ($MinMemory -gt $MaxMemory))
-                    {
-                        Throw "Dynamic Allocation is not set, Max memory was not passed or Min memory value is greater than Max memory."
-                        Exit
-                    } 
+                    if  (-not $MaxMemory -or $MinMemory -lt 0) {
+                        throw "Dynamic Allocation is not set. Valid values were not supplied for MaxMemory or MinMemory."
+                    }
+
+                    if ($MinMemory -gt $MaxMemory) {
+                        throw "Provided MinMemory value is greater than MaxMemory."
+                    }
                 }
             }
         }

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -140,11 +140,8 @@ function Set-TargetResource
         {
             "Absent"
             {
-                #If($Ensure -eq "Absent")
-                #{
-                   $MaxMemory =2147483647
+                   $MaxMemory = 2147483647
                    $MinMemory = 128
-                #} 
             }
             "Present"
             {       

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
@@ -7,6 +7,6 @@ class MSFT_xSQLServerMemory : OMI_BaseResource
     [Write, Description("Minimum memory value to set SQL Server memory to")] Sint32 MinMemory;
     [Write, Description("Maximum memory value to set SQL Server memory to")] Sint32 MaxMemory;
     [Write, Description("SQL Server to configure memory on")] String SQLServer;
-    [Write, Description("SQL Instance to configure memory on")] String SQLInstanceName;
+    [Key, Description("SQL Instance to configure memory on")] String SQLInstanceName;
 };
 

--- a/README.md
+++ b/README.md
@@ -192,12 +192,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **SQLInstance**: The SQL instance for the database
 
 ###xSQLServerMemory
-* **Ensure**: (key) An enumerated value that describes if Min and Max memory is configured
+* **Ensure**: An enumerated value that describes if Min and Max memory is configured
 * **DyamicAlloc**: (key) Flag to indicate if Memory is dynamically configured
 * **MinMemory**: Minimum memory value to set SQL Server memory to
 * **MaxMemory**: Maximum memory value to set SQL Server memory to
 * **SQLServer**: The SQL Server for the database
-* **SQLInstance**: The SQL instance for the database
+* **SQLInstance**: (key) The SQL instance for the database
 
 ###xSQLServerPowerPlan
 * **Ensure**: (key) An enumerated value that describes if Min and Max memory is configured


### PR DESCRIPTION
Changes to xSQLServerMemory
1. adding possibility to manager memory for multiply SQL instances. Changes were made to DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof file, another key value was added - SQLInstanceName;
2. adding possibility to manage memory for multiply SQL instances. Changes were made to  DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1 fileL
-  ammended change to accept 0 MB as MinMemory value, predefined value was set to -1, as 0 in all _if_ checks as _$false_;
-  SQLInstanceName value became mandatory for this xSQLServerMemory functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/49)
<!-- Reviewable:end -->