### PR TITLE
Changes to xSQLServerLogin (Fixes #105, #31)

### DIFF
--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -198,7 +198,7 @@ function Test-TargetResource
 
     $sqlServerLogin = Get-TargetResource @PSBoundParameters
 
-    $result = ( $sqlServerLogin.Ensure -eq $Ensure ) -and ( $sqlServerLogin.LoginType -eq $LoginType )
+    $result = ( $sqlServerLogin.Ensure -eq $Ensure )
     
     $result
 }

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -140,6 +140,7 @@ function Set-TargetResource
                 catch
                 {
                     Write-Verbose "Failed creating SQL login $Name of type $LoginType"
+                    
                     throw $_
                 }
             }
@@ -150,12 +151,16 @@ function Set-TargetResource
                 {
                     Write-Verbose "Deleting SQL login $Name"
 
-                    $sqlLogin = $sql.Logins
-                    $sqlLogin[ $Name ].Drop()
+                    $sqlLogin = $($sql.Logins[ $Name ])
+                    if( $sqlLogin )
+                    {
+                        Remove-SqlLogin -Login $sqlLogin
+                    }
                 }
                 catch
                 {
                     Write-Verbose "Failed deleting SQL login $Name"
+                    
                     throw $_
                 }
             }
@@ -203,6 +208,33 @@ function Test-TargetResource
     $result = ( $sqlServerLogin.Ensure -eq $Ensure )
     
     $result
+}
+
+<#
+    .SYNOPSIS
+        Removes a SQL login
+
+    .PARAMETER Login
+        A SQL login of the type Microsoft.SqlServer.Management.Smo.Login
+
+    .EXAMPLE
+        $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+        $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $server, "MyLogin" )
+        Remove-SqlLogin -Login $login
+#>
+function Remove-SqlLogin
+{
+    [CmdletBinding(SupportsShouldProcess)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.SqlServer.Management.Smo.Login]
+        $Login
+    )
+
+    if( ( $PSCmdlet.ShouldProcess( $($sqlLogin.Name), "Remove login" ) ) ) {
+        $sqlLogin.Drop()
+    }
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -140,6 +140,7 @@ function Set-TargetResource
                 catch
                 {
                     Write-Verbose "Failed creating SQL login $Name of type $LoginType"
+                    throw $_
                 }
             }
             
@@ -155,6 +156,7 @@ function Set-TargetResource
                 catch
                 {
                     Write-Verbose "Failed deleting SQL login $Name"
+                    throw $_
                 }
             }
         }

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -5,6 +5,6 @@ class MSFT_xSQLServerLogin : OMI_BaseResource
     [Key, Description("The name of the SQL login.  If LoginType='WindowsUser' or 'WindowsGroup', this is also the name of the user or group in format DOMAIN\name.")] String Name;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType='SqlLogin', a PSCredetial object for the SQL login to be created.")] String LoginCredential;
     [Write, Description("The SQL login type."), ValueMap{"SqlLogin","WindowsUser","WindowsGroup"}, Values{"SqlLogin","WindowsUser","WindowsGroup"}] String LoginType;
-    [Write, Description("The SQL Server for the login.")] String SQLServer;
-    [Write, Description("The SQL instance for the login.")] String SQLInstanceName;
+    [Key, Description("The SQL Server for the login.")] String SQLServer;
+    [Key, Description("The SQL instance for the login.")] String SQLInstanceName;
 };

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -1,10 +1,10 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerLogin")]
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
-    [Write, Description("An enumerated value that describes if the login exists on the SQL instance.\nPresent {default}  \nAbsent   \n"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The name of the SQL login.  If LoginType='WindowsUser' or 'WindowsGroup', this is also the name of the user or group in format DOMAIN\name.")] String Name;
-    [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType='SqlLogin', a PSCredetial object for the SQL login to be created.")] String LoginCredential;
-    [Write, Description("The SQL login type."), ValueMap{"SqlLogin","WindowsUser","WindowsGroup"}, Values{"SqlLogin","WindowsUser","WindowsGroup"}] String LoginType;
+    [Write, Description("If the values should be present or absent. Valid values are 'Present' or 'Absent'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Key, Description("The name of the SQL login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.")] String Name;
+    [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;
+    [Write, Description("The SQL login type. Valid values are 'SqlLogin', 'WindowsUser' or 'WindowsGroup'."), ValueMap{"SqlLogin","WindowsUser","WindowsGroup"}, Values{"SqlLogin","WindowsUser","WindowsGroup"}] String LoginType;
     [Key, Description("The SQL Server for the login.")] String SQLServer;
     [Key, Description("The SQL instance for the login.")] String SQLInstanceName;
 };

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - Fixed the issue when trying to add a static IP to a listener was ignored.
 * Fixes in xSQLAOGroupEnsure
   - Added parameters to New-ListenerADObject to allow usage of a named instance.
-* Fixes in xSQLServerLogin
+* Changes to xSQLServerLogin
    - Fixed an issue when dropping logins.
    - Fixed an issue where it was not possible to add the same login to two instances on the same server.
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - xSQLServerEndpointState
   - xSQLServerEndpointPermission
   - xSQLServerAvailabilityGroupListener
+  - xSQLServerLogin
 * Fixes in xSQLServerAvailabilityGroupListener
   - In one case the Get-method did not report that DHCP was configured. 
   - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
@@ -345,7 +346,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - Fixed the issue when trying to add a static IP to a listener was ignored.
 * Fixes in xSQLAOGroupEnsure
   - Added parameters to New-ListenerADObject to allow usage of a named instance.
-  
+* Fixes in xSQLServerLogin
+   - Fixed an issue when dropping logins.
+   - Fixed an issue where it was not possible to add the same login to two instances on the same server.
+
 ### 1.8.0.0
 
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.

--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **IsInitialized**: Output is the Reporting Services instance initialized.
 
 ### xSQLServerLogin
-* **Name**: (Key) Name of the SQL Login to create
-* **LoginCredential**: PowerShell Credential for the SQL Login to be created
-* **LoginType**: Type of SQL login to create.(SQL, WindowsUser, WindowsGroup)
-* **SQLServer**: SQL Server where login should be created
-* **SQLInstance**: SQL Instance for the login
+* **Ensure**: If the values should be present or absent. Valid values are 'Present' or 'Absent'. 
+* **Name**: (Key) The name of the SQL login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.
+* **LoginCredential**: If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.
+* **LoginType**: The SQL login type. Valid values are 'SqlLogin', 'WindowsUser' or 'WindowsGroup'.
+* **SQLServer**: (Key) The SQL Server for the login.
+* **SQLInstanceName**: (Key) The SQL instance for the login.
 
 ### xSQLServerDatabaseRole
 * **Name**: (Key) Name of the SQL Login or the role on the database

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -210,7 +210,7 @@ try
         }
 
         Context 'When the system is in the desired state' {
-            It 'Should return the state as present when desired windows user exist' {
+            It 'Should return the state as present when desired windows user exists' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\Stacy'
@@ -222,7 +222,7 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should return the state as present when desired windows group exist' {
+            It 'Should return the state as present when desired windows group exists' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\SqlUsers'
@@ -235,7 +235,7 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should return the state as present when desired sql login exist' {
+            It 'Should return the state as present when desired sql login exists' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'John'

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -1,3 +1,7 @@
+# Suppressing this rule because PlainText is required for one of the functions used in this test
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 $script:DSCModuleName      = 'xSQLServer'
 $script:DSCResourceName    = 'MSFT_xSQLServerLogin'
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -1,0 +1,459 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerLogin'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'MSSQLSERVER'
+
+    $mockSqlLoginUser = "dba" 
+    $mockSqlLoginPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+    $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
+
+    $defaultParameters = @{
+        SQLInstanceName = $instanceName
+        SQLServer = $nodeName
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru ) )
+                        'John' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownUser'
+            }
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as absent' {
+                $result.Ensure | Should Be 'Absent'
+                $result.LoginType | Should Be ''
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+    
+        Context 'When the system is in the desired state for a Windows user' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\Stacy'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsUser'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state for a Windows group' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\SqlUsers'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsGroup'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state for a SQL login' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'John'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'SqlLogin'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru ) )
+                        'John' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            It 'Should return desired state as absent when desired windows user don''t exists' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\UnknownUser'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return desired state as present when desired login exists regardless of login type' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\SqlUsers'
+                    LoginType = 'SqlLogin'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'John'
+                    LoginType = 'WindowsUser'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return that desired state as present when desired windows user exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\Stacy'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state as present when desired windows group exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\SqlUsers'
+                    LoginType = 'WindowsGroup'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state as present when desired sql login exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'John'
+                    LoginType = 'SqlLogin'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru |
+                                        Add-Member ScriptMethod Drop {} -PassThru ) )
+                        'John' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru |
+                                        Add-Member ScriptMethod Drop {} -PassThru ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Object |
+                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru |
+                                        Add-Member ScriptMethod Drop {} -PassThru ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'UnknownSqlLogin'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
+                { Set-TargetResource @testParameters } | Should Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters += @{
+                LoginCredential = $mockSqlLoginCredential
+            }
+
+            It 'Should not throw an error when desired login type is a SQL login' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'SqlLogin'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownUser'
+                LoginType = 'WindowsUser'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows User' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsUser'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownGroup'
+                LoginType = 'WindowsGroup'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows Group' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsGroup'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Name = 'John'
+            }
+
+            It 'Should not throw an error when desired login should be absent but are present' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Absent'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'John'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
+                { Set-TargetResource @testParameters } | Should Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters += @{
+                LoginCredential = $mockSqlLoginCredential
+            }
+
+            It 'Should not throw an error when desired login type is a SQL login' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'SqlLogin'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\Stacy'
+                LoginType = 'WindowsUser'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows User' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsUser'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\SqlUsers'
+                LoginType = 'WindowsGroup'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows Group' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsGroup'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Name = 'John'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should not throw an error when desired login should be absent but are already absent' {
+                Mock -CommandName Connect-SQL -MockWith {
+                    return New-Object Object | 
+                        Add-Member ScriptProperty Logins {
+                            return @{
+                                'John' = @( ( New-Object Object |
+                                                Add-Member NoteProperty LoginType 'SqlLogin' -PassThru |
+                                                Add-Member ScriptMethod Drop { 
+                                                    throw 'Called Drop() method when the login is already absent'
+                                                } -PassThru ) )
+                            }
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Absent'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -51,12 +51,9 @@ try
             return New-Object Object | 
                 Add-Member ScriptProperty Logins {
                     return @{
-                        'COMPANY\Stacy' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru ) )
-                        'John' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru ) )
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
                     }
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
@@ -117,7 +114,7 @@ try
     
             $result = Get-TargetResource @testParameters
 
-            It 'Should not return the state as present' {
+            It 'Should return the state as present' {
                 $result.Ensure | Should Be 'Present'
                 $result.LoginType | Should Be 'WindowsGroup'
             }
@@ -141,7 +138,7 @@ try
     
             $result = Get-TargetResource @testParameters
 
-            It 'Should not return the state as present' {
+            It 'Should return the state as present' {
                 $result.Ensure | Should Be 'Present'
                 $result.LoginType | Should Be 'SqlLogin'
             }
@@ -165,18 +162,15 @@ try
             return New-Object Object | 
                 Add-Member ScriptProperty Logins {
                     return @{
-                        'COMPANY\Stacy' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru ) )
-                        'John' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru ) )
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
                     }
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is not in the desired state' {
-            It 'Should return desired state as absent when desired windows user don''t exists' {
+            It 'Should return the state as absent when desired windows user does not exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\UnknownUser'
@@ -188,7 +182,7 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should return desired state as present when desired login exists regardless of login type' {
+            It 'Should return the state as present when desired login exists and login type is SQL login' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\SqlUsers'
@@ -198,6 +192,10 @@ try
                 $result = Test-TargetResource @testParameters
                 $result | Should Be $true
 
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return the state as present when desired login exists and login type is Windows' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'John'
@@ -207,12 +205,12 @@ try
                 $result = Test-TargetResource @testParameters
                 $result | Should Be $true
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
         }
 
         Context 'When the system is in the desired state' {
-            It 'Should return that desired state as present when desired windows user exist' {
+            It 'Should return the state as present when desired windows user exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\Stacy'
@@ -224,7 +222,7 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should return that desired state as present when desired windows group exist' {
+            It 'Should return the state as present when desired windows group exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'COMPANY\SqlUsers'
@@ -237,7 +235,7 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            It 'Should return that desired state as present when desired sql login exist' {
+            It 'Should return the state as present when desired sql login exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'John'
@@ -259,15 +257,9 @@ try
             return New-Object Object | 
                 Add-Member ScriptProperty Logins {
                     return @{
-                        'COMPANY\Stacy' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsUser' -PassThru |
-                                        Add-Member ScriptMethod Drop {} -PassThru ) )
-                        'John' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'SqlLogin' -PassThru |
-                                        Add-Member ScriptMethod Drop {} -PassThru ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Object |
-                                        Add-Member NoteProperty LoginType 'WindowsGroup' -PassThru |
-                                        Add-Member ScriptMethod Drop {} -PassThru ) )
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
                     }
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
@@ -339,18 +331,23 @@ try
             $testParameters = $defaultParameters
             $testParameters += @{
                 Ensure = 'Absent'
-                Name = 'John'
+                Name = 'COMPANY\Stacy'
             }
 
-            It 'Should not throw an error when desired login should be absent but are present' {
+            It 'Should call the function Remove-SqlLogin when desired state should be absent' {
+                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
                 Mock -CommandName Get-TargetResource -MockWith {
                     @{
                         Ensure = 'Absent'
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
 
-                { Set-TargetResource @testParameters } | Should Not Throw
+                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters
+
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlLogin -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
         }
 
@@ -421,32 +418,24 @@ try
             $testParameters = $defaultParameters
             $testParameters += @{
                 Ensure = 'Absent'
-                Name = 'John'
+                Name = 'COMPANY\UnknownUser'
                 LoginType = 'SqlLogin'
             }
 
-            It 'Should not throw an error when desired login should be absent but are already absent' {
-                Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object Object | 
-                        Add-Member ScriptProperty Logins {
-                            return @{
-                                'John' = @( ( New-Object Object |
-                                                Add-Member NoteProperty LoginType 'SqlLogin' -PassThru |
-                                                Add-Member ScriptMethod Drop { 
-                                                    throw 'Called Drop() method when the login is already absent'
-                                                } -PassThru ) )
-                            }
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
+            It 'Should not call the function Remove-SqlLogin when desired state is already absent' {
+                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
                 Mock -CommandName Get-TargetResource -MockWith {
                     @{
                         Ensure = 'Absent'
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
 
-                { Set-TargetResource @testParameters } | Should Not Throw
+                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters
+
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlLogin -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
             }
         }
 

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -191,6 +191,10 @@ namespace Microsoft.SqlServer.Management.Smo
 
             this.Create();
         }
+
+        public void Drop()
+        {
+        }
     }
 
     #endregion Public Classes

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -166,6 +166,10 @@ namespace Microsoft.SqlServer.Management.Smo
         public Login( Server server, string name ) {
             this.Name = name;
         } 
+
+        public Login( Object server, string name ) {
+            this.Name = name;
+        } 
             
         public string Name;
         public LoginType LoginType = LoginType.Unknown;
@@ -181,7 +185,7 @@ namespace Microsoft.SqlServer.Management.Smo
             }
         }
 
-        public void Create( System.Security.SecureString secureString )
+        public void Create( String secureString )
         {
             _mockPasswordPassed = true;
 

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -1,8 +1,33 @@
+// Stubs for the namespace Microsoft.SqlServer.Management.Smo. Used for mocking in tests.
+
 using System;
 using System.Collections.Generic;
 
 namespace Microsoft.SqlServer.Management.Smo
 {
+    #region Public Enums
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.LoginType
+    // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
+    // Used by: 
+    //  MSFT_xSQLServerLogin
+    
+    public enum LoginType
+    {
+        AsymmetricKey = 4,
+        Certificate = 3,
+        ExternalGroup = 6,
+        ExternalUser = 5,
+        SqlLogin = 2,
+        WindowsGroup = 1,
+        WindowsUser = 0,
+        Unknown = -1    // Added for verification (mock) purposes, to verify that a login type is passed  
+    }
+
+    #endregion Public Enums
+
+    #region Public Classes
+
     public class Globals
     {
         // Static property that is switched on or off by tests if data should be mocked (true) or not (false).
@@ -77,7 +102,8 @@ namespace Microsoft.SqlServer.Management.Smo
     // TypeName: Microsoft.SqlServer.Management.Smo.Server
     // BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
     // Used by: 
-    //  xSQLServerPermission.Tests.ps1
+    //  xSQLServerPermission
+    //  MSFT_xSQLServerLogin
     public class Server 
     { 
         public string MockGranteeName;
@@ -128,4 +154,40 @@ namespace Microsoft.SqlServer.Management.Smo
             }
         }
     }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.Login
+    // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
+    // Used by: 
+    //  MSFT_xSQLServerLogin
+    public class Login 
+    {
+        private bool _mockPasswordPassed = false;
+
+        public Login( Server server, string name ) {
+            this.Name = name;
+        } 
+            
+        public string Name;
+        public LoginType LoginType = LoginType.Unknown;
+
+        public void Create()
+        {
+            if( this.LoginType == LoginType.Unknown ) {
+                throw new System.Exception( "Called Create() method without a value for LoginType." );
+            }
+
+            if( this.LoginType == LoginType.SqlLogin && _mockPasswordPassed != true ) {
+                throw new System.Exception( "Called Create() method for the LoginType 'SqlLogin' but called with the wrong overloaded method. Did not pass the password with the Create() method." );
+            }
+        }
+
+        public void Create( System.Security.SecureString secureString )
+        {
+            _mockPasswordPassed = true;
+
+            this.Create();
+        }
+    }
+
+    #endregion Public Classes
 }


### PR DESCRIPTION
* Changes to xSQLServerLogin
   - Fixed an issue when dropping logins (issue #105).
   - Fixed an issue where it was not possible to add the same login to two instances on the same server (#31).
   - Added unit test for the resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/106)
<!-- Reviewable:end -->
