### PR TITLE
readme.md: fixed unreleased section

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* Added resources
+  - xSQLServerReplication
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
@@ -333,7 +335,6 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointState
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
-  - xSQLServerReplication
 * xSQLServerHelper
     - added functions 
         - Import-SQLPSModule


### PR DESCRIPTION
Automerge of PR #66 following 1.8 release incorrectly list xSQLServerReplication resource as part of 1.8 release, it should be in unreleased section.

Also fixed some line endings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/104)
<!-- Reviewable:end -->
