### PR TITLE
Add parameters for New-ListenerADObject to use named SQL server and instance

### DIFF
--- a/DSCResources/MSFT_xSQLAOGroupEnsure/MSFT_xSQLAOGroupEnsure.psm1
+++ b/DSCResources/MSFT_xSQLAOGroupEnsure/MSFT_xSQLAOGroupEnsure.psm1
@@ -125,8 +125,8 @@ function Set-TargetResource
         "Present"
         {
             Grant-ServerPerms -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -AuthorizedUser "NT AUTHORITY\SYSTEM" -SetupCredential $SetupCredential
-            New-ListenerADObject -AvailabilityGroupNameListener $AvailabilityGroupNameListener -SetupCredential $SetupCredential
-           
+            New-ListenerADObject -AvailabilityGroupNameListener $AvailabilityGroupNameListener -SetupCredential $SetupCredential -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+ 
             $FailoverCondition = 3
             $HealthCheckTimeout = 30000
             $ConnectionModeInPrimary ="AllowAllConnections"    

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - Now the resource will throw 'Not supported' when IP is changed between Static and DHCP.
   - Fixed an issue where sometimes the listener wasn't removed.
   - Fixed the issue when trying to add a static IP to a listener was ignored.
+* Fixes in xSQLAOGroupEnsure
+  - Added parameters to New-ListenerADObject to allow usage of a named instance.
 
 ### 1.8.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.


### PR DESCRIPTION
I have been having an issue where I can't use the DSC modules to set up a named instance due to the New-ListenerADObject cmdlet in DSCResources/MSFT_xSQLAOGroupEnsure/MSFT_xSQLAOGroupEnsure.psm1 not accepting a named instance. Please let me know if there is anything else I need to do.

Superseding https://github.com/PowerShell/xSQLServer/pull/100 because I can't git.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/113)
<!-- Reviewable:end -->
