### PR TITLE
Add parameters for New-ListenerADObject to use named SQL server and instance

### DIFF
--- a/DSCResources/MSFT_xSQLServerFirewall/MSFT_xSQLServerFirewall.schema.mof
+++ b/DSCResources/MSFT_xSQLServerFirewall/MSFT_xSQLServerFirewall.schema.mof
@@ -12,4 +12,3 @@ class MSFT_xSQLServerFirewall : OMI_BaseResource
     [Read, Description("Is the firewall rule for Analysis Services enabled?")] boolean AnalysisServicesFirewall;
     [Read, Description("Is the firewall rule for the Integration Services enabled?")] boolean IntegrationServicesFirewall;
  };
- 

--- a/DSCResources/xSQLServerReplication/xSQLServerReplication.psm1
+++ b/DSCResources/xSQLServerReplication/xSQLServerReplication.psm1
@@ -1,0 +1,505 @@
+﻿$dom = [AppDomain]::CreateDomain('xSQLServerReplication')
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Local', 'Remote')]
+        [System.String]
+        $DistributorMode,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $AdminLinkCredentials,
+
+        [System.String]
+        $DistributionDBName = 'distribution',
+
+        [System.String]
+        $RemoteDistributor,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WorkingDirectory,
+
+        [System.Boolean]
+        $UseTrustedConnection = $true,
+
+        [System.Boolean]
+        $UninstallWithForce = $true
+    )
+
+    $Ensure = 'Absent'
+
+    $sqlMajorVersion = Get-SqlServerMajorVersion -InstanceName $InstanceName
+    $localSqlName = Get-SqlLocalServerName -InstanceName $InstanceName
+
+    $localServerConnection = New-ServerConnection -SqlMajorVersion $sqlMajorVersion -SqlServerName $localSqlName
+    $localReplicationServer = New-ReplicationServer -SqlMajorVersion $sqlMajorVersion -ServerConnection $localServerConnection
+
+    if($localReplicationServer.IsDistributor -eq $true)
+    {
+        $Ensure = 'Present'
+        $DistributorMode = 'Local'
+    }
+    elseif($localReplicationServer.IsPublisher -eq $true)
+    {
+        $Ensure = 'Present'
+        $DistributorMode = 'Remote'
+    }
+
+    if($Ensure -eq 'Present')
+    {
+        $DistributionDBName = $localReplicationServer.DistributionDatabase
+        $RemoteDistributor = $localReplicationServer.DistributionServer
+        $WorkingDirectory = $localReplicationServer.WorkingDirectory
+    }
+               
+    $returnValue = @{
+        InstanceName = $InstanceName
+        Ensure = $Ensure
+        DistributorMode = $DistributorMode
+        DistributionDBName = $DistributionDBName
+        RemoteDistributor = $RemoteDistributor
+        WorkingDirectory = $WorkingDirectory
+    }
+    
+    return $returnValue
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Local', 'Remote')]
+        [System.String]
+        $DistributorMode,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $AdminLinkCredentials,
+
+        [System.String]
+        $DistributionDBName = 'distribution',
+
+        [System.String]
+        $RemoteDistributor,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WorkingDirectory,
+
+        [System.Boolean]
+        $UseTrustedConnection = $true,
+
+        [System.Boolean]
+        $UninstallWithForce = $true
+    )
+
+    if(($DistributorMode -eq 'Remote') -and (-not $RemoteDistributor))
+    {
+        throw "RemoteDistributor parameter cannot be empty when DistributorMode = 'Remote'!"
+    }
+
+    $sqlMajorVersion = Get-SqlServerMajorVersion -InstanceName $InstanceName
+    $localSqlName = Get-SqlLocalServerName -InstanceName $InstanceName
+
+    $localServerConnection = New-ServerConnection -SqlMajorVersion $sqlMajorVersion -SqlServerName $localSqlName
+    $localReplicationServer = New-ReplicationServer -SqlMajorVersion $sqlMajorVersion -ServerConnection $localServerConnection
+
+    if($Ensure -eq 'Present')
+    {
+        if($DistributorMode -eq 'Local' -and $localReplicationServer.IsDistributor -eq $false)
+        {
+            Write-Verbose "Local distribution will be configured ..."
+
+            $distributionDB = New-DistributionDatabase `
+                -SqlMajorVersion $sqlMajorVersion `
+                -DistributionDBName $DistributionDBName `
+                -ServerConnection $localServerConnection
+
+            Install-LocalDistributor `
+                -ReplicationServer $localReplicationServer `
+                -AdminLinkCredentials $AdminLinkCredentials `
+                -DistributionDB $distributionDB
+
+            Register-DistributorPublisher `
+                -SqlMajorVersion $sqlMajorVersion `
+                -PublisherName $localSqlName `
+                -ServerConnection $localServerConnection `
+                -DistributionDBName $DistributionDBName `
+                -WorkingDirectory $WorkingDirectory `
+                -UseTrustedConnection $UseTrustedConnection
+        }
+            
+        if($DistributorMode -eq 'Remote' -and $localReplicationServer.IsPublisher -eq $false)
+        {
+            Write-Verbose "Remote distribution will be configured ..."
+
+            $remoteConnection = New-ServerConnection -SqlMajorVersion $sqlMajorVersion -SqlServerName $RemoteDistributor
+
+            Register-DistributorPublisher `
+                -SqlMajorVersion $sqlMajorVersion `
+                -PublisherName $localSqlName `
+                -ServerConnection $remoteConnection `
+                -DistributionDBName $DistributionDBName `
+                -WorkingDirectory $WorkingDirectory `
+                -UseTrustedConnection $UseTrustedConnection
+
+            Install-RemoteDistributor `
+                -ReplicationServer $localReplicationServer `
+                -RemoteDistributor $RemoteDistributor `
+                -AdminLinkCredentials $AdminLinkCredentials
+        }
+    }
+    else #'Absent'
+    {
+        if($localReplicationServer.IsDistributor -eq $true -or $localReplicationServer.IsPublisher -eq $true)
+        {
+            Write-Verbose "Distribution will be removed ..."
+            Uninstall-Distributor -ReplicationServer $localReplicationServer -UninstallWithForce $UninstallWithForce
+        }
+        else
+        {
+            Write-Verbose "Distribution is not configured on this instance."
+        }
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Local', 'Remote')]
+        [System.String]
+        $DistributorMode,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $AdminLinkCredentials,
+
+        [System.String]
+        $DistributionDBName = 'distribution',
+
+        [System.String]
+        $RemoteDistributor,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WorkingDirectory,
+
+        [System.Boolean]
+        $UseTrustedConnection = $true,
+
+        [System.Boolean]
+        $UninstallWithForce = $true
+    )
+
+    $result = $false
+    $state = Get-TargetResource @PSBoundParameters
+
+    if($Ensure -eq 'Absent' -and $state.Ensure -eq 'Absent')
+    {
+        $result = $true
+    }
+    elseif($Ensure -eq 'Present' -and $state.Ensure -eq 'Present' -and $state.DistributorMode -eq $DistributorMode)
+    {
+        $result = $true
+    }
+          
+    return $result
+}
+
+#region helper functions
+function New-ServerConnection
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlServerName
+    )
+
+    $connInfo = Get-ConnectionInfoAssembly -SqlMajorVersion $SqlMajorVersion
+    $serverConnection = New-Object $connInfo.GetType('Microsoft.SqlServer.Management.Common.ServerConnection') $SqlServerName
+
+    return $serverConnection
+}
+
+function New-ReplicationServer
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion,
+
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ServerConnection
+    )
+
+    $rmo = Get-RmoAssembly -SqlMajorVersion $SqlMajorVersion
+    $localReplicationServer = New-Object $rmo.GetType('Microsoft.SqlServer.Replication.ReplicationServer') $ServerConnection
+
+    return $localReplicationServer;
+}
+
+function New-DistributionDatabase
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $DistributionDBName,
+
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ServerConnection
+    )
+
+    $rmo = Get-RmoAssembly -SqlMajorVersion $SqlMajorVersion
+    Write-Verbose "Creating DistributionDatabase object $DistributionDBName"
+    $distributionDB = New-Object $rmo.GetType('Microsoft.SqlServer.Replication.DistributionDatabase') $DistributionDBName, $ServerConnection
+
+    return $distributionDB
+}
+
+function New-DistributionPublisher
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $PublisherName,
+
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ServerConnection
+    )
+    
+    $rmo = Get-RmoAssembly -SqlMajorVersion $SqlMajorVersion
+    $distributorPublisher = New-object $rmo.GetType('Microsoft.SqlServer.Replication.DistributionPublisher') $PublisherName, $ServerConnection
+
+    return $distributorPublisher
+}
+
+function Install-RemoteDistributor
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ReplicationServer,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $RemoteDistributor,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $AdminLinkCredentials
+    )
+
+    Write-Verbose "Calling InstallDistributor with RemoteDistributor = $RemoteDistributor"
+    $ReplicationServer.InstallDistributor($RemoteDistributor, $AdminLinkCredentials.Password)
+}
+
+function Install-LocalDistributor
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ReplicationServer,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $AdminLinkCredentials,
+
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $DistributionDB
+    )
+
+    Write-Verbose "Calling InstallDistributor with DistributionDB"
+    $ReplicationServer.InstallDistributor($AdminLinkCredentials.Password, $DistributionDB)
+}
+
+function Uninstall-Distributor
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ReplicationServer,
+
+        [parameter(Mandatory = $true)]
+        [System.Boolean]
+        $UninstallWithForce
+    )
+    Write-Verbose 'Calling UnistallDistributor method on ReplicationServer object'
+    $ReplicationServer.UninstallDistributor($UninstallWithForce)
+}
+
+function Register-DistributorPublisher
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $PublisherName,
+
+        [parameter(Mandatory = $true)]
+        [System.Object]
+        $ServerConnection,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $DistributionDBName,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WorkingDirectory,
+
+        [parameter(Mandatory = $true)]
+        [System.Boolean]
+        $UseTrustedConnection
+    )
+
+    Write-Verbose "Creating DistributorPublisher $PublisherName on $($ServerConnection.ServerInstance)"
+
+    $distributorPublisher = New-DistributionPublisher `
+        -SqlMajorVersion $SqlMajorVersion `
+        -PublisherName $PublisherName `
+        -ServerConnection $ServerConnection
+    
+    $distributorPublisher.DistributionDatabase = $DistributionDBName
+    $distributorPublisher.WorkingDirectory = $WorkingDirectory
+    $distributorPublisher.PublisherSecurity.WindowsAuthentication = $UseTrustedConnection
+    $distributorPublisher.Create()
+}
+
+function Get-ConnectionInfoAssembly
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion
+    )
+
+    $connInfo = $dom.Load("Microsoft.SqlServer.ConnectionInfo, Version=$SqlMajorVersion.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91")
+    Write-Verbose "Loaded assembly: $($connInfo.FullName)"
+
+    return $connInfo
+}
+
+function Get-RmoAssembly
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SqlMajorVersion
+    )
+
+    $rmo = $dom.Load("Microsoft.SqlServer.Rmo, Version=$SqlMajorVersion.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91")
+    Write-Verbose "Loaded assembly: $($rmo.FullName)"
+
+    return $rmo
+}
+
+function Get-SqlServerMajorVersion
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName
+    )
+
+    $instanceId = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL").$InstanceName
+    $sqlVersion = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$instanceId\Setup").Version
+    $sqlMajorVersion = $sqlVersion.Split(".")[0]
+    if (-not $sqlMajorVersion)
+    {
+        throw "Unable to detect version for sql server instance: $InstanceName!"
+    }
+    return $sqlMajorVersion
+}
+
+function Get-SqlLocalServerName
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName
+    )
+
+    if($InstanceName -eq "MSSQLSERVER")
+    {
+        return $env:COMPUTERNAME
+    }
+    else
+    {
+        return "$($env:COMPUTERNAME)\$InstanceName"
+    }
+}
+#endregion
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/xSQLServerReplication/xSQLServerReplication.schema.mof
+++ b/DSCResources/xSQLServerReplication/xSQLServerReplication.schema.mof
@@ -1,0 +1,13 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xSQLServerReplication")]
+class xSQLServerReplication : OMI_BaseResource
+{
+    [Key, Description("SQL Server instance name where replication distribution will be configured")] String InstanceName;
+    [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] String Ensure;
+    [Required, ValueMap{"Local", "Remote"}, Values{"Local", "Remote"}] String DistributorMode;
+    [Required, EmbeddedInstance("MSFT_Credential"), Description("Distributor administration link password")] String AdminLinkCredentials;
+    [Write, Description("Distribution database name")] String DistributionDBName;
+    [Write, Description("Distributor server name if configuring publisher with remote distributor")] String RemoteDistributor;
+    [Required, Description("Publisher working directory")] String WorkingDirectory;
+    [Write, Description("Publisher security mode")] Boolean UseTrustedConnection;
+    [Write, Description("Force flag for uninstall procedure")] Boolean UninstallWithForce;
+};

--- a/Examples/SQL-ClusterDB.ps1
+++ b/Examples/SQL-ClusterDB.ps1
@@ -155,11 +155,10 @@ Configuration SQL
     }
 }
 
-$SecurePassword = ConvertTo-SecureString -String "Pass@word1" -AsPlainText -Force
-$DomainAdministratorCredential = New-Object System.Management.Automation.PSCredential ("CONTOSO\Administrator", $SecurePassword)
-$InstallerServiceAccount = New-Object System.Management.Automation.PSCredential ("CONTOSO\!Installer", $SecurePassword)
-$LocalSystemAccount = New-Object System.Management.Automation.PSCredential ("SYSTEM", $SecurePassword)
-$SQLServiceAccount = New-Object System.Management.Automation.PSCredential ("CONTOSO\!sql", $SecurePassword)
+$DomainAdministratorCredential = Get-Credential "CONTOSO\Administrator"
+$InstallerServiceAccount = Get-Credential "CONTOSO\!Installer"
+$LocalSystemAccount = Get-Credential "SYSTEM"
+$SQLServiceAccount = Get-Credential "CONTOSO\!sql"
 
 $ConfigurationData = @{
     AllNodes = @(

--- a/Examples/SQL-Standalone.ps1
+++ b/Examples/SQL-Standalone.ps1
@@ -104,9 +104,8 @@ Configuration SQLSA
     }
 }
 
-$SecurePassword = ConvertTo-SecureString -String "Pass@word1" -AsPlainText -Force
-$InstallerServiceAccount = New-Object System.Management.Automation.PSCredential ("CONTOSO\!Installer", $SecurePassword)
-$LocalSystemAccount = New-Object System.Management.Automation.PSCredential ("SYSTEM", $SecurePassword)
+$InstallerServiceAccount = Get-Credential "CONTOSO\!Installer"
+$LocalSystemAccount = Get-Credential "SYSTEM"
 
 $ConfigurationData = @{
     AllNodes = @(

--- a/Examples/SQLServerNetwork.ps1
+++ b/Examples/SQLServerNetwork.ps1
@@ -60,9 +60,8 @@ Configuration SQLNetwork
 #Following example of how to use credentials is intended only for demo and test purposes
 #For production environments please use SSencryption, more info can be found here:
 #http://blogs.msdn.com/b/powershell/archive/2014/01/31/want-to-secure-credentials-in-windows-powershell-desired-state-configuration.aspx
-$SecurePassword = ConvertTo-SecureString -String "Pass@word1" -AsPlainText -Force
-$InstallerServiceAccount = New-Object System.Management.Automation.PSCredential ("CONTOSO\!Installer", $SecurePassword)
-$LocalSystemAccount = New-Object System.Management.Automation.PSCredential ("SYSTEM", $SecurePassword)
+$InstallerServiceAccount = Get-Credential "CONTOSO\!Installer"
+$LocalSystemAccount = Get-Credential "SYSTEM"
 
 $ConfigurationData = @{
     AllNodes = @(

--- a/Examples/xSQLServerReplication.ps1
+++ b/Examples/xSQLServerReplication.ps1
@@ -1,0 +1,55 @@
+﻿#this example should be used on local machine where two sql instances are installed
+#DEFAULT instance will be configured as distributor
+#PUBLISHER instance will be configured as publisher with remote distributor as default instance
+
+$credentials = Get-Credential 'AdminLink'
+$runAsCredentials = Get-Credential
+
+configuration ReplicationTest
+{
+    Import-DscResource -ModuleName xSQLServer
+
+    Node $AllNodes.NodeName
+    {
+        LocalConfigurationManager
+        {
+            #this option should only be used during testing, remove it in production environment
+            DebugMode = 'ForceModuleImport'
+        }
+
+        xSQLServerReplication distributor
+        {
+            InstanceName = 'MSSQLSERVER'
+            AdminLinkCredentials = $credentials
+            DistributorMode = 'Local'
+            WorkingDirectory = 'C:\temp'
+            Ensure = 'Present'
+            PsDscRunAsCredential = $runAsCredentials
+        }
+
+        xSQLServerReplication publisher
+        {
+            InstanceName = 'PUBLISHER'
+            AdminLinkCredentials = $credentials
+            DistributorMode = 'Remote'
+            WorkingDirectory = 'C:\temp'
+            RemoteDistributor = $Node.NodeName
+            Ensure = 'Present'
+            PsDscRunAsCredential = $runAsCredentials
+        }
+    }
+}
+
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = $($env:COMPUTERNAME)
+            #this option should only be used during testing, remove it in production environment
+            PSDscAllowPlainTextPassword = $true
+        } 
+    )
+}
+
+ReplicationTest -ConfigurationData $ConfigurationData
+Set-DscLocalConfigurationManager .\ReplicationTest -Force -Verbose
+Start-DscConfiguration .\ReplicationTest -Wait -Force -Verbose

--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### Unreleased
 * Added resources
   - xSQLServerReplication
+* Added tests for resources
+  - xSQLServerPermission
+  - xSQLServerEndpointState
+  - xSQLServerEndpointPermission
+  - xSQLServerAvailabilityGroupListener
+* Fixes in xSQLServerAvailabilityGroupListener
+  - In one case the Get-method did not report that DHCP was configured. 
+  - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
+  - Fixed an issue where sometimes the listener wasn't removed.
+  - Fixed the issue when trying to add a static IP to a listener was ignored.
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Database**: (key) Database to be created or dropped
 * **Ensure**: An enumerated value that describes if Database is to be present or absent.
 * **SQLServer**: The SQL Server for the database
-* **SQLInstance**: The SQL instance for the database 
+* **SQLInstance**: The SQL instance for the database
 
 ###xSQLAOGroupEnsure
 * **Ensure**: (key) An enumerated value that describes if Availability Group is to be present or absent.
@@ -262,7 +262,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Port**: Port Endpoint should listen on
 * **AuthorizedUser**:  User who should have connect ability to endpoint
 * **SQLServer**: The SQL Server for the database
-* **SQLInstance**: The SQL instance for the database 
+* **SQLInstance**: The SQL instance for the database
 
 ###xWaitforAvailabilityGroup
 * **Name**:  (key) Name for availability group
@@ -312,7 +312,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Ensure**: (Default = 'Present') 'Present' will configure replication, 'Absent' will disable replication.
 * **DistributorMode**: (Required), 'Local' - Instance will be configured as it's own distributor, 'Remote' - Instace will be configure with remote distributor (remote distributor needs to be already configured for distribution).
 * **AdminLinkCredentials**: (Required) - AdminLink password to be used when setting up publisher distributor relationship.
-* **DistributionDBName**: (Default = 'distribution') distribution database name. If DistributionMode='Local' this will be created, if 'Remote' needs to match distribution database on remote distributor. 
+* **DistributionDBName**: (Default = 'distribution') distribution database name. If DistributionMode='Local' this will be created, if 'Remote' needs to match distribution database on remote distributor.
 * **RemoteDistributor**: (Required if DistributionMode='Remote') SQL Server network name that will be used as distributor for local instance.
 * **WorkingDirectory**: (Required) Publisher working directory.
 * **UseTrustedConnection**: (Default = $true) Publisher security mode.
@@ -329,10 +329,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
 * Fixes in xSQLServerAvailabilityGroupListener
-  - In one case the Get-method did not report that DHCP was configured. 
+  - In one case the Get-method did not report that DHCP was configured.
   - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
   - Fixed an issue where sometimes the listener wasn't removed.
   - Fixed the issue when trying to add a static IP to a listener was ignored.
+* Fixes in xSQLAOGroupEnsure
+  - Added parameters to New-ListenerADObject to allow usage of a named instance.
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
@@ -346,7 +348,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
 * xSQLServerHelper
-    - added functions 
+    - added functions
         - Import-SQLPSModule
         - Get-SQLPSInstanceName
         - Get-SQLPSInstance
@@ -368,7 +370,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndPoint
   - xSQLServerAlwaysOnService
 * xSQLServerHelper
-    - added functions 
+    - added functions
         - Connect-SQL
         - New-VerboseMessage
         - Grant-ServerPerms
@@ -416,7 +418,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerDatabase
 * xSQLServerSetup:
   - Corrected bug in GetFirstItemPropertyValue to correctly handle registry keys with only one value.
-  - Added support for SQL Server 
+  - Added support for SQL Server
   - 2008 R2 installation
   - Removed default values for parameters, to avoid compatibility issues and setup errors
   - Added Replication sub feature detection
@@ -441,14 +443,14 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * xSQLServerFailoverClusterSetup
   - Additional of SQLHelper Function and error handling
   - Change SourceFolder to Source to allow for multiversion Support
-  - Add Parameters to SuppressReboot or ForceReboot 
+  - Add Parameters to SuppressReboot or ForceReboot
 * Examples
   - Updated example files to use correct DebugMode parameter value ForceModuleImport, this is not boolean in WMF 5.0 RTM
   - Added xSQLServerNetwork example
 
 ### 1.3.0.0
 
-* xSqlServerSetup: 
+* xSqlServerSetup:
     - Make Features case-insensitive.
 
 ### 1.2.1.0
@@ -457,13 +459,13 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### 1.2.0.0
 
-* Updated release with the following new resources 
+* Updated release with the following new resources
     - xSQLServerFailoverClusterSetup
     - xSQLServerRSConfig
 
 ### 1.1.0.0
 
-* Initial release with the following resources 
+* Initial release with the following resources
     - xSQLServerSetup
     - xSQLServerFirewall
     - xSQLServerRSSecureConnectionLevel

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 ## Contributing
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
-
 ## Resources
 
 * **xSQLServerSetup** installs a standalone SQL Server instance
@@ -38,6 +37,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **xSQLServerEndpointState** Change state of the endpoint.
 * **xSQLServerEndpointPermission** Grant or revoke permission on the endpoint.
 * **xSQLServerAvailabilityGroupListener** Create or remove an availability group listener.
+* **xSQLServerReplication** resource to manage SQL Replication distribution and publishing.
 
 ### xSQLServerSetup
 
@@ -307,6 +307,17 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Port** The port used for the availability group listener.
 * **DHCP** If DHCP should be used for the availability group listener instead of static IP address.
 
+###xSQLServerReplication
+* **InstanceName**: (Key) SQL Server instance name where replication distribution will be configured.
+* **Ensure**: (Default = 'Present') 'Present' will configure replication, 'Absent' will disable replication.
+* **DistributorMode**: (Required), 'Local' - Instance will be configured as it's own distributor, 'Remote' - Instace will be configure with remote distributor (remote distributor needs to be already configured for distribution).
+* **AdminLinkCredentials**: (Required) - AdminLink password to be used when setting up publisher distributor relationship.
+* **DistributionDBName**: (Default = 'distribution') distribution database name. If DistributionMode='Local' this will be created, if 'Remote' needs to match distribution database on remote distributor. 
+* **RemoteDistributor**: (Required if DistributionMode='Remote') SQL Server network name that will be used as distributor for local instance.
+* **WorkingDirectory**: (Required) Publisher working directory.
+* **UseTrustedConnection**: (Default = $true) Publisher security mode.
+* **UninstallWithForce**: (Default = $true) Force flag for uninstall procedure
+
 ## Versions
 
 ### Unreleased
@@ -322,16 +333,18 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointState
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
+  - xSQLServerReplication
 * xSQLServerHelper
-	- added functions 
-		- Import-SQLPSModule
-		- Get-SQLPSInstanceName
-		- Get-SQLPSInstance
-		- Get-SQLAlwaysOnEndpoint
-	- modified functions
-		- New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
+    - added functions 
+        - Import-SQLPSModule
+        - Get-SQLPSInstanceName
+        - Get-SQLPSInstance
+        - Get-SQLAlwaysOnEndpoint
+    - modified functions
+        - New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
 
 ### 1.7.0.0
+
 * Resources Added
   - xSQLServerConfiguration
 
@@ -447,5 +460,3 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Examples
 
 Examples for use of this resource can be found with the System Center resources, such as **xSCVMM**, **xSCSMA**, and **xSCOM**.
-
-

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* Added resources
+  - xSQLServerReplication
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
@@ -333,7 +335,6 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointState
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
-  - xSQLServerReplication
 * xSQLServerHelper
     - added functions 
         - Import-SQLPSModule

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+
+### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * Added Support for SQL Server 2016
 * xSQLAOGroupEnsure

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -3,10 +3,33 @@ using System.Collections.Generic;
 
 namespace Microsoft.SqlServer.Management.Smo
 {
+    public class Globals
+    {
+        // Static property that is switched on or off by tests if data should be mocked (true) or not (false).
+        public static bool GenerateMockData = false;
+    }
+
+    // Typename: Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
+    // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
+    // Used by: 
+    //  xSQLServerEndpointPermission.Tests.ps1
+    public class ObjectPermissionSet 
+    {
+        public ObjectPermissionSet(){}
+
+        public ObjectPermissionSet(
+            bool connect )
+        {
+            this.Connect = connect; 
+        } 
+    
+        public bool Connect = false;
+    }
+    
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class ServerPermissionSet 
     {
         public ServerPermissionSet(){}
@@ -32,7 +55,7 @@ namespace Microsoft.SqlServer.Management.Smo
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionInfo
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionInfo
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class ServerPermissionInfo 
     {
         public ServerPermissionInfo()
@@ -54,11 +77,9 @@ namespace Microsoft.SqlServer.Management.Smo
     // TypeName: Microsoft.SqlServer.Management.Smo.Server
     // BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
     // Used by: 
-    //  xSQLServerPermission
+    //  xSQLServerPermission.Tests.ps1
     public class Server 
     { 
-        private bool _generateMockData = false;
-
         public string MockGranteeName;
 
         public string Name;
@@ -66,21 +87,13 @@ namespace Microsoft.SqlServer.Management.Smo
         public string InstanceName;
         public bool IsHadrEnabled = false;
 
-        public Server()
-        { 
-            _generateMockData = false;
-        } 
-
-        public Server( bool generateMockData )
-        { 
-            this._generateMockData = generateMockData;
-        } 
+        public Server(){} 
 
         public Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] EnumServerPermissions( string principal, Microsoft.SqlServer.Management.Smo.ServerPermissionSet permissionSetQuery ) 
         { 
             List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo> listOfServerPermissionInfo = new List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo>();
             
-            if( this._generateMockData ) {
+            if( Globals.GenerateMockData ) {
                 Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = { 
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( true, false, false, false ),
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, true, false, false ),
@@ -108,7 +121,11 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Revoke( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
         {
-
+            if( granteeName != this.MockGranteeName ) 
+            {
+                string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
+                throw new System.ArgumentException(errorMessage, "granteeName");
+            }
         }
     }
 }

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,0 +1,1751 @@
+﻿# Generated from SQL Server 2014 (build 12.0.4213.0)
+
+# Suppressing this rule because these functions are from an external module 
+# and are only being used as stubs
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+param()
+
+function Add-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlAvailabilityGroupListenerStaticIp {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlFirewallRule {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Backup-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByBackupContainer')]
+        [Parameter(ParameterSetName='ByDBObject')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${BackupContainer},
+
+        [object]
+        ${MirrorDevices},
+
+        [object]
+        ${BackupAction},
+
+        [string]
+        ${BackupSetName},
+
+        [string]
+        ${BackupSetDescription},
+
+        [object]
+        ${CompressionOption},
+
+        [switch]
+        ${CopyOnly},
+
+        [datetime]
+        ${ExpirationDate},
+
+        [switch]
+        ${FormatMedia},
+
+        [switch]
+        ${Incremental},
+
+        [switch]
+        ${Initialize},
+
+        [object]
+        ${LogTruncationType},
+
+        [string]
+        ${MediaDescription},
+
+        [ValidateRange(0, 2147483647)]
+        [int]
+        ${RetainDays},
+
+        [switch]
+        ${SkipTapeHeader},
+
+        [string]
+        ${UndoFileName},
+
+        [object]
+        ${EncryptionOption},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
+
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
+
+        [switch]
+        ${PassThru},
+
+        [switch]
+        ${Checksum},
+
+        [switch]
+        ${ContinueAfterError},
+
+        [switch]
+        ${NoRewind},
+
+        [switch]
+        ${Restart},
+
+        [switch]
+        ${UnloadTapeAfter},
+
+        [switch]
+        ${NoRecovery},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
+
+        [int]
+        ${BlockSize},
+
+        [int]
+        ${BufferCount},
+
+        [int]
+        ${MaxTransferSize},
+
+        [string]
+        ${MediaName},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Convert-UrnToPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Urn}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Decode-SqlName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Disable-SqlAlwaysOn {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [switch]
+        ${Force},
+
+        [pscredential]
+        ${Credential}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Enable-SqlAlwaysOn {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [switch]
+        ${Force},
+
+        [pscredential]
+        ${Credential}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Encode-SqlName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [System.Nullable[int]]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlInstance {
+    [CmdletBinding(ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${MachineName},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(Position=1)]
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ValueFromPipeline=$true)]
+        [Parameter(ParameterSetName='ByName')]
+        [psobject]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Invoke-PolicyEvaluation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${Policy},
+
+        [object]
+        ${AdHocPolicyEvaluationMode},
+
+        [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${TargetServerName},
+
+        [Parameter(ParameterSetName='ConnectionProcessing')]
+        [string]
+        ${TargetExpression},
+
+        [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+        [psobject[]]
+        ${TargetObjects},
+
+        [switch]
+        ${OutputXml}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Invoke-Sqlcmd {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [switch]
+        ${EncryptConnection},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
+
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Query},
+
+        [int]
+        ${QueryTimeout},
+
+        [int]
+        ${ConnectionTimeout},
+
+        [ValidateRange(-1, 255)]
+        [int]
+        ${ErrorLevel},
+
+        [ValidateRange(-1, 25)]
+        [int]
+        ${SeverityLevel},
+
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxCharLength},
+
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxBinaryLength},
+
+        [switch]
+        ${AbortOnError},
+
+        [switch]
+        ${DedicatedAdministratorConnection},
+
+        [switch]
+        ${DisableVariables},
+
+        [switch]
+        ${DisableCommands},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${HostName},
+
+        [string]
+        ${NewPassword},
+
+        [string[]]
+        ${Variable},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${InputFile},
+
+        [bool]
+        ${OutputSqlErrors},
+
+        [switch]
+        ${IncludeSqlUserErrors},
+
+        [switch]
+        ${SuppressProviderContextWarning},
+
+        [switch]
+        ${IgnoreProviderContext}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Join-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNull()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AvailabilityReplica},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
+
+        [object]
+        ${AutomatedBackupPreference},
+
+        [object]
+        ${FailureConditionLevel},
+
+        [int]
+        ${HealthCheckTimeout},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityGroupListener {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${DhcpSubnet},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
+
+        [ValidateRange(1, 65535)]
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${AvailabilityMode},
+
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${FailoverMode},
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
+
+        [int]
+        ${SessionTimeout},
+
+        [object]
+        ${ConnectionModeInPrimaryRole},
+
+        [object]
+        ${ConnectionModeInSecondaryRole},
+
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
+
+        [string[]]
+        ${ReadOnlyRoutingList},
+
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
+
+        [Parameter(ParameterSetName='AsTemplate')]
+        [switch]
+        ${AsTemplate},
+
+        [Parameter(ParameterSetName='AsTemplate')]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Version},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlBackupEncryptionOption {
+    [CmdletBinding()]
+    param(
+        [switch]
+        ${NoEncryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Algorithm},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptorType},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptorName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
+
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
+
+        [string]
+        ${ProviderName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlHADREndpoint {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
+
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlFirewallRule {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Restore-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ClearSuspectPageTable},
+
+        [switch]
+        ${KeepReplication},
+
+        [switch]
+        ${Partial},
+
+        [switch]
+        ${ReplaceDatabase},
+
+        [switch]
+        ${RestrictedUser},
+
+        [long[]]
+        ${Offset},
+
+        [object]
+        ${RelocateFile},
+
+        [int]
+        ${FileNumber},
+
+        [object]
+        ${RestoreAction},
+
+        [string]
+        ${StandbyFile},
+
+        [string]
+        ${StopAtMarkAfterDate},
+
+        [string]
+        ${StopAtMarkName},
+
+        [string]
+        ${StopBeforeMarkAfterDate},
+
+        [string]
+        ${StopBeforeMarkName},
+
+        [string]
+        ${ToPointInTime},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
+
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
+
+        [switch]
+        ${PassThru},
+
+        [switch]
+        ${Checksum},
+
+        [switch]
+        ${ContinueAfterError},
+
+        [switch]
+        ${NoRewind},
+
+        [switch]
+        ${Restart},
+
+        [switch]
+        ${UnloadTapeAfter},
+
+        [switch]
+        ${NoRecovery},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
+
+        [int]
+        ${BlockSize},
+
+        [int]
+        ${BufferCount},
+
+        [int]
+        ${MaxTransferSize},
+
+        [string]
+        ${MediaName},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Resume-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAuthenticationMode {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Mode},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${SqlCredential},
+
+        [switch]
+        ${ForceServiceRestart},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AutomatedBackupPreference},
+
+        [object]
+        ${FailureConditionLevel},
+
+        [int]
+        ${HealthCheckTimeout},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityGroupListener {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AvailabilityMode},
+
+        [object]
+        ${FailoverMode},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
+
+        [int]
+        ${SessionTimeout},
+
+        [object]
+        ${ConnectionModeInPrimaryRole},
+
+        [object]
+        ${ConnectionModeInSecondaryRole},
+
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
+
+        [string[]]
+        ${ReadOnlyRoutingList},
+
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
+
+        [Parameter(Position=3)]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlHADREndpoint {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
+
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
+
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${State},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlNetworkConfiguration {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Protocol},
+
+        [Parameter(Position=2)]
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${Port},
+
+        [switch]
+        ${Disable},
+
+        [switch]
+        ${ForceServiceRestart},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [bool]
+        ${MasterSwitch},
+
+        [bool]
+        ${BackupEnabled},
+
+        [int]
+        ${BackupRetentionPeriodInDays},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionOption},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Start-SqlInstance {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Stop-SqlInstance {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Suspend-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Switch-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${AllowDataLoss},
+
+        [switch]
+        ${Force},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlDatabaseReplicaState {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,0 +1,2562 @@
+﻿# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
+
+# Suppressing this rule because these functions are from an external module 
+# and are only being used as stubs
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+param()
+
+function Add-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlAvailabilityGroupListenerStaticIp {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlAzureAuthenticationContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)]
+        [switch]
+        ${Interactive},
+
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ClientID},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Secret},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Tenant}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlColumnEncryptionKeyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Add-SqlFirewallRule {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Backup-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByBackupContainer')]
+        [Parameter(ParameterSetName='ByDBObject')]
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${BackupContainer},
+
+        [object]
+        ${MirrorDevices},
+
+        [object]
+        ${BackupAction},
+
+        [string]
+        ${BackupSetName},
+
+        [string]
+        ${BackupSetDescription},
+
+        [object]
+        ${CompressionOption},
+
+        [switch]
+        ${CopyOnly},
+
+        [datetime]
+        ${ExpirationDate},
+
+        [switch]
+        ${FormatMedia},
+
+        [switch]
+        ${Incremental},
+
+        [switch]
+        ${Initialize},
+
+        [object]
+        ${LogTruncationType},
+
+        [string]
+        ${MediaDescription},
+
+        [ValidateRange(0, 2147483647)]
+        [int]
+        ${RetainDays},
+
+        [switch]
+        ${SkipTapeHeader},
+
+        [string]
+        ${UndoFileName},
+
+        [object]
+        ${EncryptionOption},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
+
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
+
+        [switch]
+        ${PassThru},
+
+        [switch]
+        ${Checksum},
+
+        [switch]
+        ${ContinueAfterError},
+
+        [switch]
+        ${NoRewind},
+
+        [switch]
+        ${Restart},
+
+        [switch]
+        ${UnloadTapeAfter},
+
+        [switch]
+        ${NoRecovery},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
+
+        [int]
+        ${BlockSize},
+
+        [int]
+        ${BufferCount},
+
+        [int]
+        ${MaxTransferSize},
+
+        [string]
+        ${MediaName},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Complete-SqlColumnMasterKeyRotation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SourceColumnMasterKeyName},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function ConvertFrom-EncodedSqlName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function ConvertTo-EncodedSqlName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SqlName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Convert-UrnToPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Urn}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Disable-SqlAlwaysOn {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [switch]
+        ${Force},
+
+        [pscredential]
+        ${Credential}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Enable-SqlAlwaysOn {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ServerInstance},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [switch]
+        ${Force},
+
+        [pscredential]
+        ${Credential}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgent {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByObject', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgentJob {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgentJobHistory {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [datetime]
+        ${StartRunDate},
+
+        [datetime]
+        ${EndRunDate},
+
+        [guid]
+        ${JobID},
+
+        [string]
+        ${JobName},
+
+        [int]
+        ${MinimumRetries},
+
+        [int]
+        ${MinimumRunDurationInSeconds},
+
+        [switch]
+        ${OldestFirst},
+
+        [object]
+        ${OutcomesType},
+
+        [int]
+        ${SqlMessageID},
+
+        [int]
+        ${SqlSeverity},
+
+        [object]
+        ${Since},
+
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgentJobSchedule {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgentJobStep {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlAgentSchedule {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlColumnEncryptionKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlColumnMasterKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=2, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [System.Nullable[int]]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlErrorLog {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [timespan]
+        ${Timespan},
+
+        [datetime]
+        ${Before},
+
+        [datetime]
+        ${After},
+
+        [object]
+        ${Since},
+
+        [switch]
+        ${Ascending},
+
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlInstance {
+    [CmdletBinding(ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${MachineName},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Get-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(Position=1)]
+        [Parameter(ParameterSetName='ByObject')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [string]
+        ${DatabaseName},
+
+        [Parameter(ParameterSetName='ByName')]
+        [Parameter(ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Invoke-PolicyEvaluation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${Policy},
+
+        [object]
+        ${AdHocPolicyEvaluationMode},
+
+        [Parameter(ParameterSetName='ConnectionProcessing', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${TargetServerName},
+
+        [Parameter(ParameterSetName='ConnectionProcessing')]
+        [string]
+        ${TargetExpression},
+
+        [Parameter(ParameterSetName='ObjectProcessing', Mandatory=$true)]
+        [psobject[]]
+        ${TargetObjects},
+
+        [switch]
+        ${OutputXml}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Invoke-Sqlcmd {
+    [CmdletBinding(DefaultParameterSetName='ByConnectionParameters')]
+    param(
+        [Parameter(ParameterSetName='ByConnectionParameters', ValueFromPipeline=$true)]
+        [psobject]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${EncryptConnection},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
+
+        [Parameter(Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Query},
+
+        [int]
+        ${QueryTimeout},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [int]
+        ${ConnectionTimeout},
+
+        [ValidateRange(-1, 255)]
+        [int]
+        ${ErrorLevel},
+
+        [ValidateRange(-1, 25)]
+        [int]
+        ${SeverityLevel},
+
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxCharLength},
+
+        [ValidateRange(1, 2147483647)]
+        [int]
+        ${MaxBinaryLength},
+
+        [switch]
+        ${AbortOnError},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${DedicatedAdministratorConnection},
+
+        [switch]
+        ${DisableVariables},
+
+        [switch]
+        ${DisableCommands},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${HostName},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [string]
+        ${NewPassword},
+
+        [string[]]
+        ${Variable},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${InputFile},
+
+        [bool]
+        ${OutputSqlErrors},
+
+        [switch]
+        ${IncludeSqlUserErrors},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${SuppressProviderContextWarning},
+
+        [Parameter(ParameterSetName='ByConnectionParameters')]
+        [switch]
+        ${IgnoreProviderContext},
+
+        [Alias('As')]
+        [object]
+        ${OutputAs},
+
+        [Parameter(ParameterSetName='ByConnectionString', Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ConnectionString}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Invoke-SqlColumnMasterKeyRotation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${SourceColumnMasterKeyName},
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${TargetColumnMasterKeyName},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Join-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNull()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AvailabilityReplica},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Database},
+
+        [object]
+        ${AutomatedBackupPreference},
+
+        [object]
+        ${FailureConditionLevel},
+
+        [int]
+        ${HealthCheckTimeout},
+
+        [switch]
+        ${BasicAvailabilityGroup},
+
+        [switch]
+        ${DatabaseHealthTrigger},
+
+        [switch]
+        ${DtcSupportEnabled},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityGroupListener {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${DhcpSubnet},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${StaticIp},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${AvailabilityMode},
+
+        [Parameter(Mandatory=$true)]
+        [object]
+        ${FailoverMode},
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
+
+        [int]
+        ${SessionTimeout},
+
+        [object]
+        ${ConnectionModeInPrimaryRole},
+
+        [object]
+        ${ConnectionModeInSecondaryRole},
+
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
+
+        [string[]]
+        ${ReadOnlyRoutingList},
+
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
+
+        [Parameter(ParameterSetName='AsTemplate')]
+        [switch]
+        ${AsTemplate},
+
+        [Parameter(ParameterSetName='AsTemplate')]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Version},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlAzureKeyVaultColumnMasterKeySettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyUrl}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlBackupEncryptionOption {
+    [CmdletBinding()]
+    param(
+        [switch]
+        ${NoEncryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Algorithm},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptorType},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptorName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlCertificateStoreColumnMasterKeySettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CertificateStoreLocation},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Thumbprint}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlCngColumnMasterKeySettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CngProviderName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlColumnEncryptionKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlColumnEncryptionKeyEncryptedValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${TargetColumnMasterKeySettings},
+
+        [Parameter(Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnMasterKeySettings},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptedValue}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlColumnEncryptionSettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptionType},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EncryptionKey}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlColumnMasterKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnMasterKeySettings},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
+
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
+
+        [string]
+        ${ProviderName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlCspColumnMasterKeySettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${CspProviderName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${KeyName}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function New-SqlHADREndpoint {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
+
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlColumnEncryptionKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlColumnEncryptionKeyValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${ColumnMasterKeyName},
+
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlColumnMasterKey {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Name},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=2, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Remove-SqlFirewallRule {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Restore-SqlDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ClearSuspectPageTable},
+
+        [switch]
+        ${KeepReplication},
+
+        [switch]
+        ${Partial},
+
+        [switch]
+        ${ReplaceDatabase},
+
+        [switch]
+        ${RestrictedUser},
+
+        [long[]]
+        ${Offset},
+
+        [object]
+        ${RelocateFile},
+
+        [int]
+        ${FileNumber},
+
+        [object]
+        ${RestoreAction},
+
+        [string]
+        ${StandbyFile},
+
+        [string]
+        ${StopAtMarkAfterDate},
+
+        [string]
+        ${StopAtMarkName},
+
+        [string]
+        ${StopBeforeMarkAfterDate},
+
+        [string]
+        ${StopBeforeMarkName},
+
+        [string]
+        ${ToPointInTime},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, Position=1)]
+        [Parameter(ParameterSetName='ByPath', Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Database},
+
+        [Parameter(ParameterSetName='ByDBObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${DatabaseObject},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${BackupFile},
+
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${BackupDevice},
+
+        [switch]
+        ${PassThru},
+
+        [switch]
+        ${Checksum},
+
+        [switch]
+        ${ContinueAfterError},
+
+        [switch]
+        ${NoRewind},
+
+        [switch]
+        ${Restart},
+
+        [switch]
+        ${UnloadTapeAfter},
+
+        [switch]
+        ${NoRecovery},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFile},
+
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${DatabaseFileGroup},
+
+        [int]
+        ${BlockSize},
+
+        [int]
+        ${BufferCount},
+
+        [int]
+        ${MaxTransferSize},
+
+        [string]
+        ${MediaName},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Resume-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Save-SqlMigrationReport {
+    [CmdletBinding()]
+    param(
+        [string]
+        ${Server},
+
+        [string]
+        ${Database},
+
+        [string]
+        ${Schema},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Username},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Password},
+
+        [string]
+        ${Object},
+
+        [object]
+        ${InputObject},
+
+        [object]
+        ${MigrationType},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${FolderPath}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAuthenticationMode {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Mode},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${SqlCredential},
+
+        [switch]
+        ${ForceServiceRestart},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AutomatedBackupPreference},
+
+        [object]
+        ${FailureConditionLevel},
+
+        [int]
+        ${HealthCheckTimeout},
+
+        [bool]
+        ${DatabaseHealthTrigger},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityGroupListener {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(1, 65535)]
+        [int]
+        ${Port},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [object]
+        ${AvailabilityMode},
+
+        [object]
+        ${FailoverMode},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${EndpointUrl},
+
+        [int]
+        ${SessionTimeout},
+
+        [object]
+        ${ConnectionModeInPrimaryRole},
+
+        [object]
+        ${ConnectionModeInSecondaryRole},
+
+        [ValidateRange(0, 100)]
+        [int]
+        ${BackupPriority},
+
+        [string[]]
+        ${ReadOnlyRoutingList},
+
+        [string]
+        ${ReadonlyRoutingConnectionUrl},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlColumnEncryption {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${ColumnEncryptionSettings},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlCredential {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Identity},
+
+        [Parameter(Position=3)]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        ${Secret},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlErrorLog {
+    [CmdletBinding(DefaultParameterSetName='ByPath')]
+    param(
+        [Parameter(ParameterSetName='ByName', Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(ParameterSetName='ByName')]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [Parameter(ParameterSetName='ByName')]
+        [int]
+        ${ConnectionTimeout},
+
+        [ValidateRange(6, 99)]
+        [uint16]
+        ${MaxLogCount},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlHADREndpoint {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Owner},
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Certificate},
+
+        [ValidateNotNullOrEmpty()]
+        [ipaddress]
+        ${IpAddress},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${AuthenticationOrder},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Encryption},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionAlgorithm},
+
+        [ValidateNotNullOrEmpty()]
+        [int]
+        ${Port},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${State},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlNetworkConfiguration {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${Protocol},
+
+        [Parameter(Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${Port},
+
+        [switch]
+        ${Disable},
+
+        [switch]
+        ${ForceServiceRestart},
+
+        [switch]
+        ${NoServiceRestart},
+
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Set-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [psobject]
+        ${SqlCredential},
+
+        [bool]
+        ${MasterSwitch},
+
+        [bool]
+        ${BackupEnabled},
+
+        [int]
+        ${BackupRetentionPeriodInDays},
+
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${EncryptionOption},
+
+        [string]
+        ${DatabaseName},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        ${Path},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Start-SqlInstance {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Stop-SqlInstance {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [Parameter(ParameterSetName='ByName', Mandatory=$true, ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${ServerInstance},
+
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [pscredential]
+        [System.Management.Automation.CredentialAttribute()]
+        ${Credential},
+
+        [switch]
+        ${AutomaticallyAcceptUntrustedCertificates},
+
+        [ValidateRange(0, 2147483647)]
+        [ValidateNotNullOrEmpty()]
+        [System.Nullable[int]]
+        ${ManagementPublicPort},
+
+        [ValidateNotNullOrEmpty()]
+        [ValidateRange(0, 2147483647)]
+        [System.Nullable[int]]
+        ${RetryTimeout}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Suspend-SqlAvailabilityDatabase {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Switch-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${AllowDataLoss},
+
+        [switch]
+        ${Force},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject},
+
+        [switch]
+        ${Script}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlAvailabilityGroup {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlAvailabilityReplica {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlDatabaseReplicaState {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}
+
+function Test-SqlSmartAdmin {
+    [CmdletBinding(DefaultParameterSetName='ByPath', ConfirmImpact='Medium')]
+    param(
+        [switch]
+        ${ShowPolicyDetails},
+
+        [switch]
+        ${AllowUserPolicies},
+
+        [switch]
+        ${NoRefresh},
+
+        [Parameter(ParameterSetName='ByPath', Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        ${Path},
+
+        [Parameter(ParameterSetName='ByObject', Mandatory=$true, Position=1, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [object]
+        ${InputObject}
+   )
+
+    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+}

--- a/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -1,0 +1,684 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerAvailabilityGroupListener'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    # Loading stub cmdlets
+    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+
+    # Static parameter values
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $availabilityGroup = 'AG01'
+    $listnerName = 'AGListner'
+    
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $listnerName
+        AvailabilityGroup = $availabilityGroup
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should not return any IP addresses' {
+                $result.IpAddress | Should Be $null
+            }
+
+            It 'Should not return port' {
+                $result.Port | Should Be 0
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state, without DHCP' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5030
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state, with DHCP' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5031 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5031
+            }
+
+            It 'Should return that DHCP is used' {
+                $result.DHCP | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                 Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state (for static IP)' {
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when IP address is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is absent but should be present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when port is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is not in the desired state (for DHCP)' {
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when DHCP is present but should be absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.100/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state (for static IP)' {
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state (for DHCP)' {
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should throw when trying to change an existing IP address' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '10.0.0.1/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw when trying to change from static IP to DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+            return New-Object Object | 
+                Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                    return @(
+                        # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                        (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            Add-Member NoteProperty IsDHCP $false -PassThru | 
+                            Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                            Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                        )
+                    )
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is in the desired state' {
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointPermission.Tests.ps1
@@ -1,0 +1,428 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerEndpointPermission'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $principal = 'COMPANY\SqlServiceAcct'
+    $otherPrincipal = 'COMPANY\OtherAcct'
+    $endpointName = 'DefaultEndpointMirror'
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $endpointName
+        Principal = $principal
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
+
+            It 'Should not return any permissions' {
+                $result.Permission | Should Be ''
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $principal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
+
+            It 'Should return the permissions passed as parameter' {
+                $result.Permission | Should Be 'CONNECT'
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Present'
+                Permission = 'CONNECT'
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Permission = 'CONNECT'
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return that desired state is present when wanted desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            It 'Should call the the method Grant when desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the the method Revoke when desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should not throw error when desired state is already Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not throw error when desired state is already Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/xSQLServerEndpointState.Tests.ps1
@@ -1,0 +1,370 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerEndPointState'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading stub cmdlets
+    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $endpointName = 'DefaultEndpointMirror'
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName
+        Name = $endpointName
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        $testParameters = $defaultParameters
+
+        Context 'When the system is not in the desired state' {
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the same value as expected state Started' {
+                $result.State | Should Not Be 'Started'
+                $result.State | Should Be 'Stopped'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Started' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Started' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+            
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the same value as expected state Stopped' {
+                $result.State | Should Not Be 'Stopped'
+                $result.State | Should Be 'Started'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Stopped' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Stopped' {
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the same value as expected state Started' {
+                $result.State | Should Not Be 'Stopped'
+                $result.State | Should Be 'Started'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Started' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLPSInstance when expected state is Started' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the same value as expected state Stopped' {
+                $result.State | Should Not Be 'Started'
+                $result.State | Should Be 'Stopped'
+            }
+
+            It 'Should return the same values as passed as parameters when expected state is Stopped' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Get-SQLPSInstance when expected state is Stopped' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+    
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as absent when desired state is Started' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Started' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as absent when desired state is Stopped' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Stopped' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as present when desired state is Started' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Started' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is present' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state as present when desired state is Stopped' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    State = 'Stopped' 
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Stopped is present' {
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock Set-SqlHADREndpoint -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Stopped' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+                    Add-Member ScriptProperty Protocol {
+                        return New-Object Object |
+                            Add-Member ScriptProperty Tcp {
+                                return New-Object Object |
+                                        Add-Member ScriptProperty ListenerIPAddress {
+                                            return New-Object Object |
+                                                    Add-Member NoteProperty IPAddressToString '10.0.0.1' -PassThru
+                                        } -PassThru
+                            } -PassThru
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is not equal to Stopped' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Started' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+                    Add-Member ScriptProperty Protocol {
+                        return New-Object Object |
+                            Add-Member ScriptProperty Tcp {
+                                return New-Object Object |
+                                        Add-Member ScriptProperty ListenerIPAddress {
+                                            return New-Object Object |
+                                                    Add-Member NoteProperty IPAddressToString '10.0.0.1' -PassThru
+                                        } -PassThru
+                            } -PassThru
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is not equal to Started' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            } 
+       }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Stopped' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is equal to Stopped' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Stopped' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                State = 'Started' 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object |            
+                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should not throw an error when desired state is equal to Started' {
+                { Set-TargetResource @testParameters } | Should Not Throw
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Started' {
+                 Set-TargetResource @testParameters
+                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            } 
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/xSQLServerReplication.Tests.ps1
+++ b/Tests/Unit/xSQLServerReplication.Tests.ps1
@@ -1,0 +1,983 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param ()
+
+$script:DSCModuleName   = 'xSQLServer'
+$script:DSCResourceName = 'xSQLServerReplication'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+# Begin Testing
+try
+{
+    InModuleScope $script:DSCResourceName {
+
+        Describe 'Helper functions' {
+            Context 'Get-SqlServerMajorVersion' {
+
+                Mock -CommandName Get-ItemProperty `
+                    -MockWith { return [pscustomobject]@{ MSSQLSERVER = 'MSSQL12.MSSQLSERVER'} } `
+                    -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' }
+
+                It 'Should return corrent major version for default instance' {
+
+                    Mock -CommandName Get-ItemProperty `
+                        -MockWith { return [pscustomobject]@{ Version = '12.1.4100.1' } } `
+                        -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL12.MSSQLSERVER\Setup' }
+
+                    Get-SqlServerMajorVersion -InstanceName 'MSSQLSERVER' | Should be '12'
+                }
+
+                It 'Should throw error if major version cannot be resolved' {
+
+                    Mock -CommandName Get-ItemProperty `
+                        -MockWith { return [pscustomobject]@{ Version = '' } }`
+                        -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL12.MSSQLSERVER\Setup' }
+
+                    { Get-SqlServerMajorVersion -InstanceName 'MSSQLSERVER' } | Should Throw "instance: MSSQLSERVER!"
+                }
+            }
+
+            Context 'Get-SqlLocalServerName' {
+
+                It 'Should return COMPUTERNAME given MSSQLSERVER' {
+                    Get-SqlLocalServerName -InstanceName MSSQLSERVER | Should be $env:COMPUTERNAME
+                }
+
+                It 'Should return COMPUTERNAME\InstanceName given InstanceName' {
+                    Get-SqlLocalServerName -InstanceName InstanceName | Should be "$($env:COMPUTERNAME)\InstanceName"
+                }
+
+            }
+        }
+
+        $secpasswd = ConvertTo-SecureString 'P@$$w0rd1' -AsPlainText -Force
+        $credentials = New-Object System.Management.Automation.PSCredential ('AdminLink', $secpasswd)
+
+        Describe 'The system is not in the desired state given Local distribution mode' {
+
+            $testParameters = @{
+                InstanceName = 'MSSQLSERVER'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Local'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Present'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $false
+                    IsPublisher = $false
+                    DistributionDatabase = ''
+                    DistributionServer = 'SERVERNAME'
+                    WorkingDirectory = ''
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get methot' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Absent' {
+                    $result.Ensure | Should Be 'Absent'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It 'Get method returns RemoteDistributor is empty' {
+                    $result.RemoteDistributor | Should Be ''
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+
+            Context 'Test method' {
+                It 'Test method returns false' {
+                    Test-TargetResource @testParameters | Should be $false
+                }
+            }
+
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Set method calls New-DistributionDatabase with $DistributionDBName = distribution' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 1 `
+                        -ParameterFilter { $DistributionDBName -eq 'distribution' }
+                }
+                It 'Set method calls Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 1 `
+                        -ParameterFilter { $ReplicationServer.DistributionServer -eq 'SERVERNAME' }
+                }
+                It 'Set method calls Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 1 `
+                        -ParameterFilter { $PublisherName -eq 'SERVERNAME' }
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Set method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+            }
+        }
+
+        Describe 'The system is not in the desired state given Remote distribution mode' {
+
+            $testParameters = @{
+                InstanceName = 'INSTANCENAME'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Remote'
+                RemoteDistributor = 'REMOTESERVER'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Present'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $false
+                    IsPublisher = $false
+                    DistributionDatabase = ''
+                    DistributionServer = ''
+                    WorkingDirectory = ''
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get methot' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Absent' {
+                    $result.Ensure | Should Be 'Absent'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It "Get method returns RemoteDistributor = $($testParameters.RemoteDistributor)" {
+                    $result.RemoteDistributor | Should Be $testParameters.RemoteDistributor
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+
+            Context 'Test method' {
+                It 'Test method returns false' {
+                    Test-TargetResource @testParameters | Should be $false
+                }
+            }
+
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It "Set method calls New-ServerConnection with $SqlServerName = $($testParameters.RemoteDistributor)" {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq $testParameters.RemoteDistributor }
+                }
+                It 'Set method calls Register-DistributorPublisher with RemoteDistributor connection' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 1 `
+                        -ParameterFilter { 
+                            $PublisherName -eq 'SERVERNAME\INSTANCENAME' `
+                            -and $ServerConnection.ServerInstance -eq $testParameters.RemoteDistributor
+                        }
+                }
+                It 'Set method calls Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 1 `
+                        -ParameterFilter { $RemoteDistributor -eq $testParameters.RemoteDistributor }
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Set method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+            }
+        }
+
+        Describe 'The system is in sync given Local distribution mode' {
+
+            $testParameters = @{
+                InstanceName = 'MSSQLSERVER'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Local'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Present'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $true
+                    IsPublisher = $true
+                    DistributionDatabase = 'distribution'
+                    DistributionServer = 'SERVERNAME'
+                    WorkingDirectory = 'C:\temp'
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get method' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Present' {
+                    $result.Ensure | Should Be 'Present'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It 'Get method returns RemoteDistributor = SERVERNAME' {
+                    $result.RemoteDistributor | Should Be 'SERVERNAME'
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+            
+            Context 'Test method' {
+                It 'Test method returns true' {
+                    Test-TargetResource @testParameters | Should be $true
+                }
+            }
+            
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Set method doesnt call New-DistributionDatabase with $DistributionDBName = distribution' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Set method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Set method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+            }
+        }
+
+        Describe 'The system is in sync given Remote distribution mode' {
+
+            $testParameters = @{
+                InstanceName = 'INSTANCENAME'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Remote'
+                RemoteDistributor = 'REMOTESERVER'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Present'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $false
+                    IsPublisher = $true
+                    DistributionDatabase = 'distribution'
+                    DistributionServer = 'REMOTESERVER'
+                    WorkingDirectory = 'C:\temp'
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get methot' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Present' {
+                    $result.Ensure | Should Be 'Present'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It "Get method returns RemoteDistributor = $($testParameters.RemoteDistributor)" {
+                    $result.RemoteDistributor | Should Be $testParameters.RemoteDistributor
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+
+            Context 'Test method' {
+                It 'Test method returns true' {
+                    Test-TargetResource @testParameters | Should be $true
+                }
+            }
+
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Set method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Set method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Set method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+            }
+        }
+
+        Describe 'The system is not in desired state given Local distribution, but should be Absent' {
+
+            $testParameters = @{
+                InstanceName = 'MSSQLSERVER'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Local'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Absent'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $true
+                    IsPublisher = $true
+                    DistributionDatabase = 'distribution'
+                    DistributionServer = 'SERVERNAME'
+                    WorkingDirectory = 'C:\temp'
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get method' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Present' {
+                    $result.Ensure | Should Be 'Present'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It 'Get method returns RemoteDistributor is empty' {
+                    $result.RemoteDistributor | Should Be 'SERVERNAME'
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+
+            Context 'Test method' {
+                It 'Test method returns false' {
+                    Test-TargetResource @testParameters | Should be $false
+                }
+            }
+
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Set method calls Uninstall-Distributor with $ReplicationServer.DistributionServer = SERVERNAME' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 1 `
+                        -ParameterFilter { $ReplicationServer.DistributionServer -eq 'SERVERNAME' }
+                }
+                It 'Set method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Set method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
+                }
+            }
+        }
+
+        Describe 'The system is not in desired state given Remote distribution, but should be Absent' {
+
+            $testParameters = @{
+                InstanceName = 'INSTANCENAME'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Remote'
+                RemoteDistributor = 'REMOTESERVER'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Absent'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $false
+                    IsPublisher = $true
+                    DistributionDatabase = 'distribution'
+                    DistributionServer = 'REMOTESERVER'
+                    WorkingDirectory = 'C:\temp'
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get methot' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Present' {
+                    $result.Ensure | Should Be 'Present'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It "Get method returns RemoteDistributor = $($testParameters.RemoteDistributor)" {
+                    $result.RemoteDistributor | Should Be $testParameters.RemoteDistributor
+                }
+                It 'Get method returns WorkingDirectory = C:\temp' {
+                    $result.WorkingDirectory | Should Be 'C:\temp'
+                }
+            }
+
+            Context 'Test method' {
+                It 'Test method returns false' {
+                    Test-TargetResource @testParameters | Should be $false
+                }
+            }
+
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = INSTANCENAME' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'INSTANCENAME' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME\INSTANCENAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
+                }
+                It 'Set method calls Uninstall-Distributor with $ReplicationServer.DistributionServer = REMOTESERVER' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 1 `
+                        -ParameterFilter { $ReplicationServer.DistributionServer -eq 'REMOTESERVER' }
+                }
+                It 'Set method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Set method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
+                }
+            }
+        }
+
+        Describe 'The system is in sync when Absent' {
+
+            $testParameters = @{
+                InstanceName = 'MSSQLSERVER'
+                AdminLinkCredentials = $credentials
+                DistributorMode = 'Local'
+                WorkingDirectory = 'C:\temp'
+                Ensure = 'Absent'
+            }
+
+            Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
+            Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
+            Mock -CommandName New-ServerConnection -MockWith { 
+                return [pscustomobject]@{
+                    ServerInstance = $SqlServerName
+                } 
+            }
+            Mock -CommandName New-ReplicationServer -MockWith {
+                return [pscustomobject]@{
+                    IsDistributor = $false
+                    IsPublisher = $false
+                    DistributionDatabase = ''
+                    DistributionServer = ''
+                    WorkingDirectory = ''
+                }
+            }
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName Install-LocalDistributor -MockWith { }
+            Mock -CommandName Install-RemoteDistributor -MockWith { }
+            Mock -CommandName Register-DistributorPublisher -MockWith { }
+            Mock -CommandName Uninstall-Distributor -MockWith {}
+
+            Context 'Get method' {
+                $result = Get-TargetResource @testParameters
+                It 'Get method calls Get-SqlServerMajorVersion with InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Get method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Get method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Get method doesnt call New-DistributionDatabase' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Get method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                }
+                It 'Get method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                }
+                It 'Ger method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Ger method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+                It 'Get method returns Ensure = Absent' {
+                    $result.Ensure | Should Be 'Absent'
+                }
+                It "Get method returns InstanceName = $($testParameters.InstanceName)" {
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                }
+                It "Get method returns DistributorMode = $($testParameters.DistributorMode)" {
+                    $result.DistributorMode | Should Be $testParameters.DistributorMode
+                }
+                It 'Get method returns DistributionDBName = distribution' {
+                    $result.DistributionDBName | Should Be 'distribution'
+                }
+                It 'Get method returns RemoteDistributor is empty' {
+                    $result.RemoteDistributor | Should Be ''
+                }
+                It "Get method returns WorkingDirectory = $($testParameters.WorkingDirectory)" {
+                    $result.WorkingDirectory | Should Be $testParameters.WorkingDirectory
+                }
+            }
+            
+            Context 'Test method' {
+                It 'Test method returns true' {
+                    Test-TargetResource @testParameters | Should be $true
+                }
+            }
+            
+            Context 'Set method' {
+                Set-TargetResource @testParameters
+                It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlServerMajorVersion -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls Get-SqlLocalServerName with $InstanceName = MSSQLSERVER' {
+                    Assert-MockCalled -CommandName Get-SqlLocalServerName -Times 1 `
+                        -ParameterFilter { $InstanceName -eq 'MSSQLSERVER' }
+                }
+                It 'Set method calls New-ServerConnection with $SqlServerName = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ServerConnection -Times 1 `
+                        -ParameterFilter { $SqlServerName -eq 'SERVERNAME' }
+                }
+                It 'Set method calls New-ReplicationServer with $ServerConnection.ServerInstance = SERVERNAME' {
+                    Assert-MockCalled -CommandName New-ReplicationServer -Times 1 `
+                        -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
+                }
+                It 'Set method doesnt call New-DistributionDatabase with $DistributionDBName = distribution' {
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                }
+                It 'Set method doesnt call Install-LocalDistributor' {
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
+                }
+                It 'Set method doesnt call Install-RemoteDistributor' {
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
+                }
+                It 'Set method doesnt call Register-DistributorPublisher' {
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                }
+                It 'Set method doesnt call Uninstall-Distributor' {
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                }
+            }
+        }
+
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 #---------------------------------# 
 #      environment configuration  # 
 #---------------------------------# 
-version: 1.7.{build}.0
+version: 1.8.{build}.0
 install: 
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: |
@@ -38,7 +38,7 @@ deploy_script:
       # Creating project artifact
       $stagingDirectory = (Resolve-Path ..).Path
       $manifest = Join-Path $pwd "xSQLServer.psd1"
-      (Get-Content $manifest -Raw).Replace("1.7.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
+      (Get-Content $manifest -Raw).Replace("1.8.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
       $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
       Add-Type -assemblyname System.IO.Compression.FileSystem
       [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -21,6 +21,7 @@ FeatureNotSupported = '{0}' is not a valid value for setting 'FEATURES'.  Refer 
 AvailabilityGroupListenerNotFound = Trying to make a change to a listener that does not exist.
 AvailabilityGroupListenerErrorVerifyExist = Unexpected result when trying to verify existence of listener {0}.
 AvailabilityGroupListenerIPChangeError = IP-address configuration mismatch. Expecting {0} found {1}. Resource does not support changing IP-address. Listener needs to be removed and then created again.
+AvailabilityGroupListenerDHCPChangeError = IP-address configuration mismatch. Expecting {0} found {1}. Resource does not support changing between static IP and DHCP. Listener needs to be removed and then created again.
 
 # Endpoint
 EndpointNotFound = Endpoint {0} does not exist

--- a/xSQLServer.psd1
+++ b/xSQLServer.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.7.0.0'
+ModuleVersion = '1.8.0.0'
 
 # ID used to uniquely identify this module
 GUID = '74e9ddb5-4cbc-4fa2-a222-2bcfb533fd66'
@@ -47,11 +47,29 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '* Resources Added
-  - xSQLServerConfiguration
+        ReleaseNotes = '* Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Added Support for SQL Server 2016
+* xSQLAOGroupEnsure
+   - Fixed spelling mistake in AutoBackupPreference property
+   - Added BackupPriority property
+* Added resources
+  - xSQLServerPermission
+  - xSQLServerEndpointState
+  - xSQLServerEndpointPermission
+  - xSQLServerAvailabilityGroupListener
+* xSQLServerHelper
+	- added functions 
+		- Import-SQLPSModule
+		- Get-SQLPSInstanceName
+		- Get-SQLPSInstance
+		- Get-SQLAlwaysOnEndpoint
+	- modified functions
+		- New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
+
 '
 
     } # End of PSData hashtable
 
 } # End of PrivateData hashtable
 }
+

--- a/xSQLServer.psd1
+++ b/xSQLServer.psd1
@@ -58,14 +58,13 @@ PrivateData = @{
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
 * xSQLServerHelper
-	- added functions 
-		- Import-SQLPSModule
-		- Get-SQLPSInstanceName
-		- Get-SQLPSInstance
-		- Get-SQLAlwaysOnEndpoint
-	- modified functions
-		- New-TerminatingError - *added optional parameter `InnerException` to be able to give the user more information in the returned message*
-
+  - added functions 
+  - Import-SQLPSModule
+  - Get-SQLPSInstanceName
+  - Get-SQLPSInstance
+  - Get-SQLAlwaysOnEndpoint
+    - modified functions
+      - New-TerminatingError - *added optional parameter "InnerException" to be able to give the user more information in the returned message*
 '
 
     } # End of PSData hashtable


### PR DESCRIPTION
I have been having an issue where I can't use the DSC modules to set up a named instance due to the `New-ListenerADObject` cmdlet in `DSCResources/MSFT_xSQLAOGroupEnsure/MSFT_xSQLAOGroupEnsure.psm1` not accepting a named instance. Please let me know if there is anything else I need to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/100)
<!-- Reviewable:end -->
