### PR TITLE
Additional tests, and some fixes, related to AlwaysOn

### DIFF
--- a/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
@@ -274,9 +274,20 @@ function Test-TargetResource
         }
         
         [System.Boolean] $result = $false
-        if( ( $Ensure -eq "" -or ( $Ensure -ne "" -and $listenerState.Ensure -eq $Ensure) ) -and ($Port -eq "" -or $listenerState.Port -eq $Port) -and $ipAddressEqual ) {
-            $result = $true
+        if( $listenerState.Ensure -eq $Ensure)  {
+            if( $Ensure -eq 'Absent' ) {
+                $result = $true
+            } elseif ( ( $Port -eq "" -or $listenerState.Port -eq $Port ) -and $ipAddressEqual ) {
+                $result = $true
+            }
         }
+
+        if( $Ensure -eq "" ) { # Will handle changes when Ensure is not set. 
+            if( ($Port -eq "" -or $listenerState.Port -eq $Port) -and $ipAddressEqual ) {
+                $result = $true
+            }
+        }
+
     } else {
         throw New-TerminatingError -ErrorType UnexpectedErrorFromGet -ErrorCategory InvalidResult
     }

--- a/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
@@ -169,6 +169,10 @@ function Set-TargetResource
                         throw New-TerminatingError -ErrorType AvailabilityGroupListenerIPChangeError -FormatArgs @($($IpAddress -join ', '),$($listenerState.IpAddress -join ', ')) -ErrorCategory InvalidOperation
                     }
                 }
+
+                if( $($PSBoundParameters.ContainsKey('DHCP')) -and $listenerState.DHCP -ne $DHCP ) {
+                    throw New-TerminatingError -ErrorType AvailabilityGroupListenerDHCPChangeError -FormatArgs @( $DHCP, $($listenerState.DHCP) ) -ErrorCategory InvalidOperation
+                }
                 
                 if( $listenerState.Port -ne $Port -or -not $ipAddressEqual ) {
                     New-VerboseMessage -Message "Listener differ in configuration."
@@ -277,13 +281,11 @@ function Test-TargetResource
         if( $listenerState.Ensure -eq $Ensure)  {
             if( $Ensure -eq 'Absent' ) {
                 $result = $true
-            } elseif ( ( $Port -eq "" -or $listenerState.Port -eq $Port ) -and $ipAddressEqual ) {
-                $result = $true
             }
         }
 
-        if( $Ensure -eq "" ) { # Will handle changes when Ensure is not set. 
-            if( ($Port -eq "" -or $listenerState.Port -eq $Port) -and $ipAddressEqual ) {
+        if( -not $($PSBoundParameters.ContainsKey('Ensure')) -or $Ensure -eq "Present" ) { 
+            if( ($Port -eq "" -or $listenerState.Port -eq $Port) -and $ipAddressEqual -and ( -not $($PSBoundParameters.ContainsKey('DHCP')) -or $listenerState.DHCP -eq $DHCP ) ) {
                 $result = $true
             }
         }

--- a/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
@@ -285,7 +285,10 @@ function Test-TargetResource
         }
 
         if( -not $($PSBoundParameters.ContainsKey('Ensure')) -or $Ensure -eq "Present" ) { 
-            if( ($Port -eq "" -or $listenerState.Port -eq $Port) -and $ipAddressEqual -and ( -not $($PSBoundParameters.ContainsKey('DHCP')) -or $listenerState.DHCP -eq $DHCP ) ) {
+            if( ( $Port -eq "" -or $listenerState.Port -eq $Port) -and 
+                $ipAddressEqual -and 
+                ( -not $($PSBoundParameters.ContainsKey('DHCP')) -or $listenerState.DHCP -eq $DHCP ) ) 
+            {
                 $result = $true
             }
         }

--- a/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
@@ -197,7 +197,7 @@ function Set-TargetResource
                             $newIpAddress = @()
                             
                             foreach( $currentIpAddress in $IpAddress ) {
-                                if( -not $listenerState.IpAddress -contains $currentIpAddress ) {
+                                if( -not ( $listenerState.IpAddress -contains $currentIpAddress ) ) {
                                     $newIpAddress += $currentIpAddress
                                 }
                             }

--- a/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/xSQLServerAvailabilityGroupListener/xSQLServerAvailabilityGroupListener.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
 
             $presentIpAddress = $listener.AvailabilityGroupListenerIPAddresses
 
-            $dhcp = [bool]( $presentIpAddress | Select-Object -first 1 IsDHCP )
+            $dhcp = [bool]( $presentIpAddress | Select-Object -First 1 -ExpandProperty IsDHCP )
 
             $ipAddress = @()
             foreach( $currentIpAddress in $presentIpAddress ) {

--- a/README.md
+++ b/README.md
@@ -328,6 +328,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 		- Get-SQLAlwaysOnEndpoint
 	- modified functions
 		- New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
+* Added tests for resources
+  - xSQLServerPermission
+  - xSQLServerEndpointState
+  - xSQLServerEndpointPermission
+  - xSQLServerAvailabilityGroupListener
 
 ### 1.7.0.0
 * Resources Added

--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointState
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
+* Fixes in xSQLServerAvailabilityGroupListener
+  - In one case the Get-method did not report that DHCP was configured. 
+  - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
+  - Fixed an issue where sometimes the listener wasn't removed.
 
 ### 1.7.0.0
 * Resources Added

--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* Added tests for resources
+  - xSQLServerPermission
+  - xSQLServerEndpointState
+  - xSQLServerEndpointPermission
+  - xSQLServerAvailabilityGroupListener
+* Fixes in xSQLServerAvailabilityGroupListener
+  - In one case the Get-method did not report that DHCP was configured. 
+  - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
+  - Fixed an issue where sometimes the listener wasn't removed.
+  - Fixed the issue when trying to add a static IP to a listener was ignored.
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
@@ -342,16 +352,6 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
         - Get-SQLAlwaysOnEndpoint
     - modified functions
         - New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
-* Added tests for resources
-  - xSQLServerPermission
-  - xSQLServerEndpointState
-  - xSQLServerEndpointPermission
-  - xSQLServerAvailabilityGroupListener
-* Fixes in xSQLServerAvailabilityGroupListener
-  - In one case the Get-method did not report that DHCP was configured. 
-  - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
-  - Fixed an issue where sometimes the listener wasn't removed.
-  - Fixed the issue when trying to add a static IP to a listener was ignored.
 
 ### 1.7.0.0
 

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -9,10 +9,27 @@ namespace Microsoft.SqlServer.Management.Smo
         public static bool GenerateMockData = false;
     }
 
+    // Typename: Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
+    // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
+    // Used by: 
+    //  xSQLServerEndpointPermission.Tests.ps1
+    public class ObjectPermissionSet 
+    {
+        public ObjectPermissionSet(){}
+
+        public ObjectPermissionSet(
+            bool connect )
+        {
+            this.Connect = connect; 
+        } 
+    
+        public bool Connect = false;
+    }
+    
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class ServerPermissionSet 
     {
         public ServerPermissionSet(){}
@@ -38,7 +55,7 @@ namespace Microsoft.SqlServer.Management.Smo
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionInfo
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionInfo
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class ServerPermissionInfo 
     {
         public ServerPermissionInfo()
@@ -60,7 +77,7 @@ namespace Microsoft.SqlServer.Management.Smo
     // TypeName: Microsoft.SqlServer.Management.Smo.Server
     // BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class Server 
     { 
         public string MockGranteeName;
@@ -104,7 +121,11 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Revoke( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
         {
-
+            if( granteeName != this.MockGranteeName ) 
+            {
+                string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
+                throw new System.ArgumentException(errorMessage, "granteeName");
+            }
         }
     }
 }

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.SqlServer.Management.Smo
 {
+    public class Globals
+    {
+        // Static property that is switched on or off by tests if data should be mocked (true) or not (false).
+        public static bool GenerateMockData = false;
+    }
+
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
     // Used by: 
@@ -57,8 +63,6 @@ namespace Microsoft.SqlServer.Management.Smo
     //  xSQLServerPermission
     public class Server 
     { 
-        private bool _generateMockData = false;
-
         public string MockGranteeName;
 
         public string Name;
@@ -66,21 +70,13 @@ namespace Microsoft.SqlServer.Management.Smo
         public string InstanceName;
         public bool IsHadrEnabled = false;
 
-        public Server()
-        { 
-            _generateMockData = false;
-        } 
-
-        public Server( bool generateMockData )
-        { 
-            this._generateMockData = generateMockData;
-        } 
+        public Server(){} 
 
         public Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] EnumServerPermissions( string principal, Microsoft.SqlServer.Management.Smo.ServerPermissionSet permissionSetQuery ) 
         { 
             List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo> listOfServerPermissionInfo = new List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo>();
             
-            if( this._generateMockData ) {
+            if( Globals.GenerateMockData ) {
                 Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = { 
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( true, false, false, false ),
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, true, false, false ),

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,1748 +1,1746 @@
 ﻿# Generated from SQL Server 2014 (build 12.0.4213.0)
 
 function Add-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Database},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAvailabilityGroupListenerStaticIp {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${StaticIp},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlFirewallRule {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Backup-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [Parameter(ParameterSetName='ByBackupContainer')]
-       [Parameter(ParameterSetName='ByDBObject')]
-       [Parameter(ParameterSetName='ByName')]
-       [Parameter(ParameterSetName='ByObject')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${BackupContainer},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByBackupContainer')]
+        [Parameter(ParameterSetName='ByDBObject')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${BackupContainer},
 
-       [object]
-       ${MirrorDevices},
+        [object]
+        ${MirrorDevices},
 
-       [object]
-       ${BackupAction},
+        [object]
+        ${BackupAction},
 
-       [string]
-       ${BackupSetName},
+        [string]
+        ${BackupSetName},
 
-       [string]
-       ${BackupSetDescription},
+        [string]
+        ${BackupSetDescription},
 
-       [object]
-       ${CompressionOption},
+        [object]
+        ${CompressionOption},
 
-       [switch]
-       ${CopyOnly},
+        [switch]
+        ${CopyOnly},
 
-       [datetime]
-       ${ExpirationDate},
+        [datetime]
+        ${ExpirationDate},
 
-       [switch]
-       ${FormatMedia},
+        [switch]
+        ${FormatMedia},
 
-       [switch]
-       ${Incremental},
+        [switch]
+        ${Incremental},
 
-       [switch]
-       ${Initialize},
+        [switch]
+        ${Initialize},
 
-       [object]
-       ${LogTruncationType},
+        [object]
+        ${LogTruncationType},
 
-       [string]
-       ${MediaDescription},
+        [string]
+        ${MediaDescription},
 
-       [ValidateRange(0, 2147483647)]
-       [int]
-       ${RetainDays},
+        [ValidateRange(0, 2147483647)]
+        [int]
+        ${RetainDays},
 
-       [switch]
-       ${SkipTapeHeader},
+        [switch]
+        ${SkipTapeHeader},
 
-       [string]
-       ${UndoFileName},
+        [string]
+        ${UndoFileName},
 
-       [object]
-       ${EncryptionOption},
+        [object]
+        ${EncryptionOption},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${DatabaseObject},
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${BackupFile},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
 
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${BackupDevice},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
 
-       [switch]
-       ${PassThru},
+        [switch]
+        ${PassThru},
 
-       [switch]
-       ${Checksum},
+        [switch]
+        ${Checksum},
 
-       [switch]
-       ${ContinueAfterError},
+        [switch]
+        ${ContinueAfterError},
 
-       [switch]
-       ${NoRewind},
+        [switch]
+        ${NoRewind},
 
-       [switch]
-       ${Restart},
+        [switch]
+        ${Restart},
 
-       [switch]
-       ${UnloadTapeAfter},
+        [switch]
+        ${UnloadTapeAfter},
 
-       [switch]
-       ${NoRecovery},
+        [switch]
+        ${NoRecovery},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFile},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFileGroup},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
 
-       [int]
-       ${BlockSize},
+        [int]
+        ${BlockSize},
 
-       [int]
-       ${BufferCount},
+        [int]
+        ${BufferCount},
 
-       [int]
-       ${MaxTransferSize},
+        [int]
+        ${MaxTransferSize},
 
-       [string]
-       ${MediaName},
+        [string]
+        ${MediaName},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Convert-UrnToPath {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Urn}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Urn}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Decode-SqlName {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SqlName}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Disable-SqlAlwaysOn {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [pscredential]
-       ${Credential}
+        [pscredential]
+        ${Credential}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Enable-SqlAlwaysOn {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [pscredential]
-       ${Credential}
+        [pscredential]
+        ${Credential}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Encode-SqlName {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SqlName}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [System.Nullable[int]]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [System.Nullable[int]]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlInstance {
-   [CmdletBinding(ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${MachineName},
+    [CmdletBinding(ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${MachineName},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByName')]
-       [Parameter(Position=1)]
-       [Parameter(ParameterSetName='ByPath')]
-       [Parameter(ParameterSetName='ByObject')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(Position=1)]
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ValueFromPipeline=$true)]
-       [Parameter(ParameterSetName='ByName')]
-       [psobject]
-       ${ServerInstance},
+        [Parameter(ValueFromPipeline=$true)]
+        [Parameter(ParameterSetName='ByName')]
+        [psobject]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-PolicyEvaluation {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${Policy},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${Policy},
 
-       [object]
-       ${AdHocPolicyEvaluationMode},
+        [object]
+        ${AdHocPolicyEvaluationMode},
 
-       [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${TargetServerName},
+        [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${TargetServerName},
 
-       [Parameter(ParameterSetName='ConnectionProcessing')]
-       [string]
-       ${TargetExpression},
+        [Parameter(ParameterSetName='ConnectionProcessing')]
+        [string]
+        ${TargetExpression},
 
-       [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
-       [psobject[]]
-       ${TargetObjects},
+        [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+        [psobject[]]
+        ${TargetObjects},
 
-       [switch]
-       ${OutputXml}
+        [switch]
+        ${OutputXml}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-Sqlcmd {
-   [CmdletBinding()]
-   param(
-       [Parameter(ValueFromPipeline=$true)]
-       [psobject]
-       ${ServerInstance},
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [switch]
-       ${EncryptConnection},
+        [switch]
+        ${EncryptConnection},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Username},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Password},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
 
-       [Parameter(Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Query},
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Query},
 
-       [int]
-       ${QueryTimeout},
+        [int]
+        ${QueryTimeout},
 
-       [int]
-       ${ConnectionTimeout},
+        [int]
+        ${ConnectionTimeout},
 
-       [ValidateRange(-1, 255)]
-       [int]
-       ${ErrorLevel},
+        [ValidateRange(-1, 255)]
+        [int]
+        ${ErrorLevel},
 
-       [ValidateRange(-1, 25)]
-       [int]
-       ${SeverityLevel},
+        [ValidateRange(-1, 25)]
+        [int]
+        ${SeverityLevel},
 
-       [ValidateRange(1, 2147483647)]
-       [int]
-       ${MaxCharLength},
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxCharLength},
 
-       [ValidateRange(1, 2147483647)]
-       [int]
-       ${MaxBinaryLength},
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxBinaryLength},
 
-       [switch]
-       ${AbortOnError},
+        [switch]
+        ${AbortOnError},
 
-       [switch]
-       ${DedicatedAdministratorConnection},
+        [switch]
+        ${DedicatedAdministratorConnection},
 
-       [switch]
-       ${DisableVariables},
+        [switch]
+        ${DisableVariables},
 
-       [switch]
-       ${DisableCommands},
+        [switch]
+        ${DisableCommands},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${HostName},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${HostName},
 
-       [string]
-       ${NewPassword},
+        [string]
+        ${NewPassword},
 
-       [string[]]
-       ${Variable},
+        [string[]]
+        ${Variable},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${InputFile},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${InputFile},
 
-       [bool]
-       ${OutputSqlErrors},
+        [bool]
+        ${OutputSqlErrors},
 
-       [switch]
-       ${IncludeSqlUserErrors},
+        [switch]
+        ${IncludeSqlUserErrors},
 
-       [switch]
-       ${SuppressProviderContextWarning},
+        [switch]
+        ${SuppressProviderContextWarning},
 
-       [switch]
-       ${IgnoreProviderContext}
+        [switch]
+        ${IgnoreProviderContext}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Join-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNull()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNull()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AvailabilityReplica},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AvailabilityReplica},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Database},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
 
-       [object]
-       ${AutomatedBackupPreference},
+        [object]
+        ${AutomatedBackupPreference},
 
-       [object]
-       ${FailureConditionLevel},
+        [object]
+        ${FailureConditionLevel},
 
-       [int]
-       ${HealthCheckTimeout},
+        [int]
+        ${HealthCheckTimeout},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroupListener {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${DhcpSubnet},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${DhcpSubnet},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${StaticIp},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
 
-       [ValidateRange(1, 65535)]
-       [ValidateNotNullOrEmpty()]
-       [int]
-       ${Port},
+        [ValidateRange(1, 65535)]
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [object]
-       ${AvailabilityMode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${AvailabilityMode},
 
-       [Parameter(Mandatory=$true)]
-       [object]
-       ${FailoverMode},
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${FailoverMode},
 
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EndpointUrl},
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
 
-       [int]
-       ${SessionTimeout},
+        [int]
+        ${SessionTimeout},
 
-       [object]
-       ${ConnectionModeInPrimaryRole},
+        [object]
+        ${ConnectionModeInPrimaryRole},
 
-       [object]
-       ${ConnectionModeInSecondaryRole},
+        [object]
+        ${ConnectionModeInSecondaryRole},
 
-       [ValidateRange(0, 100)]
-       [int]
-       ${BackupPriority},
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
 
-       [string[]]
-       ${ReadOnlyRoutingList},
+        [string[]]
+        ${ReadOnlyRoutingList},
 
-       [string]
-       ${ReadonlyRoutingConnectionUrl},
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
 
-       [Parameter(ParameterSetName='AsTemplate')]
-       [switch]
-       ${AsTemplate},
+        [Parameter(ParameterSetName='AsTemplate')]
+        [switch]
+        ${AsTemplate},
 
-       [Parameter(ParameterSetName='AsTemplate')]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Version},
+        [Parameter(ParameterSetName='AsTemplate')]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Version},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlBackupEncryptionOption {
-   [CmdletBinding()]
-   param(
-       [switch]
-       ${NoEncryption},
+    [CmdletBinding()]
+    param(
+        [switch]
+        ${NoEncryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Algorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Algorithm},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptorType},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptorType},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptorName}
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptorName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Identity},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
 
-       [ValidateNotNullOrEmpty()]
-       [securestring]
-       ${Secret},
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
 
-       [string]
-       ${ProviderName},
+        [string]
+        ${ProviderName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlHADREndpoint {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [int]
-       ${Port},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Owner},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Certificate},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
 
-       [ValidateNotNullOrEmpty()]
-       [ipaddress]
-       ${IpAddress},
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AuthenticationOrder},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Encryption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionAlgorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlFirewallRule {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Restore-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ClearSuspectPageTable},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ClearSuspectPageTable},
 
-       [switch]
-       ${KeepReplication},
+        [switch]
+        ${KeepReplication},
 
-       [switch]
-       ${Partial},
+        [switch]
+        ${Partial},
 
-       [switch]
-       ${ReplaceDatabase},
+        [switch]
+        ${ReplaceDatabase},
 
-       [switch]
-       ${RestrictedUser},
+        [switch]
+        ${RestrictedUser},
 
-       [long[]]
-       ${Offset},
+        [long[]]
+        ${Offset},
 
-       [object]
-       ${RelocateFile},
+        [object]
+        ${RelocateFile},
 
-       [int]
-       ${FileNumber},
+        [int]
+        ${FileNumber},
 
-       [object]
-       ${RestoreAction},
+        [object]
+        ${RestoreAction},
 
-       [string]
-       ${StandbyFile},
+        [string]
+        ${StandbyFile},
 
-       [string]
-       ${StopAtMarkAfterDate},
+        [string]
+        ${StopAtMarkAfterDate},
 
-       [string]
-       ${StopAtMarkName},
+        [string]
+        ${StopAtMarkName},
 
-       [string]
-       ${StopBeforeMarkAfterDate},
+        [string]
+        ${StopBeforeMarkAfterDate},
 
-       [string]
-       ${StopBeforeMarkName},
+        [string]
+        ${StopBeforeMarkName},
 
-       [string]
-       ${ToPointInTime},
+        [string]
+        ${ToPointInTime},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${DatabaseObject},
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${BackupFile},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
 
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${BackupDevice},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
 
-       [switch]
-       ${PassThru},
+        [switch]
+        ${PassThru},
 
-       [switch]
-       ${Checksum},
+        [switch]
+        ${Checksum},
 
-       [switch]
-       ${ContinueAfterError},
+        [switch]
+        ${ContinueAfterError},
 
-       [switch]
-       ${NoRewind},
+        [switch]
+        ${NoRewind},
 
-       [switch]
-       ${Restart},
+        [switch]
+        ${Restart},
 
-       [switch]
-       ${UnloadTapeAfter},
+        [switch]
+        ${UnloadTapeAfter},
 
-       [switch]
-       ${NoRecovery},
+        [switch]
+        ${NoRecovery},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFile},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFileGroup},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
 
-       [int]
-       ${BlockSize},
+        [int]
+        ${BlockSize},
 
-       [int]
-       ${BufferCount},
+        [int]
+        ${BufferCount},
 
-       [int]
-       ${MaxTransferSize},
+        [int]
+        ${MaxTransferSize},
 
-       [string]
-       ${MediaName},
+        [string]
+        ${MediaName},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Resume-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAuthenticationMode {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Mode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Mode},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${SqlCredential},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${SqlCredential},
 
-       [switch]
-       ${ForceServiceRestart},
+        [switch]
+        ${ForceServiceRestart},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [object]
-       ${AutomatedBackupPreference},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AutomatedBackupPreference},
 
-       [object]
-       ${FailureConditionLevel},
+        [object]
+        ${FailureConditionLevel},
 
-       [int]
-       ${HealthCheckTimeout},
+        [int]
+        ${HealthCheckTimeout},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroupListener {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(1, 65535)]
-       [int]
-       ${Port},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [object]
-       ${AvailabilityMode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AvailabilityMode},
 
-       [object]
-       ${FailoverMode},
+        [object]
+        ${FailoverMode},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EndpointUrl},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
 
-       [int]
-       ${SessionTimeout},
+        [int]
+        ${SessionTimeout},
 
-       [object]
-       ${ConnectionModeInPrimaryRole},
+        [object]
+        ${ConnectionModeInPrimaryRole},
 
-       [object]
-       ${ConnectionModeInSecondaryRole},
+        [object]
+        ${ConnectionModeInSecondaryRole},
 
-       [ValidateRange(0, 100)]
-       [int]
-       ${BackupPriority},
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
 
-       [string[]]
-       ${ReadOnlyRoutingList},
+        [string[]]
+        ${ReadOnlyRoutingList},
 
-       [string]
-       ${ReadonlyRoutingConnectionUrl},
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Identity},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
 
-       [Parameter(Position=3)]
-       [ValidateNotNullOrEmpty()]
-       [securestring]
-       ${Secret},
+        [Parameter(Position=3)]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlHADREndpoint {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Owner},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Certificate},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
 
-       [ValidateNotNullOrEmpty()]
-       [ipaddress]
-       ${IpAddress},
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AuthenticationOrder},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Encryption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionAlgorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
 
-       [ValidateNotNullOrEmpty()]
-       [int]
-       ${Port},
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${State},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${State},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlNetworkConfiguration {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Protocol},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Protocol},
 
-       [Parameter(Position=2)]
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${Port},
+        [Parameter(Position=2)]
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${Port},
 
-       [switch]
-       ${Disable},
+        [switch]
+        ${Disable},
 
-       [switch]
-       ${ForceServiceRestart},
+        [switch]
+        ${ForceServiceRestart},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [bool]
-       ${MasterSwitch},
+        [bool]
+        ${MasterSwitch},
 
-       [bool]
-       ${BackupEnabled},
+        [bool]
+        ${BackupEnabled},
 
-       [int]
-       ${BackupRetentionPeriodInDays},
+        [int]
+        ${BackupRetentionPeriodInDays},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionOption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionOption},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Start-SqlInstance {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Stop-SqlInstance {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Suspend-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Switch-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${AllowDataLoss},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${AllowDataLoss},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlDatabaseReplicaState {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
-
-

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,0 +1,1746 @@
+﻿function Add-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlAvailabilityGroupListenerStaticIp {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${StaticIp},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlFirewallRule {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Backup-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [Parameter(ParameterSetName='ByBackupContainer')]
+       [Parameter(ParameterSetName='ByDBObject')]
+       [Parameter(ParameterSetName='ByName')]
+       [Parameter(ParameterSetName='ByObject')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${BackupContainer},
+
+       [object]
+       ${MirrorDevices},
+
+       [object]
+       ${BackupAction},
+
+       [string]
+       ${BackupSetName},
+
+       [string]
+       ${BackupSetDescription},
+
+       [object]
+       ${CompressionOption},
+
+       [switch]
+       ${CopyOnly},
+
+       [datetime]
+       ${ExpirationDate},
+
+       [switch]
+       ${FormatMedia},
+
+       [switch]
+       ${Incremental},
+
+       [switch]
+       ${Initialize},
+
+       [object]
+       ${LogTruncationType},
+
+       [string]
+       ${MediaDescription},
+
+       [ValidateRange(0, 2147483647)]
+       [int]
+       ${RetainDays},
+
+       [switch]
+       ${SkipTapeHeader},
+
+       [string]
+       ${UndoFileName},
+
+       [object]
+       ${EncryptionOption},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${DatabaseObject},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${BackupFile},
+
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${BackupDevice},
+
+       [switch]
+       ${PassThru},
+
+       [switch]
+       ${Checksum},
+
+       [switch]
+       ${ContinueAfterError},
+
+       [switch]
+       ${NoRewind},
+
+       [switch]
+       ${Restart},
+
+       [switch]
+       ${UnloadTapeAfter},
+
+       [switch]
+       ${NoRecovery},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFile},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFileGroup},
+
+       [int]
+       ${BlockSize},
+
+       [int]
+       ${BufferCount},
+
+       [int]
+       ${MaxTransferSize},
+
+       [string]
+       ${MediaName},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Convert-UrnToPath {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Urn}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Decode-SqlName {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SqlName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Disable-SqlAlwaysOn {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ServerInstance},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [switch]
+       ${Force},
+
+       [pscredential]
+       ${Credential}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Enable-SqlAlwaysOn {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ServerInstance},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [switch]
+       ${Force},
+
+       [pscredential]
+       ${Credential}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Encode-SqlName {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SqlName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [System.Nullable[int]]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlInstance {
+   [CmdletBinding(ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${MachineName},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByName')]
+       [Parameter(Position=1)]
+       [Parameter(ParameterSetName='ByPath')]
+       [Parameter(ParameterSetName='ByObject')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ValueFromPipeline=$true)]
+       [Parameter(ParameterSetName='ByName')]
+       [psobject]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Invoke-PolicyEvaluation {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${Policy},
+
+       [object]
+       ${AdHocPolicyEvaluationMode},
+
+       [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${TargetServerName},
+
+       [Parameter(ParameterSetName='ConnectionProcessing')]
+       [string]
+       ${TargetExpression},
+
+       [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+       [psobject[]]
+       ${TargetObjects},
+
+       [switch]
+       ${OutputXml}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Invoke-Sqlcmd {
+   [CmdletBinding()]
+   param(
+       [Parameter(ValueFromPipeline=$true)]
+       [psobject]
+       ${ServerInstance},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [switch]
+       ${EncryptConnection},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Username},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Password},
+
+       [Parameter(Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Query},
+
+       [int]
+       ${QueryTimeout},
+
+       [int]
+       ${ConnectionTimeout},
+
+       [ValidateRange(-1, 255)]
+       [int]
+       ${ErrorLevel},
+
+       [ValidateRange(-1, 25)]
+       [int]
+       ${SeverityLevel},
+
+       [ValidateRange(1, 2147483647)]
+       [int]
+       ${MaxCharLength},
+
+       [ValidateRange(1, 2147483647)]
+       [int]
+       ${MaxBinaryLength},
+
+       [switch]
+       ${AbortOnError},
+
+       [switch]
+       ${DedicatedAdministratorConnection},
+
+       [switch]
+       ${DisableVariables},
+
+       [switch]
+       ${DisableCommands},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${HostName},
+
+       [string]
+       ${NewPassword},
+
+       [string[]]
+       ${Variable},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${InputFile},
+
+       [bool]
+       ${OutputSqlErrors},
+
+       [switch]
+       ${IncludeSqlUserErrors},
+
+       [switch]
+       ${SuppressProviderContextWarning},
+
+       [switch]
+       ${IgnoreProviderContext}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Join-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNull()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AvailabilityReplica},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Database},
+
+       [object]
+       ${AutomatedBackupPreference},
+
+       [object]
+       ${FailureConditionLevel},
+
+       [int]
+       ${HealthCheckTimeout},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityGroupListener {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${DhcpSubnet},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${StaticIp},
+
+       [ValidateRange(1, 65535)]
+       [ValidateNotNullOrEmpty()]
+       [int]
+       ${Port},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [object]
+       ${AvailabilityMode},
+
+       [Parameter(Mandatory=$true)]
+       [object]
+       ${FailoverMode},
+
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EndpointUrl},
+
+       [int]
+       ${SessionTimeout},
+
+       [object]
+       ${ConnectionModeInPrimaryRole},
+
+       [object]
+       ${ConnectionModeInSecondaryRole},
+
+       [ValidateRange(0, 100)]
+       [int]
+       ${BackupPriority},
+
+       [string[]]
+       ${ReadOnlyRoutingList},
+
+       [string]
+       ${ReadonlyRoutingConnectionUrl},
+
+       [Parameter(ParameterSetName='AsTemplate')]
+       [switch]
+       ${AsTemplate},
+
+       [Parameter(ParameterSetName='AsTemplate')]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Version},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlBackupEncryptionOption {
+   [CmdletBinding()]
+   param(
+       [switch]
+       ${NoEncryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Algorithm},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptorType},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptorName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Identity},
+
+       [ValidateNotNullOrEmpty()]
+       [securestring]
+       ${Secret},
+
+       [string]
+       ${ProviderName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlHADREndpoint {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [int]
+       ${Port},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Owner},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Certificate},
+
+       [ValidateNotNullOrEmpty()]
+       [ipaddress]
+       ${IpAddress},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AuthenticationOrder},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Encryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionAlgorithm},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlFirewallRule {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Restore-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ClearSuspectPageTable},
+
+       [switch]
+       ${KeepReplication},
+
+       [switch]
+       ${Partial},
+
+       [switch]
+       ${ReplaceDatabase},
+
+       [switch]
+       ${RestrictedUser},
+
+       [long[]]
+       ${Offset},
+
+       [object]
+       ${RelocateFile},
+
+       [int]
+       ${FileNumber},
+
+       [object]
+       ${RestoreAction},
+
+       [string]
+       ${StandbyFile},
+
+       [string]
+       ${StopAtMarkAfterDate},
+
+       [string]
+       ${StopAtMarkName},
+
+       [string]
+       ${StopBeforeMarkAfterDate},
+
+       [string]
+       ${StopBeforeMarkName},
+
+       [string]
+       ${ToPointInTime},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${DatabaseObject},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${BackupFile},
+
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${BackupDevice},
+
+       [switch]
+       ${PassThru},
+
+       [switch]
+       ${Checksum},
+
+       [switch]
+       ${ContinueAfterError},
+
+       [switch]
+       ${NoRewind},
+
+       [switch]
+       ${Restart},
+
+       [switch]
+       ${UnloadTapeAfter},
+
+       [switch]
+       ${NoRecovery},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFile},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFileGroup},
+
+       [int]
+       ${BlockSize},
+
+       [int]
+       ${BufferCount},
+
+       [int]
+       ${MaxTransferSize},
+
+       [string]
+       ${MediaName},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Resume-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAuthenticationMode {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Mode},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${SqlCredential},
+
+       [switch]
+       ${ForceServiceRestart},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [object]
+       ${AutomatedBackupPreference},
+
+       [object]
+       ${FailureConditionLevel},
+
+       [int]
+       ${HealthCheckTimeout},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityGroupListener {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(1, 65535)]
+       [int]
+       ${Port},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [object]
+       ${AvailabilityMode},
+
+       [object]
+       ${FailoverMode},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EndpointUrl},
+
+       [int]
+       ${SessionTimeout},
+
+       [object]
+       ${ConnectionModeInPrimaryRole},
+
+       [object]
+       ${ConnectionModeInSecondaryRole},
+
+       [ValidateRange(0, 100)]
+       [int]
+       ${BackupPriority},
+
+       [string[]]
+       ${ReadOnlyRoutingList},
+
+       [string]
+       ${ReadonlyRoutingConnectionUrl},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Identity},
+
+       [Parameter(Position=3)]
+       [ValidateNotNullOrEmpty()]
+       [securestring]
+       ${Secret},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlHADREndpoint {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Owner},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Certificate},
+
+       [ValidateNotNullOrEmpty()]
+       [ipaddress]
+       ${IpAddress},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AuthenticationOrder},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Encryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionAlgorithm},
+
+       [ValidateNotNullOrEmpty()]
+       [int]
+       ${Port},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${State},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlNetworkConfiguration {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Protocol},
+
+       [Parameter(Position=2)]
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${Port},
+
+       [switch]
+       ${Disable},
+
+       [switch]
+       ${ForceServiceRestart},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [bool]
+       ${MasterSwitch},
+
+       [bool]
+       ${BackupEnabled},
+
+       [int]
+       ${BackupRetentionPeriodInDays},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionOption},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Start-SqlInstance {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Stop-SqlInstance {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Suspend-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Switch-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${AllowDataLoss},
+
+       [switch]
+       ${Force},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlDatabaseReplicaState {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,5 +1,10 @@
 ﻿# Generated from SQL Server 2014 (build 12.0.4213.0)
 
+# Suppressing this rule because these functions are from an external module 
+# and are only being used as stubs
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+param()
+
 function Add-SqlAvailabilityDatabase {
     [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
     param(

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,4 +1,6 @@
-﻿function Add-SqlAvailabilityDatabase {
+﻿# Generated from SQL Server 2014 (build 12.0.4213.0)
+
+function Add-SqlAvailabilityDatabase {
    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
    param(
        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
@@ -20,7 +22,7 @@
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAvailabilityGroupListenerStaticIp {
@@ -45,7 +47,7 @@ function Add-SqlAvailabilityGroupListenerStaticIp {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlFirewallRule {
@@ -86,7 +88,7 @@ function Add-SqlFirewallRule {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Backup-SqlDatabase {
@@ -244,7 +246,7 @@ function Backup-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Convert-UrnToPath {
@@ -256,7 +258,7 @@ function Convert-UrnToPath {
        ${Urn}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Decode-SqlName {
@@ -268,7 +270,7 @@ function Decode-SqlName {
        ${SqlName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Disable-SqlAlwaysOn {
@@ -299,7 +301,7 @@ function Disable-SqlAlwaysOn {
        ${Credential}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Enable-SqlAlwaysOn {
@@ -330,7 +332,7 @@ function Enable-SqlAlwaysOn {
        ${Credential}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Encode-SqlName {
@@ -342,7 +344,7 @@ function Encode-SqlName {
        ${SqlName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlCredential {
@@ -367,7 +369,7 @@ function Get-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlDatabase {
@@ -406,7 +408,7 @@ function Get-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlInstance {
@@ -442,7 +444,7 @@ function Get-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlSmartAdmin {
@@ -475,7 +477,7 @@ function Get-SqlSmartAdmin {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-PolicyEvaluation {
@@ -506,7 +508,7 @@ function Invoke-PolicyEvaluation {
        ${OutputXml}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-Sqlcmd {
@@ -597,7 +599,7 @@ function Invoke-Sqlcmd {
        ${IgnoreProviderContext}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Join-SqlAvailabilityGroup {
@@ -622,7 +624,7 @@ function Join-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroup {
@@ -665,7 +667,7 @@ function New-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroupListener {
@@ -703,7 +705,7 @@ function New-SqlAvailabilityGroupListener {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityReplica {
@@ -769,7 +771,7 @@ function New-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlBackupEncryptionOption {
@@ -791,7 +793,7 @@ function New-SqlBackupEncryptionOption {
        ${EncryptorName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCredential {
@@ -828,7 +830,7 @@ function New-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlHADREndpoint {
@@ -881,7 +883,7 @@ function New-SqlHADREndpoint {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityDatabase {
@@ -901,7 +903,7 @@ function Remove-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityGroup {
@@ -921,7 +923,7 @@ function Remove-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityReplica {
@@ -941,7 +943,7 @@ function Remove-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlCredential {
@@ -961,7 +963,7 @@ function Remove-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlFirewallRule {
@@ -1002,7 +1004,7 @@ function Remove-SqlFirewallRule {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Restore-SqlDatabase {
@@ -1147,7 +1149,7 @@ function Restore-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Resume-SqlAvailabilityDatabase {
@@ -1167,7 +1169,7 @@ function Resume-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAuthenticationMode {
@@ -1225,7 +1227,7 @@ function Set-SqlAuthenticationMode {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroup {
@@ -1254,7 +1256,7 @@ function Set-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroupListener {
@@ -1279,7 +1281,7 @@ function Set-SqlAvailabilityGroupListener {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityReplica {
@@ -1328,7 +1330,7 @@ function Set-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlCredential {
@@ -1358,7 +1360,7 @@ function Set-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlHADREndpoint {
@@ -1410,7 +1412,7 @@ function Set-SqlHADREndpoint {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlNetworkConfiguration {
@@ -1471,7 +1473,7 @@ function Set-SqlNetworkConfiguration {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlSmartAdmin {
@@ -1508,7 +1510,7 @@ function Set-SqlSmartAdmin {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Start-SqlInstance {
@@ -1549,7 +1551,7 @@ function Start-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Stop-SqlInstance {
@@ -1590,7 +1592,7 @@ function Stop-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Suspend-SqlAvailabilityDatabase {
@@ -1610,7 +1612,7 @@ function Suspend-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Switch-SqlAvailabilityGroup {
@@ -1636,7 +1638,7 @@ function Switch-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityGroup {
@@ -1662,7 +1664,7 @@ function Test-SqlAvailabilityGroup {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityReplica {
@@ -1688,7 +1690,7 @@ function Test-SqlAvailabilityReplica {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlDatabaseReplicaState {
@@ -1714,7 +1716,7 @@ function Test-SqlDatabaseReplicaState {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlSmartAdmin {
@@ -1740,7 +1742,7 @@ function Test-SqlSmartAdmin {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,5 +1,10 @@
 ﻿# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
 
+# Suppressing this rule because these functions are from an external module 
+# and are only being used as stubs
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+param()
+
 function Add-SqlAvailabilityDatabase {
     [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
     param(

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,4 +1,6 @@
-﻿function Add-SqlAvailabilityDatabase {
+﻿# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
+
+function Add-SqlAvailabilityDatabase {
    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
    param(
        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
@@ -20,7 +22,7 @@
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAvailabilityGroupListenerStaticIp {
@@ -45,7 +47,7 @@ function Add-SqlAvailabilityGroupListenerStaticIp {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAzureAuthenticationContext {
@@ -71,7 +73,7 @@ function Add-SqlAzureAuthenticationContext {
        ${Tenant}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlColumnEncryptionKeyValue {
@@ -106,7 +108,7 @@ function Add-SqlColumnEncryptionKeyValue {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlFirewallRule {
@@ -147,7 +149,7 @@ function Add-SqlFirewallRule {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Backup-SqlDatabase {
@@ -305,7 +307,7 @@ function Backup-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Complete-SqlColumnMasterKeyRotation {
@@ -330,7 +332,7 @@ function Complete-SqlColumnMasterKeyRotation {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function ConvertFrom-EncodedSqlName {
@@ -342,7 +344,7 @@ function ConvertFrom-EncodedSqlName {
        ${SqlName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function ConvertTo-EncodedSqlName {
@@ -354,7 +356,7 @@ function ConvertTo-EncodedSqlName {
        ${SqlName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Convert-UrnToPath {
@@ -366,7 +368,7 @@ function Convert-UrnToPath {
        ${Urn}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Disable-SqlAlwaysOn {
@@ -397,7 +399,7 @@ function Disable-SqlAlwaysOn {
        ${Credential}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Enable-SqlAlwaysOn {
@@ -428,7 +430,7 @@ function Enable-SqlAlwaysOn {
        ${Credential}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgent {
@@ -459,7 +461,7 @@ function Get-SqlAgent {
        ${ConnectionTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJob {
@@ -495,7 +497,7 @@ function Get-SqlAgentJob {
        ${Path}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobHistory {
@@ -559,7 +561,7 @@ function Get-SqlAgentJobHistory {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobSchedule {
@@ -581,7 +583,7 @@ function Get-SqlAgentJobSchedule {
        ${Path}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobStep {
@@ -603,7 +605,7 @@ function Get-SqlAgentJobStep {
        ${Path}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentSchedule {
@@ -639,7 +641,7 @@ function Get-SqlAgentSchedule {
        ${Path}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlColumnEncryptionKey {
@@ -664,7 +666,7 @@ function Get-SqlColumnEncryptionKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlColumnMasterKey {
@@ -689,7 +691,7 @@ function Get-SqlColumnMasterKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlCredential {
@@ -714,7 +716,7 @@ function Get-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlDatabase {
@@ -753,7 +755,7 @@ function Get-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlErrorLog {
@@ -799,7 +801,7 @@ function Get-SqlErrorLog {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlInstance {
@@ -835,7 +837,7 @@ function Get-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlSmartAdmin {
@@ -871,7 +873,7 @@ function Get-SqlSmartAdmin {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-PolicyEvaluation {
@@ -902,7 +904,7 @@ function Invoke-PolicyEvaluation {
        ${OutputXml}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-Sqlcmd {
@@ -1012,7 +1014,7 @@ function Invoke-Sqlcmd {
        ${ConnectionString}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-SqlColumnMasterKeyRotation {
@@ -1042,7 +1044,7 @@ function Invoke-SqlColumnMasterKeyRotation {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Join-SqlAvailabilityGroup {
@@ -1067,7 +1069,7 @@ function Join-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroup {
@@ -1119,7 +1121,7 @@ function New-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroupListener {
@@ -1157,7 +1159,7 @@ function New-SqlAvailabilityGroupListener {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityReplica {
@@ -1223,7 +1225,7 @@ function New-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAzureKeyVaultColumnMasterKeySettings {
@@ -1235,7 +1237,7 @@ function New-SqlAzureKeyVaultColumnMasterKeySettings {
        ${KeyUrl}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlBackupEncryptionOption {
@@ -1257,7 +1259,7 @@ function New-SqlBackupEncryptionOption {
        ${EncryptorName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCertificateStoreColumnMasterKeySettings {
@@ -1274,7 +1276,7 @@ function New-SqlCertificateStoreColumnMasterKeySettings {
        ${Thumbprint}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCngColumnMasterKeySettings {
@@ -1291,7 +1293,7 @@ function New-SqlCngColumnMasterKeySettings {
        ${KeyName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionKey {
@@ -1325,7 +1327,7 @@ function New-SqlColumnEncryptionKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionKeyEncryptedValue {
@@ -1347,7 +1349,7 @@ function New-SqlColumnEncryptionKeyEncryptedValue {
        ${EncryptedValue}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionSettings {
@@ -1369,7 +1371,7 @@ function New-SqlColumnEncryptionSettings {
        ${EncryptionKey}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnMasterKey {
@@ -1399,7 +1401,7 @@ function New-SqlColumnMasterKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCredential {
@@ -1436,7 +1438,7 @@ function New-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCspColumnMasterKeySettings {
@@ -1453,7 +1455,7 @@ function New-SqlCspColumnMasterKeySettings {
        ${KeyName}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlHADREndpoint {
@@ -1506,7 +1508,7 @@ function New-SqlHADREndpoint {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityDatabase {
@@ -1526,7 +1528,7 @@ function Remove-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityGroup {
@@ -1546,7 +1548,7 @@ function Remove-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityReplica {
@@ -1566,7 +1568,7 @@ function Remove-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnEncryptionKey {
@@ -1591,7 +1593,7 @@ function Remove-SqlColumnEncryptionKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnEncryptionKeyValue {
@@ -1621,7 +1623,7 @@ function Remove-SqlColumnEncryptionKeyValue {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnMasterKey {
@@ -1646,7 +1648,7 @@ function Remove-SqlColumnMasterKey {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlCredential {
@@ -1666,7 +1668,7 @@ function Remove-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlFirewallRule {
@@ -1707,7 +1709,7 @@ function Remove-SqlFirewallRule {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Restore-SqlDatabase {
@@ -1852,7 +1854,7 @@ function Restore-SqlDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Resume-SqlAvailabilityDatabase {
@@ -1872,7 +1874,7 @@ function Resume-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Save-SqlMigrationReport {
@@ -1909,7 +1911,7 @@ function Save-SqlMigrationReport {
        ${FolderPath}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAuthenticationMode {
@@ -1967,7 +1969,7 @@ function Set-SqlAuthenticationMode {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroup {
@@ -1999,7 +2001,7 @@ function Set-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroupListener {
@@ -2024,7 +2026,7 @@ function Set-SqlAvailabilityGroupListener {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityReplica {
@@ -2073,7 +2075,7 @@ function Set-SqlAvailabilityReplica {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlColumnEncryption {
@@ -2098,7 +2100,7 @@ function Set-SqlColumnEncryption {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlCredential {
@@ -2128,7 +2130,7 @@ function Set-SqlCredential {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlErrorLog {
@@ -2166,7 +2168,7 @@ function Set-SqlErrorLog {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlHADREndpoint {
@@ -2218,7 +2220,7 @@ function Set-SqlHADREndpoint {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlNetworkConfiguration {
@@ -2279,7 +2281,7 @@ function Set-SqlNetworkConfiguration {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlSmartAdmin {
@@ -2319,7 +2321,7 @@ function Set-SqlSmartAdmin {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Start-SqlInstance {
@@ -2360,7 +2362,7 @@ function Start-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Stop-SqlInstance {
@@ -2401,7 +2403,7 @@ function Stop-SqlInstance {
        ${RetryTimeout}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Suspend-SqlAvailabilityDatabase {
@@ -2421,7 +2423,7 @@ function Suspend-SqlAvailabilityDatabase {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Switch-SqlAvailabilityGroup {
@@ -2447,7 +2449,7 @@ function Switch-SqlAvailabilityGroup {
        ${Script}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityGroup {
@@ -2473,7 +2475,7 @@ function Test-SqlAvailabilityGroup {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityReplica {
@@ -2499,7 +2501,7 @@ function Test-SqlAvailabilityReplica {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlDatabaseReplicaState {
@@ -2525,7 +2527,7 @@ function Test-SqlDatabaseReplicaState {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlSmartAdmin {
@@ -2551,7 +2553,7 @@ function Test-SqlSmartAdmin {
        ${InputObject}
    )
 
-   throw 'NotImplemented'
+   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,0 +1,2557 @@
+﻿function Add-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlAvailabilityGroupListenerStaticIp {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${StaticIp},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlAzureAuthenticationContext {
+   [CmdletBinding()]
+   param(
+       [Parameter(Position=0)]
+       [switch]
+       ${Interactive},
+
+       [Parameter(Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ClientID},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Secret},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Tenant}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlColumnEncryptionKeyValue {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ColumnMasterKeyName},
+
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptedValue},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Add-SqlFirewallRule {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Backup-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByBackupContainer')]
+       [Parameter(ParameterSetName='ByDBObject')]
+       [Parameter(ParameterSetName='ByPath')]
+       [Parameter(ParameterSetName='ByName')]
+       [Parameter(ParameterSetName='ByObject')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${BackupContainer},
+
+       [object]
+       ${MirrorDevices},
+
+       [object]
+       ${BackupAction},
+
+       [string]
+       ${BackupSetName},
+
+       [string]
+       ${BackupSetDescription},
+
+       [object]
+       ${CompressionOption},
+
+       [switch]
+       ${CopyOnly},
+
+       [datetime]
+       ${ExpirationDate},
+
+       [switch]
+       ${FormatMedia},
+
+       [switch]
+       ${Incremental},
+
+       [switch]
+       ${Initialize},
+
+       [object]
+       ${LogTruncationType},
+
+       [string]
+       ${MediaDescription},
+
+       [ValidateRange(0, 2147483647)]
+       [int]
+       ${RetainDays},
+
+       [switch]
+       ${SkipTapeHeader},
+
+       [string]
+       ${UndoFileName},
+
+       [object]
+       ${EncryptionOption},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${DatabaseObject},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${BackupFile},
+
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${BackupDevice},
+
+       [switch]
+       ${PassThru},
+
+       [switch]
+       ${Checksum},
+
+       [switch]
+       ${ContinueAfterError},
+
+       [switch]
+       ${NoRewind},
+
+       [switch]
+       ${Restart},
+
+       [switch]
+       ${UnloadTapeAfter},
+
+       [switch]
+       ${NoRecovery},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFile},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFileGroup},
+
+       [int]
+       ${BlockSize},
+
+       [int]
+       ${BufferCount},
+
+       [int]
+       ${MaxTransferSize},
+
+       [string]
+       ${MediaName},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Complete-SqlColumnMasterKeyRotation {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SourceColumnMasterKeyName},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function ConvertFrom-EncodedSqlName {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SqlName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function ConvertTo-EncodedSqlName {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SqlName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Convert-UrnToPath {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Urn}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Disable-SqlAlwaysOn {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ServerInstance},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [switch]
+       ${Force},
+
+       [pscredential]
+       ${Credential}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Enable-SqlAlwaysOn {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ServerInstance},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [switch]
+       ${Force},
+
+       [pscredential]
+       ${Credential}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgent {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(ParameterSetName='ByObject', Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgentJob {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgentJobHistory {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [datetime]
+       ${StartRunDate},
+
+       [datetime]
+       ${EndRunDate},
+
+       [guid]
+       ${JobID},
+
+       [string]
+       ${JobName},
+
+       [int]
+       ${MinimumRetries},
+
+       [int]
+       ${MinimumRunDurationInSeconds},
+
+       [switch]
+       ${OldestFirst},
+
+       [object]
+       ${OutcomesType},
+
+       [int]
+       ${SqlMessageID},
+
+       [int]
+       ${SqlSeverity},
+
+       [object]
+       ${Since},
+
+       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgentJobSchedule {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgentJobStep {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlAgentSchedule {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlColumnEncryptionKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlColumnMasterKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [System.Nullable[int]]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlErrorLog {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [timespan]
+       ${Timespan},
+
+       [datetime]
+       ${Before},
+
+       [datetime]
+       ${After},
+
+       [object]
+       ${Since},
+
+       [switch]
+       ${Ascending},
+
+       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlInstance {
+   [CmdletBinding(ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${MachineName},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Get-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [Parameter(ParameterSetName='ByName')]
+       [Parameter(Position=1)]
+       [Parameter(ParameterSetName='ByObject')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [string]
+       ${DatabaseName},
+
+       [Parameter(ParameterSetName='ByName')]
+       [Parameter(ValueFromPipeline=$true)]
+       [psobject]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Invoke-PolicyEvaluation {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${Policy},
+
+       [object]
+       ${AdHocPolicyEvaluationMode},
+
+       [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${TargetServerName},
+
+       [Parameter(ParameterSetName='ConnectionProcessing')]
+       [string]
+       ${TargetExpression},
+
+       [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+       [psobject[]]
+       ${TargetObjects},
+
+       [switch]
+       ${OutputXml}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Invoke-Sqlcmd {
+   [CmdletBinding(DefaultParameterSetName='ByConnectionParameters')]
+   param(
+       [Parameter(ParameterSetName='ByConnectionParameters', ValueFromPipeline=$true)]
+       [psobject]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [switch]
+       ${EncryptConnection},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Username},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Password},
+
+       [Parameter(Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Query},
+
+       [int]
+       ${QueryTimeout},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [int]
+       ${ConnectionTimeout},
+
+       [ValidateRange(-1, 255)]
+       [int]
+       ${ErrorLevel},
+
+       [ValidateRange(-1, 25)]
+       [int]
+       ${SeverityLevel},
+
+       [ValidateRange(1, 2147483647)]
+       [int]
+       ${MaxCharLength},
+
+       [ValidateRange(1, 2147483647)]
+       [int]
+       ${MaxBinaryLength},
+
+       [switch]
+       ${AbortOnError},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [switch]
+       ${DedicatedAdministratorConnection},
+
+       [switch]
+       ${DisableVariables},
+
+       [switch]
+       ${DisableCommands},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${HostName},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [string]
+       ${NewPassword},
+
+       [string[]]
+       ${Variable},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${InputFile},
+
+       [bool]
+       ${OutputSqlErrors},
+
+       [switch]
+       ${IncludeSqlUserErrors},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [switch]
+       ${SuppressProviderContextWarning},
+
+       [Parameter(ParameterSetName='ByConnectionParameters')]
+       [switch]
+       ${IgnoreProviderContext},
+
+       [Alias('As')]
+       [object]
+       ${OutputAs},
+
+       [Parameter(ParameterSetName='ByConnectionString', Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ConnectionString}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Invoke-SqlColumnMasterKeyRotation {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${SourceColumnMasterKeyName},
+
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${TargetColumnMasterKeyName},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Join-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNull()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AvailabilityReplica},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Database},
+
+       [object]
+       ${AutomatedBackupPreference},
+
+       [object]
+       ${FailureConditionLevel},
+
+       [int]
+       ${HealthCheckTimeout},
+
+       [switch]
+       ${BasicAvailabilityGroup},
+
+       [switch]
+       ${DatabaseHealthTrigger},
+
+       [switch]
+       ${DtcSupportEnabled},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityGroupListener {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${DhcpSubnet},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${StaticIp},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(1, 65535)]
+       [int]
+       ${Port},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [object]
+       ${AvailabilityMode},
+
+       [Parameter(Mandatory=$true)]
+       [object]
+       ${FailoverMode},
+
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EndpointUrl},
+
+       [int]
+       ${SessionTimeout},
+
+       [object]
+       ${ConnectionModeInPrimaryRole},
+
+       [object]
+       ${ConnectionModeInSecondaryRole},
+
+       [ValidateRange(0, 100)]
+       [int]
+       ${BackupPriority},
+
+       [string[]]
+       ${ReadOnlyRoutingList},
+
+       [string]
+       ${ReadonlyRoutingConnectionUrl},
+
+       [Parameter(ParameterSetName='AsTemplate')]
+       [switch]
+       ${AsTemplate},
+
+       [Parameter(ParameterSetName='AsTemplate')]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Version},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlAzureKeyVaultColumnMasterKeySettings {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${KeyUrl}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlBackupEncryptionOption {
+   [CmdletBinding()]
+   param(
+       [switch]
+       ${NoEncryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Algorithm},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptorType},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptorName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlCertificateStoreColumnMasterKeySettings {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${CertificateStoreLocation},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Thumbprint}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlCngColumnMasterKeySettings {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${CngProviderName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${KeyName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlColumnEncryptionKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ColumnMasterKeyName},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptedValue},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlColumnEncryptionKeyEncryptedValue {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${TargetColumnMasterKeySettings},
+
+       [Parameter(Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${ColumnMasterKeySettings},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptedValue}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlColumnEncryptionSettings {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ColumnName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptionType},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EncryptionKey}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlColumnMasterKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${ColumnMasterKeySettings},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Identity},
+
+       [ValidateNotNullOrEmpty()]
+       [securestring]
+       ${Secret},
+
+       [string]
+       ${ProviderName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlCspColumnMasterKeySettings {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${CspProviderName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${KeyName}
+   )
+
+   throw 'NotImplemented'
+}
+
+function New-SqlHADREndpoint {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [int]
+       ${Port},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Owner},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Certificate},
+
+       [ValidateNotNullOrEmpty()]
+       [ipaddress]
+       ${IpAddress},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AuthenticationOrder},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Encryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionAlgorithm},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlColumnEncryptionKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlColumnEncryptionKeyValue {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${ColumnMasterKeyName},
+
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlColumnMasterKey {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Name},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Remove-SqlFirewallRule {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Restore-SqlDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ClearSuspectPageTable},
+
+       [switch]
+       ${KeepReplication},
+
+       [switch]
+       ${Partial},
+
+       [switch]
+       ${ReplaceDatabase},
+
+       [switch]
+       ${RestrictedUser},
+
+       [long[]]
+       ${Offset},
+
+       [object]
+       ${RelocateFile},
+
+       [int]
+       ${FileNumber},
+
+       [object]
+       ${RestoreAction},
+
+       [string]
+       ${StandbyFile},
+
+       [string]
+       ${StopAtMarkAfterDate},
+
+       [string]
+       ${StopAtMarkName},
+
+       [string]
+       ${StopBeforeMarkAfterDate},
+
+       [string]
+       ${StopBeforeMarkName},
+
+       [string]
+       ${ToPointInTime},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Database},
+
+       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${DatabaseObject},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${BackupFile},
+
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${BackupDevice},
+
+       [switch]
+       ${PassThru},
+
+       [switch]
+       ${Checksum},
+
+       [switch]
+       ${ContinueAfterError},
+
+       [switch]
+       ${NoRewind},
+
+       [switch]
+       ${Restart},
+
+       [switch]
+       ${UnloadTapeAfter},
+
+       [switch]
+       ${NoRecovery},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFile},
+
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${DatabaseFileGroup},
+
+       [int]
+       ${BlockSize},
+
+       [int]
+       ${BufferCount},
+
+       [int]
+       ${MaxTransferSize},
+
+       [string]
+       ${MediaName},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Resume-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Save-SqlMigrationReport {
+   [CmdletBinding()]
+   param(
+       [string]
+       ${Server},
+
+       [string]
+       ${Database},
+
+       [string]
+       ${Schema},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Username},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Password},
+
+       [string]
+       ${Object},
+
+       [object]
+       ${InputObject},
+
+       [object]
+       ${MigrationType},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${FolderPath}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAuthenticationMode {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Mode},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${SqlCredential},
+
+       [switch]
+       ${ForceServiceRestart},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [object]
+       ${AutomatedBackupPreference},
+
+       [object]
+       ${FailureConditionLevel},
+
+       [int]
+       ${HealthCheckTimeout},
+
+       [bool]
+       ${DatabaseHealthTrigger},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityGroupListener {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(1, 65535)]
+       [int]
+       ${Port},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [object]
+       ${AvailabilityMode},
+
+       [object]
+       ${FailoverMode},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${EndpointUrl},
+
+       [int]
+       ${SessionTimeout},
+
+       [object]
+       ${ConnectionModeInPrimaryRole},
+
+       [object]
+       ${ConnectionModeInSecondaryRole},
+
+       [ValidateRange(0, 100)]
+       [int]
+       ${BackupPriority},
+
+       [string[]]
+       ${ReadOnlyRoutingList},
+
+       [string]
+       ${ReadonlyRoutingConnectionUrl},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlColumnEncryption {
+   [CmdletBinding()]
+   param(
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${ColumnEncryptionSettings},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlCredential {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Identity},
+
+       [Parameter(Position=3)]
+       [ValidateNotNullOrEmpty()]
+       [securestring]
+       ${Secret},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlErrorLog {
+   [CmdletBinding(DefaultParameterSetName='ByPath')]
+   param(
+       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(ParameterSetName='ByName')]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [Parameter(ParameterSetName='ByName')]
+       [int]
+       ${ConnectionTimeout},
+
+       [ValidateRange(6, 99)]
+       [uint16]
+       ${MaxLogCount},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlHADREndpoint {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Owner},
+
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Certificate},
+
+       [ValidateNotNullOrEmpty()]
+       [ipaddress]
+       ${IpAddress},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${AuthenticationOrder},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Encryption},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionAlgorithm},
+
+       [ValidateNotNullOrEmpty()]
+       [int]
+       ${Port},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${State},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlNetworkConfiguration {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(Mandatory=$true, Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${Protocol},
+
+       [Parameter(Position=2)]
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${Port},
+
+       [switch]
+       ${Disable},
+
+       [switch]
+       ${ForceServiceRestart},
+
+       [switch]
+       ${NoServiceRestart},
+
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Set-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [ValidateNotNullOrEmpty()]
+       [psobject]
+       ${SqlCredential},
+
+       [bool]
+       ${MasterSwitch},
+
+       [bool]
+       ${BackupEnabled},
+
+       [int]
+       ${BackupRetentionPeriodInDays},
+
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${EncryptionOption},
+
+       [string]
+       ${DatabaseName},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string]
+       ${Path},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Start-SqlInstance {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Stop-SqlInstance {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath')]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${ServerInstance},
+
+       [Parameter(Mandatory=$true, Position=0)]
+       [ValidateNotNullOrEmpty()]
+       [pscredential]
+       [System.Management.Automation.CredentialAttribute()]
+       ${Credential},
+
+       [switch]
+       ${AutomaticallyAcceptUntrustedCertificates},
+
+       [ValidateRange(0, 2147483647)]
+       [ValidateNotNullOrEmpty()]
+       [System.Nullable[int]]
+       ${ManagementPublicPort},
+
+       [ValidateNotNullOrEmpty()]
+       [ValidateRange(0, 2147483647)]
+       [System.Nullable[int]]
+       ${RetryTimeout}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Suspend-SqlAvailabilityDatabase {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Switch-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${AllowDataLoss},
+
+       [switch]
+       ${Force},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject},
+
+       [switch]
+       ${Script}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlAvailabilityGroup {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlAvailabilityReplica {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlDatabaseReplicaState {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+function Test-SqlSmartAdmin {
+   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+   param(
+       [switch]
+       ${ShowPolicyDetails},
+
+       [switch]
+       ${AllowUserPolicies},
+
+       [switch]
+       ${NoRefresh},
+
+       [Parameter(ParameterSetName='ByPath', Position=1)]
+       [ValidateNotNullOrEmpty()]
+       [string[]]
+       ${Path},
+
+       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+       [ValidateNotNullOrEmpty()]
+       [object]
+       ${InputObject}
+   )
+
+   throw 'NotImplemented'
+}
+
+

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,2559 +1,2557 @@
 ﻿# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
 
 function Add-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Database},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAvailabilityGroupListenerStaticIp {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${StaticIp},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlAzureAuthenticationContext {
-   [CmdletBinding()]
-   param(
-       [Parameter(Position=0)]
-       [switch]
-       ${Interactive},
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)]
+        [switch]
+        ${Interactive},
 
-       [Parameter(Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ClientID},
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ClientID},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Secret},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Secret},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Tenant}
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Tenant}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlColumnEncryptionKeyValue {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ColumnMasterKeyName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
 
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptedValue},
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Add-SqlFirewallRule {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Backup-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByBackupContainer')]
-       [Parameter(ParameterSetName='ByDBObject')]
-       [Parameter(ParameterSetName='ByPath')]
-       [Parameter(ParameterSetName='ByName')]
-       [Parameter(ParameterSetName='ByObject')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${BackupContainer},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByBackupContainer')]
+        [Parameter(ParameterSetName='ByDBObject')]
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${BackupContainer},
 
-       [object]
-       ${MirrorDevices},
+        [object]
+        ${MirrorDevices},
 
-       [object]
-       ${BackupAction},
+        [object]
+        ${BackupAction},
 
-       [string]
-       ${BackupSetName},
+        [string]
+        ${BackupSetName},
 
-       [string]
-       ${BackupSetDescription},
+        [string]
+        ${BackupSetDescription},
 
-       [object]
-       ${CompressionOption},
+        [object]
+        ${CompressionOption},
 
-       [switch]
-       ${CopyOnly},
+        [switch]
+        ${CopyOnly},
 
-       [datetime]
-       ${ExpirationDate},
+        [datetime]
+        ${ExpirationDate},
 
-       [switch]
-       ${FormatMedia},
+        [switch]
+        ${FormatMedia},
 
-       [switch]
-       ${Incremental},
+        [switch]
+        ${Incremental},
 
-       [switch]
-       ${Initialize},
+        [switch]
+        ${Initialize},
 
-       [object]
-       ${LogTruncationType},
+        [object]
+        ${LogTruncationType},
 
-       [string]
-       ${MediaDescription},
+        [string]
+        ${MediaDescription},
 
-       [ValidateRange(0, 2147483647)]
-       [int]
-       ${RetainDays},
+        [ValidateRange(0, 2147483647)]
+        [int]
+        ${RetainDays},
 
-       [switch]
-       ${SkipTapeHeader},
+        [switch]
+        ${SkipTapeHeader},
 
-       [string]
-       ${UndoFileName},
+        [string]
+        ${UndoFileName},
 
-       [object]
-       ${EncryptionOption},
+        [object]
+        ${EncryptionOption},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${DatabaseObject},
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${BackupFile},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
 
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${BackupDevice},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
 
-       [switch]
-       ${PassThru},
+        [switch]
+        ${PassThru},
 
-       [switch]
-       ${Checksum},
+        [switch]
+        ${Checksum},
 
-       [switch]
-       ${ContinueAfterError},
+        [switch]
+        ${ContinueAfterError},
 
-       [switch]
-       ${NoRewind},
+        [switch]
+        ${NoRewind},
 
-       [switch]
-       ${Restart},
+        [switch]
+        ${Restart},
 
-       [switch]
-       ${UnloadTapeAfter},
+        [switch]
+        ${UnloadTapeAfter},
 
-       [switch]
-       ${NoRecovery},
+        [switch]
+        ${NoRecovery},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFile},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFileGroup},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
 
-       [int]
-       ${BlockSize},
+        [int]
+        ${BlockSize},
 
-       [int]
-       ${BufferCount},
+        [int]
+        ${BufferCount},
 
-       [int]
-       ${MaxTransferSize},
+        [int]
+        ${MaxTransferSize},
 
-       [string]
-       ${MediaName},
+        [string]
+        ${MediaName},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Complete-SqlColumnMasterKeyRotation {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SourceColumnMasterKeyName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SourceColumnMasterKeyName},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function ConvertFrom-EncodedSqlName {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SqlName}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function ConvertTo-EncodedSqlName {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SqlName}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Convert-UrnToPath {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Urn}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Urn}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Disable-SqlAlwaysOn {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [pscredential]
-       ${Credential}
+        [pscredential]
+        ${Credential}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Enable-SqlAlwaysOn {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [pscredential]
-       ${Credential}
+        [pscredential]
+        ${Credential}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgent {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(ParameterSetName='ByObject', Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByObject', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout}
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJob {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path}
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobHistory {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [datetime]
-       ${StartRunDate},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [datetime]
+        ${StartRunDate},
 
-       [datetime]
-       ${EndRunDate},
+        [datetime]
+        ${EndRunDate},
 
-       [guid]
-       ${JobID},
+        [guid]
+        ${JobID},
 
-       [string]
-       ${JobName},
+        [string]
+        ${JobName},
 
-       [int]
-       ${MinimumRetries},
+        [int]
+        ${MinimumRetries},
 
-       [int]
-       ${MinimumRunDurationInSeconds},
+        [int]
+        ${MinimumRunDurationInSeconds},
 
-       [switch]
-       ${OldestFirst},
+        [switch]
+        ${OldestFirst},
 
-       [object]
-       ${OutcomesType},
+        [object]
+        ${OutcomesType},
 
-       [int]
-       ${SqlMessageID},
+        [int]
+        ${SqlMessageID},
 
-       [int]
-       ${SqlSeverity},
+        [int]
+        ${SqlSeverity},
 
-       [object]
-       ${Since},
+        [object]
+        ${Since},
 
-       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobSchedule {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path}
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentJobStep {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path}
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlAgentSchedule {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path}
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlColumnEncryptionKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlColumnMasterKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [System.Nullable[int]]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [System.Nullable[int]]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlErrorLog {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [timespan]
-       ${Timespan},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [timespan]
+        ${Timespan},
 
-       [datetime]
-       ${Before},
+        [datetime]
+        ${Before},
 
-       [datetime]
-       ${After},
+        [datetime]
+        ${After},
 
-       [object]
-       ${Since},
+        [object]
+        ${Since},
 
-       [switch]
-       ${Ascending},
+        [switch]
+        ${Ascending},
 
-       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlInstance {
-   [CmdletBinding(ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${MachineName},
+    [CmdletBinding(ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${MachineName},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Get-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [Parameter(ParameterSetName='ByName')]
-       [Parameter(Position=1)]
-       [Parameter(ParameterSetName='ByObject')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(Position=1)]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [string]
-       ${DatabaseName},
+        [string]
+        ${DatabaseName},
 
-       [Parameter(ParameterSetName='ByName')]
-       [Parameter(ValueFromPipeline=$true)]
-       [psobject]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-PolicyEvaluation {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${Policy},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${Policy},
 
-       [object]
-       ${AdHocPolicyEvaluationMode},
+        [object]
+        ${AdHocPolicyEvaluationMode},
 
-       [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${TargetServerName},
+        [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${TargetServerName},
 
-       [Parameter(ParameterSetName='ConnectionProcessing')]
-       [string]
-       ${TargetExpression},
+        [Parameter(ParameterSetName='ConnectionProcessing')]
+        [string]
+        ${TargetExpression},
 
-       [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
-       [psobject[]]
-       ${TargetObjects},
+        [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+        [psobject[]]
+        ${TargetObjects},
 
-       [switch]
-       ${OutputXml}
+        [switch]
+        ${OutputXml}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-Sqlcmd {
-   [CmdletBinding(DefaultParameterSetName='ByConnectionParameters')]
-   param(
-       [Parameter(ParameterSetName='ByConnectionParameters', ValueFromPipeline=$true)]
-       [psobject]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByConnectionParameters')]
+    param(
+        [Parameter(ParameterSetName='ByConnectionParameters', ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [switch]
-       ${EncryptConnection},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${EncryptConnection},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Username},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Password},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
 
-       [Parameter(Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Query},
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Query},
 
-       [int]
-       ${QueryTimeout},
+        [int]
+        ${QueryTimeout},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [int]
+        ${ConnectionTimeout},
 
-       [ValidateRange(-1, 255)]
-       [int]
-       ${ErrorLevel},
+        [ValidateRange(-1, 255)]
+        [int]
+        ${ErrorLevel},
 
-       [ValidateRange(-1, 25)]
-       [int]
-       ${SeverityLevel},
+        [ValidateRange(-1, 25)]
+        [int]
+        ${SeverityLevel},
 
-       [ValidateRange(1, 2147483647)]
-       [int]
-       ${MaxCharLength},
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxCharLength},
 
-       [ValidateRange(1, 2147483647)]
-       [int]
-       ${MaxBinaryLength},
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxBinaryLength},
 
-       [switch]
-       ${AbortOnError},
+        [switch]
+        ${AbortOnError},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [switch]
-       ${DedicatedAdministratorConnection},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${DedicatedAdministratorConnection},
 
-       [switch]
-       ${DisableVariables},
+        [switch]
+        ${DisableVariables},
 
-       [switch]
-       ${DisableCommands},
+        [switch]
+        ${DisableCommands},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${HostName},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${HostName},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [string]
-       ${NewPassword},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [string]
+        ${NewPassword},
 
-       [string[]]
-       ${Variable},
+        [string[]]
+        ${Variable},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${InputFile},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${InputFile},
 
-       [bool]
-       ${OutputSqlErrors},
+        [bool]
+        ${OutputSqlErrors},
 
-       [switch]
-       ${IncludeSqlUserErrors},
+        [switch]
+        ${IncludeSqlUserErrors},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [switch]
-       ${SuppressProviderContextWarning},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${SuppressProviderContextWarning},
 
-       [Parameter(ParameterSetName='ByConnectionParameters')]
-       [switch]
-       ${IgnoreProviderContext},
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${IgnoreProviderContext},
 
-       [Alias('As')]
-       [object]
-       ${OutputAs},
+        [Alias('As')]
+        [object]
+        ${OutputAs},
 
-       [Parameter(ParameterSetName='ByConnectionString', Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ConnectionString}
+        [Parameter(ParameterSetName='ByConnectionString', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ConnectionString}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Invoke-SqlColumnMasterKeyRotation {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${SourceColumnMasterKeyName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SourceColumnMasterKeyName},
 
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${TargetColumnMasterKeyName},
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${TargetColumnMasterKeyName},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Join-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNull()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNull()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AvailabilityReplica},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AvailabilityReplica},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Database},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
 
-       [object]
-       ${AutomatedBackupPreference},
+        [object]
+        ${AutomatedBackupPreference},
 
-       [object]
-       ${FailureConditionLevel},
+        [object]
+        ${FailureConditionLevel},
 
-       [int]
-       ${HealthCheckTimeout},
+        [int]
+        ${HealthCheckTimeout},
 
-       [switch]
-       ${BasicAvailabilityGroup},
+        [switch]
+        ${BasicAvailabilityGroup},
 
-       [switch]
-       ${DatabaseHealthTrigger},
+        [switch]
+        ${DatabaseHealthTrigger},
 
-       [switch]
-       ${DtcSupportEnabled},
+        [switch]
+        ${DtcSupportEnabled},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityGroupListener {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${DhcpSubnet},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${DhcpSubnet},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${StaticIp},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(1, 65535)]
-       [int]
-       ${Port},
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [object]
-       ${AvailabilityMode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${AvailabilityMode},
 
-       [Parameter(Mandatory=$true)]
-       [object]
-       ${FailoverMode},
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${FailoverMode},
 
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EndpointUrl},
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
 
-       [int]
-       ${SessionTimeout},
+        [int]
+        ${SessionTimeout},
 
-       [object]
-       ${ConnectionModeInPrimaryRole},
+        [object]
+        ${ConnectionModeInPrimaryRole},
 
-       [object]
-       ${ConnectionModeInSecondaryRole},
+        [object]
+        ${ConnectionModeInSecondaryRole},
 
-       [ValidateRange(0, 100)]
-       [int]
-       ${BackupPriority},
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
 
-       [string[]]
-       ${ReadOnlyRoutingList},
+        [string[]]
+        ${ReadOnlyRoutingList},
 
-       [string]
-       ${ReadonlyRoutingConnectionUrl},
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
 
-       [Parameter(ParameterSetName='AsTemplate')]
-       [switch]
-       ${AsTemplate},
+        [Parameter(ParameterSetName='AsTemplate')]
+        [switch]
+        ${AsTemplate},
 
-       [Parameter(ParameterSetName='AsTemplate')]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Version},
+        [Parameter(ParameterSetName='AsTemplate')]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Version},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlAzureKeyVaultColumnMasterKeySettings {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${KeyUrl}
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyUrl}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlBackupEncryptionOption {
-   [CmdletBinding()]
-   param(
-       [switch]
-       ${NoEncryption},
+    [CmdletBinding()]
+    param(
+        [switch]
+        ${NoEncryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Algorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Algorithm},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptorType},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptorType},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptorName}
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptorName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCertificateStoreColumnMasterKeySettings {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${CertificateStoreLocation},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CertificateStoreLocation},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Thumbprint}
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Thumbprint}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCngColumnMasterKeySettings {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${CngProviderName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CngProviderName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${KeyName}
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ColumnMasterKeyName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptedValue},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionKeyEncryptedValue {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${TargetColumnMasterKeySettings},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${TargetColumnMasterKeySettings},
 
-       [Parameter(Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${ColumnMasterKeySettings},
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnMasterKeySettings},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptedValue}
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnEncryptionSettings {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ColumnName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptionType},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptionType},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EncryptionKey}
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptionKey}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlColumnMasterKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${ColumnMasterKeySettings},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnMasterKeySettings},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Identity},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
 
-       [ValidateNotNullOrEmpty()]
-       [securestring]
-       ${Secret},
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
 
-       [string]
-       ${ProviderName},
+        [string]
+        ${ProviderName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlCspColumnMasterKeySettings {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${CspProviderName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CspProviderName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${KeyName}
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyName}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function New-SqlHADREndpoint {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [int]
-       ${Port},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Owner},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Certificate},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
 
-       [ValidateNotNullOrEmpty()]
-       [ipaddress]
-       ${IpAddress},
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AuthenticationOrder},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Encryption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionAlgorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnEncryptionKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnEncryptionKeyValue {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${ColumnMasterKeyName},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
 
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlColumnMasterKey {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Name},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Remove-SqlFirewallRule {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Restore-SqlDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ClearSuspectPageTable},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ClearSuspectPageTable},
 
-       [switch]
-       ${KeepReplication},
+        [switch]
+        ${KeepReplication},
 
-       [switch]
-       ${Partial},
+        [switch]
+        ${Partial},
 
-       [switch]
-       ${ReplaceDatabase},
+        [switch]
+        ${ReplaceDatabase},
 
-       [switch]
-       ${RestrictedUser},
+        [switch]
+        ${RestrictedUser},
 
-       [long[]]
-       ${Offset},
+        [long[]]
+        ${Offset},
 
-       [object]
-       ${RelocateFile},
+        [object]
+        ${RelocateFile},
 
-       [int]
-       ${FileNumber},
+        [int]
+        ${FileNumber},
 
-       [object]
-       ${RestoreAction},
+        [object]
+        ${RestoreAction},
 
-       [string]
-       ${StandbyFile},
+        [string]
+        ${StandbyFile},
 
-       [string]
-       ${StopAtMarkAfterDate},
+        [string]
+        ${StopAtMarkAfterDate},
 
-       [string]
-       ${StopAtMarkName},
+        [string]
+        ${StopAtMarkName},
 
-       [string]
-       ${StopBeforeMarkAfterDate},
+        [string]
+        ${StopBeforeMarkAfterDate},
 
-       [string]
-       ${StopBeforeMarkName},
+        [string]
+        ${StopBeforeMarkName},
 
-       [string]
-       ${ToPointInTime},
+        [string]
+        ${ToPointInTime},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
-       [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Database},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
 
-       [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${DatabaseObject},
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${BackupFile},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
 
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${BackupDevice},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
 
-       [switch]
-       ${PassThru},
+        [switch]
+        ${PassThru},
 
-       [switch]
-       ${Checksum},
+        [switch]
+        ${Checksum},
 
-       [switch]
-       ${ContinueAfterError},
+        [switch]
+        ${ContinueAfterError},
 
-       [switch]
-       ${NoRewind},
+        [switch]
+        ${NoRewind},
 
-       [switch]
-       ${Restart},
+        [switch]
+        ${Restart},
 
-       [switch]
-       ${UnloadTapeAfter},
+        [switch]
+        ${UnloadTapeAfter},
 
-       [switch]
-       ${NoRecovery},
+        [switch]
+        ${NoRecovery},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFile},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
 
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${DatabaseFileGroup},
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
 
-       [int]
-       ${BlockSize},
+        [int]
+        ${BlockSize},
 
-       [int]
-       ${BufferCount},
+        [int]
+        ${BufferCount},
 
-       [int]
-       ${MaxTransferSize},
+        [int]
+        ${MaxTransferSize},
 
-       [string]
-       ${MediaName},
+        [string]
+        ${MediaName},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Resume-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Save-SqlMigrationReport {
-   [CmdletBinding()]
-   param(
-       [string]
-       ${Server},
+    [CmdletBinding()]
+    param(
+        [string]
+        ${Server},
 
-       [string]
-       ${Database},
+        [string]
+        ${Database},
 
-       [string]
-       ${Schema},
+        [string]
+        ${Schema},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Username},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Password},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
 
-       [string]
-       ${Object},
+        [string]
+        ${Object},
 
-       [object]
-       ${InputObject},
+        [object]
+        ${InputObject},
 
-       [object]
-       ${MigrationType},
+        [object]
+        ${MigrationType},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${FolderPath}
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${FolderPath}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAuthenticationMode {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Mode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Mode},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${SqlCredential},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${SqlCredential},
 
-       [switch]
-       ${ForceServiceRestart},
+        [switch]
+        ${ForceServiceRestart},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [object]
-       ${AutomatedBackupPreference},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AutomatedBackupPreference},
 
-       [object]
-       ${FailureConditionLevel},
+        [object]
+        ${FailureConditionLevel},
 
-       [int]
-       ${HealthCheckTimeout},
+        [int]
+        ${HealthCheckTimeout},
 
-       [bool]
-       ${DatabaseHealthTrigger},
+        [bool]
+        ${DatabaseHealthTrigger},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityGroupListener {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(1, 65535)]
-       [int]
-       ${Port},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [object]
-       ${AvailabilityMode},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AvailabilityMode},
 
-       [object]
-       ${FailoverMode},
+        [object]
+        ${FailoverMode},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${EndpointUrl},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
 
-       [int]
-       ${SessionTimeout},
+        [int]
+        ${SessionTimeout},
 
-       [object]
-       ${ConnectionModeInPrimaryRole},
+        [object]
+        ${ConnectionModeInPrimaryRole},
 
-       [object]
-       ${ConnectionModeInSecondaryRole},
+        [object]
+        ${ConnectionModeInSecondaryRole},
 
-       [ValidateRange(0, 100)]
-       [int]
-       ${BackupPriority},
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
 
-       [string[]]
-       ${ReadOnlyRoutingList},
+        [string[]]
+        ${ReadOnlyRoutingList},
 
-       [string]
-       ${ReadonlyRoutingConnectionUrl},
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlColumnEncryption {
-   [CmdletBinding()]
-   param(
-       [Parameter(Mandatory=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${ColumnEncryptionSettings},
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnEncryptionSettings},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlCredential {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Identity},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
 
-       [Parameter(Position=3)]
-       [ValidateNotNullOrEmpty()]
-       [securestring]
-       ${Secret},
+        [Parameter(Position=3)]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlErrorLog {
-   [CmdletBinding(DefaultParameterSetName='ByPath')]
-   param(
-       [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(ParameterSetName='ByName')]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [Parameter(ParameterSetName='ByName')]
-       [int]
-       ${ConnectionTimeout},
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
 
-       [ValidateRange(6, 99)]
-       [uint16]
-       ${MaxLogCount},
+        [ValidateRange(6, 99)]
+        [uint16]
+        ${MaxLogCount},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlHADREndpoint {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Owner},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
 
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Certificate},
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
 
-       [ValidateNotNullOrEmpty()]
-       [ipaddress]
-       ${IpAddress},
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${AuthenticationOrder},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Encryption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionAlgorithm},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
 
-       [ValidateNotNullOrEmpty()]
-       [int]
-       ${Port},
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${State},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${State},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlNetworkConfiguration {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(Mandatory=$true, Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${Protocol},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Protocol},
 
-       [Parameter(Position=2)]
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${Port},
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${Port},
 
-       [switch]
-       ${Disable},
+        [switch]
+        ${Disable},
 
-       [switch]
-       ${ForceServiceRestart},
+        [switch]
+        ${ForceServiceRestart},
 
-       [switch]
-       ${NoServiceRestart},
+        [switch]
+        ${NoServiceRestart},
 
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Set-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [ValidateNotNullOrEmpty()]
-       [psobject]
-       ${SqlCredential},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
 
-       [bool]
-       ${MasterSwitch},
+        [bool]
+        ${MasterSwitch},
 
-       [bool]
-       ${BackupEnabled},
+        [bool]
+        ${BackupEnabled},
 
-       [int]
-       ${BackupRetentionPeriodInDays},
+        [int]
+        ${BackupRetentionPeriodInDays},
 
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${EncryptionOption},
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionOption},
 
-       [string]
-       ${DatabaseName},
+        [string]
+        ${DatabaseName},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Start-SqlInstance {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Stop-SqlInstance {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath')]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${ServerInstance},
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
 
-       [Parameter(Mandatory=$true, Position=0)]
-       [ValidateNotNullOrEmpty()]
-       [pscredential]
-       [System.Management.Automation.CredentialAttribute()]
-       ${Credential},
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
 
-       [switch]
-       ${AutomaticallyAcceptUntrustedCertificates},
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
 
-       [ValidateRange(0, 2147483647)]
-       [ValidateNotNullOrEmpty()]
-       [System.Nullable[int]]
-       ${ManagementPublicPort},
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
 
-       [ValidateNotNullOrEmpty()]
-       [ValidateRange(0, 2147483647)]
-       [System.Nullable[int]]
-       ${RetryTimeout}
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Suspend-SqlAvailabilityDatabase {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Switch-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${AllowDataLoss},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${AllowDataLoss},
 
-       [switch]
-       ${Force},
+        [switch]
+        ${Force},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject},
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
 
-       [switch]
-       ${Script}
+        [switch]
+        ${Script}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityGroup {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlAvailabilityReplica {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlDatabaseReplicaState {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
 
 function Test-SqlSmartAdmin {
-   [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
-   param(
-       [switch]
-       ${ShowPolicyDetails},
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
 
-       [switch]
-       ${AllowUserPolicies},
+        [switch]
+        ${AllowUserPolicies},
 
-       [switch]
-       ${NoRefresh},
+        [switch]
+        ${NoRefresh},
 
-       [Parameter(ParameterSetName='ByPath', Position=1)]
-       [ValidateNotNullOrEmpty()]
-       [string[]]
-       ${Path},
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
 
-       [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
-       [ValidateNotNullOrEmpty()]
-       [object]
-       ${InputObject}
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
    )
 
-   throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
 }
-
-

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -28,6 +28,9 @@ try
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
+    # Loading stub cmdlets
+    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+
     $nodeName = 'localhost'
     $instanceName = 'DEFAULT'
     $availabilityGroup = 'AG01'
@@ -639,13 +642,13 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Get-Module -Name MockSQLPS | Remove-Module -Force
-        New-Module -Name MockSQLPS -ScriptBlock {
-            function New-SqlAvailabilityGroupListener { return }
-            function Set-SqlAvailabilityGroupListener { return }
-            function Add-SqlAvailabilityGroupListenerStaticIp { return }
-            Export-ModuleMember -Function *-SqlAvailability*
-        } | Import-Module -Force
+        # Get-Module -Name MockSQLPS | Remove-Module -Force
+        # New-Module -Name MockSQLPS -ScriptBlock {
+        #     function New-SqlAvailabilityGroupListener { return }
+        #     function Set-SqlAvailabilityGroupListener { return }
+        #     function Add-SqlAvailabilityGroupListenerStaticIp { return }
+        #     Export-ModuleMember -Function *-SqlAvailability*
+        # } | Import-Module -Force
 
         Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -38,12 +38,12 @@ try
     $listnerName = 'AGListner'
     
     # Values used for mocking
-    $desiredPortNumber = 5030
-    $actualPortNumber = 5555
-    $desiredIPAddress = '192.168.0.10'
-    $actualIPAddress = '10.0.0.1'
-    $desiredSubnetMask = '255.255.255.0'
-    $actualSubnetMask = '255.255.252.0'
+    $global:desiredPortNumber = 5030
+    $global:actualPortNumber = 5555
+    $global:desiredIPAddress = '192.168.0.10'
+    $global:actualIPAddress = '10.0.0.1'
+    $global:desiredSubnetMask = '255.255.255.0'
+    $global:actualSubnetMask = '255.255.252.0'
 
     $defaultParameters = @{
         InstanceName = $instanceName
@@ -96,15 +96,14 @@ try
             Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                 return New-Object Object | 
-                    Add-Member NoteProperty Name $listnerName -PassThru | 
-                    Add-Member NoteProperty PortNumber $actualPortNumber -PassThru | 
+                    Add-Member NoteProperty PortNumber $global:actualPortNumber -PassThru | 
                     Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                 Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
-                                Add-Member NoteProperty IPAddress $actualIPAddress -PassThru |
-                                Add-Member NoteProperty SubnetMask $actualSubnetMask -PassThru
+                                Add-Member NoteProperty IPAddress $global:actualIPAddress -PassThru |
+                                Add-Member NoteProperty SubnetMask $global:actualSubnetMask -PassThru
                             )
                         )
                     } -PassThru -Force 
@@ -146,7 +145,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                 return New-Object Object | 
-                    Add-Member NoteProperty Name $listnerName -PassThru | 
                     Add-Member NoteProperty PortNumber 5031 -PassThru | 
                     Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
@@ -221,7 +219,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -253,7 +250,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -285,7 +281,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -317,7 +312,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -349,7 +343,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
                             return @(
@@ -378,7 +371,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -407,7 +399,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -436,7 +427,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -487,7 +477,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -519,7 +508,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -548,7 +536,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -577,7 +564,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -606,7 +592,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -666,7 +651,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -699,7 +683,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -732,7 +715,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -765,7 +747,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -801,7 +782,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
@@ -833,7 +813,6 @@ try
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                     return New-Object Object | 
-                        Add-Member NoteProperty Name $listnerName -PassThru | 
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -37,14 +37,6 @@ try
     $availabilityGroup = 'AG01'
     $listnerName = 'AGListner'
     
-    # Values used for mocking
-    $global:desiredPortNumber = 5030
-    $global:actualPortNumber = 5555
-    $global:desiredIPAddress = '192.168.0.10'
-    $global:actualIPAddress = '10.0.0.1'
-    $global:desiredSubnetMask = '255.255.255.0'
-    $global:actualSubnetMask = '255.255.252.0'
-
     $defaultParameters = @{
         InstanceName = $instanceName
         NodeName = $nodeName 
@@ -89,21 +81,29 @@ try
                  Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
             }
         }
+
+        # Values used for mocking
+        $desiredPortNumber = 5030
+        $desiredIPAddress = '192.168.0.10'
+        $desiredSubnetMask = '255.255.255.0'
     
         Context 'When the system is in the desired state, without DHCP' {
             $testParameters = $defaultParameters
 
             Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                $actualPortNumber = 5030
+                $actualIPAddress = '192.168.0.10'
+                $actualSubnetMask = '255.255.255.0'
                 # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
                 return New-Object Object | 
-                    Add-Member NoteProperty PortNumber $global:actualPortNumber -PassThru | 
+                    Add-Member NoteProperty PortNumber $actualPortNumber -PassThru | 
                     Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                 Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
-                                Add-Member NoteProperty IPAddress $global:actualIPAddress -PassThru |
-                                Add-Member NoteProperty SubnetMask $global:actualSubnetMask -PassThru
+                                Add-Member NoteProperty IPAddress $actualIPAddress -PassThru |
+                                Add-Member NoteProperty SubnetMask $actualSubnetMask -PassThru
                             )
                         )
                     } -PassThru -Force 
@@ -123,11 +123,11 @@ try
             }
 
             It 'Should return correct IP address' {
-                $result.IpAddress | Should Be "$actualIPAddress/$actualSubnetMask"
+                $result.IpAddress | Should Be "$desiredIPAddress/$desiredSubnetMask"
             }
 
             It 'Should return correct port' {
-                $result.Port | Should Be $actualPortNumber
+                $result.Port | Should Be $desiredPortNumber
             }
 
             It 'Should return that DHCP is not used' {

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -96,8 +96,8 @@ try
                     Add-Member NoteProperty PortNumber 5030 -PassThru | 
                     Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
-                            # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                 Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                 Add-Member NoteProperty IPAddress '10.0.0.1' -PassThru |
                                 Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -150,8 +150,8 @@ try
                     Add-Member NoteProperty PortNumber 5031 -PassThru | 
                     Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                         return @(
-                            # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                 Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                 Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                 Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -229,8 +229,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -261,8 +261,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -293,8 +293,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -325,8 +325,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -357,8 +357,8 @@ try
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
@@ -386,8 +386,8 @@ try
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -415,8 +415,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '10.0.0.1' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -444,8 +444,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -499,8 +499,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -531,8 +531,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -560,8 +560,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -589,8 +589,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -618,8 +618,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -690,8 +690,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -723,8 +723,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -756,8 +756,8 @@ try
                         Add-Member NoteProperty PortNumber 5555 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -789,8 +789,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -829,8 +829,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
@@ -861,8 +861,8 @@ try
                         Add-Member NoteProperty PortNumber 5030 -PassThru | 
                         Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
                             return @(
-                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
                                     Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
                                     Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -1,0 +1,893 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerAvailabilityGroupListener'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $availabilityGroup = 'AG01'
+    $listnerName = 'AGListner'
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $listnerName
+        AvailabilityGroup = $availabilityGroup
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should not return any IP addresses' {
+                $result.IpAddress | Should Be $null
+            }
+
+            It 'Should not return port' {
+                $result.Port | Should Be 0
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state, without DHCP' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $listnerName -PassThru | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                Add-Member NoteProperty IPAddress '10.0.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '10.0.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5030
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state, with DHCP' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $listnerName -PassThru | 
+                    Add-Member NoteProperty PortNumber 5031 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5031
+            }
+
+            It 'Should return that DHCP is used' {
+                $result.DHCP | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when IP address is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is present but should be absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.100/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is absent but should be present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.100/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when port is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.100/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.0.100' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '10.0.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Get-Module -Name MockSQLPS | Remove-Module -Force
+        New-Module -Name MockSQLPS -ScriptBlock {
+            function New-SqlAvailabilityGroupListener { return }
+            function Set-SqlAvailabilityGroupListener { return }
+            function Add-SqlAvailabilityGroupListenerStaticIp { return }
+            Export-ModuleMember -Function *-SqlAvailability*
+        } | Import-Module -Force
+
+        Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw when trying to change an existing IP address' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '10.0.0.1/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw when trying to change from static IP to DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = @('192.168.10.45/255.255.252.0','10.0.0.1/255.255.252.0')
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $listnerName -PassThru | 
+                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -TypeName [bool] -PassThru | 
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
@@ -1,0 +1,452 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerEndpointPermission'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $principal = 'COMPANY\SqlServiceAcct'
+    $otherPrincipal = 'COMPANY\OtherAcct'
+    $endpointName = 'DefaultEndpointMirror'
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $endpointName
+        Principal = $principal
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
+
+            It 'Should not return any permissions' {
+                $result.Permission | Should Be ''
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $principal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
+
+            It 'Should return the permissions passed as parameter' {
+                $result.Permission | Should Be 'CONNECT'
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Present'
+                Permission = 'CONNECT'
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Permission = 'CONNECT'
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should call the the method Grant when desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the the method Revoke when desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should not throw error when desired state is already Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not throw error when desired state is already Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
@@ -45,10 +45,6 @@ try
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             $testParameters = $defaultParameters
 
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
@@ -89,10 +85,6 @@ try
         }
     
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             $testParameters = $defaultParameters
 
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
@@ -137,10 +129,6 @@ try
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             $testParameters = $defaultParameters
             $testParameters += @{
                 Ensure = 'Present'
@@ -199,10 +187,6 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should return that desired state is present when wanted desired state is to be Present' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
@@ -265,10 +249,6 @@ try
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should call the the method Grant when desired state is to be Present' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
@@ -353,10 +333,6 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should not throw error when desired state is already Present' {
                 $testParameters = $defaultParameters
                 $testParameters += @{

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -47,7 +47,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -71,7 +70,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
     
@@ -97,7 +95,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -121,7 +118,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -151,7 +147,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -172,7 +167,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -195,7 +189,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -216,7 +209,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -250,7 +242,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
                     Add-Member ScriptProperty Protocol {
                         return New-Object Object |
@@ -286,7 +277,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
                     Add-Member ScriptProperty Protocol {
                         return New-Object Object |
@@ -324,7 +314,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -350,7 +339,6 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -24,18 +24,13 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Pester Test Initialization
-
-    # Loading mocked classes
-    #Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
-    #endregion Pester Test Initialization
-
     $defaultParameters = @{
         InstanceName = 'DEFAULT'
         NodeName = 'localhost'
         Name = 'DefaultMirrorEndpoint'
         
     }
+    #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         $testParameters = $defaultParameters

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -24,12 +24,17 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Pester Test Initialization
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $endpointName = 'DefaultEndpointMirror'
+
     $defaultParameters = @{
-        InstanceName = 'DEFAULT'
-        NodeName = 'localhost'
-        Name = 'DefaultMirrorEndpoint'
-        
+        InstanceName = $instanceName
+        NodeName = $nodeName
+        Name = $endpointName
     }
+
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
@@ -43,7 +48,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -67,7 +72,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
     
@@ -97,7 +102,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -121,7 +126,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -155,7 +160,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -176,7 +181,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -203,7 +208,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -224,7 +229,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -269,7 +274,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -295,7 +300,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -327,7 +332,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -353,7 +358,7 @@ try
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
-                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
                     Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
             } -ModuleName $script:DSCResourceName -Verifiable
 

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -44,10 +44,6 @@ try
         $testParameters = $defaultParameters
 
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank 
-            }
-
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
@@ -98,10 +94,6 @@ try
         }
     
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
@@ -156,10 +148,6 @@ try
     
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-            
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
@@ -204,10 +192,6 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                 # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                 return New-Object Object |            
@@ -258,10 +242,6 @@ try
         Mock Set-SqlHADREndpoint -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             $testParameters = $defaultParameters
             $testParameters += @{
                 State = 'Stopped' 
@@ -336,10 +316,6 @@ try
        }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             $testParameters = $defaultParameters
             $testParameters += @{
                 State = 'Stopped' 

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -1,0 +1,390 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerEndPointState'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    #Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    #endregion Pester Test Initialization
+
+    $defaultParameters = @{
+        InstanceName = 'DEFAULT'
+        NodeName = 'localhost'
+        Name = 'DefaultMirrorEndpoint'
+        
+    }
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        $testParameters = $defaultParameters
+
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the same value as expected state Started' {
+                $result.State | Should Not Be 'Started'
+                $result.State | Should Be 'Stopped'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Started' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Started' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+            
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the same value as expected state Stopped' {
+                $result.State | Should Not Be 'Stopped'
+                $result.State | Should Be 'Started'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Stopped' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Stopped' {
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the same value as expected state Started' {
+                $result.State | Should Not Be 'Stopped'
+                $result.State | Should Be 'Started'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Started' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLPSInstance when expected state is Started' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the same value as expected state Stopped' {
+                $result.State | Should Not Be 'Started'
+                $result.State | Should Be 'Stopped'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Stopped' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLPSInstance when expected state is Stopped' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+    
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+            
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as absent when desired state is Started' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Started' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as absent when desired state is Stopped' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Stopped' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as present when desired state is Started' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Started' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is present' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as present when desired state is Stopped' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Stopped' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Stopped is present' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Get-Module -Name MockSQLPS | Remove-Module -Force
+        New-Module -Name MockSQLPS -ScriptBlock {
+            function Set-SqlHADREndpoint { return }
+        
+            Export-ModuleMember -Function Set-SqlHADREndpoint
+        } | Import-Module -Force -Scope Global
+
+        Mock Set-SqlHADREndpoint -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Stopped' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is not equal to Stopped' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Started' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is not equal to Started' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            } 
+       }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Stopped' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is equal to Stopped' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Started' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty Name $testParameters.Name -PassThru | 
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is equal to Started' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            } 
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -252,7 +252,7 @@ try
             function Set-SqlHADREndpoint { return }
         
             Export-ModuleMember -Function Set-SqlHADREndpoint
-        } | Import-Module -Force -Scope Global
+        } | Import-Module -Force
 
         Mock Set-SqlHADREndpoint -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -61,7 +61,7 @@ try
     
             $result = Get-TargetResource @testParameters
 
-            It 'Should return the desired state as Absent' {
+            It 'Should return the desired state as absent' {
                 $result.Ensure | Should Be 'Absent'
             }
 
@@ -211,7 +211,7 @@ try
                 { Set-TargetResource @testParameters } | Should Not Throw
             }
 
-            It 'Should call the mock function Get-SQLPSInstance twice' {
+            It 'Should call the mock function Get-SQLPSInstance' {
                  Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
             }
         }
@@ -251,6 +251,4 @@ finally
     Restore-TestEnvironment -TestEnvironment $TestEnvironment 
 
     #endregion
-
-    Remove-module $script:DSCResourceName -Force
 }

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -44,10 +44,6 @@ try
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             Mock -CommandName Get-SQLPSInstance -MockWith {
                 [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
@@ -85,10 +81,6 @@ try
         }
     
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             Mock -CommandName Get-SQLPSInstance -MockWith {
                 [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
@@ -139,10 +131,6 @@ try
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should return that desired state is absent when wanted desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
@@ -195,10 +183,6 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should return that desired state is present when wanted desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
@@ -255,10 +239,6 @@ try
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Context 'When the system is not in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should not throw error when desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
@@ -309,10 +289,6 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            BeforeAll {
-                # This has intentially been left blank
-            }
-
             It 'Should not throw error when desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -35,7 +35,7 @@ try
 
     #endregion Pester Test Initialization
 
-    $testParameters = @{
+    $defaultParameters = @{
         InstanceName = $instanceName
         NodeName = $nodeName
         Principal = $principal
@@ -45,20 +45,24 @@ try
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith {
-                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
-
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                    $mockObjectSmoServer.DisplayName = $instanceName
-                    $mockObjectSmoServer.InstanceName = $instanceName
-                    $mockObjectSmoServer.IsHadrEnabled = $False
-                    $mockObjectSmoServer.MockGranteeName = $principal
-
-                    return $mockObjectSmoServer
-                } -ModuleName $script:DSCResourceName -Verifiable
+                # This has intentially been left blank
             }
+
+            Mock -CommandName Get-SQLPSInstance -MockWith {
+                [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                $mockObjectSmoServer.DisplayName = $instanceName
+                $mockObjectSmoServer.InstanceName = $instanceName
+                $mockObjectSmoServer.IsHadrEnabled = $False
+                $mockObjectSmoServer.MockGranteeName = $principal
+
+                return $mockObjectSmoServer
+            } -ModuleName $script:DSCResourceName -Verifiable
     
+            $testParameters = $defaultParameters
+
             $result = Get-TargetResource @testParameters
 
             It 'Should return the desired state as absent' {
@@ -82,19 +86,23 @@ try
     
         Context 'When the system is in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith {
-                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
-                    
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                    $mockObjectSmoServer.DisplayName = $instanceName
-                    $mockObjectSmoServer.InstanceName = $instanceName
-                    $mockObjectSmoServer.IsHadrEnabled = $False
-                    $mockObjectSmoServer.MockGranteeName = $principal
-
-                    return $mockObjectSmoServer
-                } -ModuleName $script:DSCResourceName -Verifiable
+                # This has intentially been left blank
             }
+
+            Mock -CommandName Get-SQLPSInstance -MockWith {
+                [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                $mockObjectSmoServer.DisplayName = $instanceName
+                $mockObjectSmoServer.InstanceName = $instanceName
+                $mockObjectSmoServer.IsHadrEnabled = $False
+                $mockObjectSmoServer.MockGranteeName = $principal
+
+                return $mockObjectSmoServer
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $testParameters = $defaultParameters
 
             $result = Get-TargetResource @testParameters
 
@@ -129,14 +137,13 @@ try
         Assert-VerifiableMocks
     }
 
-    # This is added to the hash table after the Get method is tested, because Get method doesn't have Ensure as a parameter. 
-    $testParameters += @{
-        Ensure = 'Present'
-    }
-
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
@@ -149,20 +156,19 @@ try
 
                     return $mockObjectSmoServer
                 } -ModuleName $script:DSCResourceName -Verifiable
-            }
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
 
-            It 'Should return that desired state is absent' {
                 $result = Test-TargetResource @testParameters
                 $result | Should Be $false
+
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should call the mock function Get-SQLPSInstance' {
-                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-
-        Context 'When the system is in the desired state' {
-            BeforeAll {
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
@@ -175,15 +181,72 @@ try
 
                     return $mockObjectSmoServer
                 } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
             }
 
-            It 'Should return that desired state is present' {
+            It 'Should return that desired state is present when wanted desired state is to be Present' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
+
                 $result = Test-TargetResource @testParameters
                 $result | Should Be $true
+
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should call the mock function Get-SQLPSInstance' {
-                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
         }
 
@@ -193,6 +256,10 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should not throw error when desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
@@ -201,23 +268,22 @@ try
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
                     $mockObjectSmoServer.IsHadrEnabled = $False
-                    $mockObjectSmoServer.MockGranteeName = $principal
+                    $mockObjectSmoServer.MockGranteeName = $principal   
 
                     return $mockObjectSmoServer
                 } -ModuleName $script:DSCResourceName -Verifiable
-            }
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
 
-            It 'Should not throw an error' {
                 { Set-TargetResource @testParameters } | Should Not Throw
+
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should call the mock function Get-SQLPSInstance' {
-                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-
-        Context 'When the system is in the desired state' {
-            BeforeAll {
+            It 'Should not throw error when desired state is to be Absent' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
@@ -230,17 +296,72 @@ try
 
                     return $mockObjectSmoServer
                 } -ModuleName $script:DSCResourceName -Verifiable
-            }
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
 
-            It 'Should not throw an error' {
                 { Set-TargetResource @testParameters } | Should Not Throw
-            }
 
-            It 'Should call the mock function Get-SQLPSInstance' {
-                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
             }
         }
 
+        Context 'When the system is in the desired state' {
+            BeforeAll {
+                # This has intentially been left blank
+            }
+
+            It 'Should not throw error when desired state is to be Present' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'   
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should not throw error when desired state is to be Absent' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                 Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+#>
         Assert-VerifiableMocks
     }
 }

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -45,8 +45,10 @@ try
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $false )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
@@ -80,8 +82,10 @@ try
     
         Context 'When the system is in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $true )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+                    
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
@@ -133,8 +137,10 @@ try
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $false )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
@@ -157,8 +163,10 @@ try
 
         Context 'When the system is in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $true )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
@@ -185,8 +193,10 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Context 'When the system is not in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $false )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName
@@ -208,8 +218,10 @@ try
 
         Context 'When the system is in the desired state' {
             BeforeAll {
-                Mock -CommandName Get-SQLPSInstance -MockWith { 
-                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $true )
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
                     $mockObjectSmoServer.Name = "$nodeName\$instanceName"
                     $mockObjectSmoServer.DisplayName = $instanceName
                     $mockObjectSmoServer.InstanceName = $instanceName

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -21,6 +21,7 @@ FeatureNotSupported = '{0}' is not a valid value for setting 'FEATURES'.  Refer 
 AvailabilityGroupListenerNotFound = Trying to make a change to a listener that does not exist.
 AvailabilityGroupListenerErrorVerifyExist = Unexpected result when trying to verify existence of listener {0}.
 AvailabilityGroupListenerIPChangeError = IP-address configuration mismatch. Expecting {0} found {1}. Resource does not support changing IP-address. Listener needs to be removed and then created again.
+AvailabilityGroupListenerDHCPChangeError = IP-address configuration mismatch. Expecting {0} found {1}. Resource does not support changing between static IP and DHCP. Listener needs to be removed and then created again.
 
 # Endpoint
 EndpointNotFound = Endpoint {0} does not exist


### PR DESCRIPTION
* Added tests for resources
  - xSQLServerPermission
  - xSQLServerEndpointState
  - xSQLServerEndpointPermission
  - xSQLServerAvailabilityGroupListener
* Fixes in xSQLServerAvailabilityGroupListener
  - In one case the Get-method did not report that DHCP was configured. 
  - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
  - Fixed an issue where sometimes the listener wasn't removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/98)
<!-- Reviewable:end -->
