### PR TITLE
xSQLServerMemory: code improvements

### DIFF
--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -10,182 +10,12 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [ValidateSet("Present","Absent")]
-        [System.String]
-        $Ensure,
-
-        [parameter(Mandatory = $true)]
-        [System.Boolean]
-        $DynamicAlloc,
-
-        [System.Int32]
-        $MinMemory = -1,
-
-        [System.Int32]
-        $MaxMemory,
-
-        [System.String]
-        $SQLServer = $env:COMPUTERNAME,
-
         [parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName
-    )
-
-        if(!$SQL)
-        {
-            $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-        }
-
-        if($SQL)
-        {
-            $GetMinMemory = $sql.Configuration.MinServerMemory.ConfigValue
-            $GetMaxMemory = $sql.Configuration.MaxServerMemory.ConfigValue
-        }
-
-        if ($GetMaxMemory -eq 2147483647)
-        {
-            $Ensure = "Absent"
-        }
-        else
-        {
-            $Ensure = "Present"
-        }
-
-        $returnValue = @{
-                DynamicAlloc = $DynamicAlloc
-                MinMemory = $MinMemory
-                MaxMemory = $MaxMemory
-                Ensure = $Ensure
-                }
-        $returnValue
-}
-
-
-function Set-TargetResource
-{
-    [CmdletBinding()]
-    param
-    (
-        [ValidateSet("Present","Absent")]
-        [System.String]
-        $Ensure,
-
-        [parameter(Mandatory = $true)]
-        [System.Boolean]
-        $DynamicAlloc,
-
-        [System.Int32]
-        $MinMemory = -1,
-
-        [System.Int32]
-        $MaxMemory,
+        $SQLInstanceName,
 
         [System.String]
-        $SQLServer = $env:COMPUTERNAME,
-
-        [parameter(Mandatory = $true)]
-        [System.String]
-        $SQLInstanceName
-    )
-
-    if(!$SQL)
-    {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    }
-
-    If($SQL)
-    {
-        $serverMem = $sql.PhysicalMemory
-        switch($Ensure)
-        {
-            "Absent"
-            {
-                   $MaxMemory = 2147483647
-                   $MinMemory = 128
-            }
-            "Present"
-            {       
-                if ($DynamicAlloc)
-                {
-                    if ($serverMem -ge 128000) 
-                    {
-                        #Server mem - 10GB
-                        $MaxMemory = $serverMem - 10000 
-                    }
-                    elseif ($serverMem -ge 32000 -and $serverMem -lt 128000) 
-                    {
-                        #Server mem - 4GB 
-                        $MaxMemory = $serverMem - 4000
-                    }
-                    elseif ($serverMem -ge 16000)
-                    {
-                        #Server mem - 2GB 
-                        $MaxMemory = $serverMem - 2000
-                    }
-                    else
-                    {
-                        #Server mem - 1GB 
-                        $MaxMemory = $serverMem - 1000
-                    }
-                }
-                else
-                {
-                    if  (-not $MaxMemory -or $MinMemory -lt 0) {
-                        throw "Dynamic Allocation is not set. Valid values were not supplied for MaxMemory or MinMemory."
-                    }
-
-                    if ($MinMemory -gt $MaxMemory) {
-                        throw "Provided MinMemory value is greater than MaxMemory."
-                    }
-                }
-            }
-        }
-        try
-        {            
-            $sql.Configuration.MaxServerMemory.ConfigValue = $MaxMemory
-            if($MinMemory -ge 0)
-            {
-                Write-Verbose -message "MinMem will be set to $MinMemory."
-                $sql.Configuration.MinServerMemory.ConfigValue = $MinMemory
-            }
-            $sql.alter()
-            New-VerboseMessage -Message "SQL Server Memory has been capped to $MaxMemory."
-        }
-        catch
-        {
-            New-VerboseMessage -Message "Failed setting Min and Max SQL Memory"
-        }
-    }
-}
-
-
-function Test-TargetResource
-{
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param
-    (
-        [ValidateSet("Present","Absent")]
-        [System.String]
-        $Ensure,
-
-        [parameter(Mandatory = $true)]
-        [System.Boolean]
-        $DynamicAlloc,
-
-        [System.Int32]
-        $MinMemory = -1,
-
-        [System.Int32]
-        $MaxMemory,
-
-        [System.String]
-        $SQLServer = $env:COMPUTERNAME,
-        
-        [parameter(Mandatory = $true)]
-        [System.String]
-        $SQLInstanceName
+        $SQLServer = $env:COMPUTERNAME
     )
 
     if(!$SQL)
@@ -195,58 +25,201 @@ function Test-TargetResource
 
     if($SQL)
     {
-        $GetMinMemory = $sql.Configuration.MinServerMemory.ConfigValue
-        $GetMaxMemory = $sql.Configuration.MaxServerMemory.ConfigValue
+        $minMemory = $sql.Configuration.MinServerMemory.ConfigValue
+        $maxMemory = $sql.Configuration.MaxServerMemory.ConfigValue
+    }
+
+    $returnValue = @{
+        SQLInstanceName = $SQLInstanceName
+        SQLServer = $SQLServer
+        MinMemory = $minMemory
+        MaxMemory = $maxMemory
+    }
+
+    $returnValue
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SQLInstanceName,
+
+        [System.String]
+        $SQLServer = $env:COMPUTERNAME,
+
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = 'Present',
+
+        [System.Boolean]
+        $DynamicAlloc = $false,
+
+        [System.Int32]
+        $MaxMemory = 2147483647,
+
+        [System.Int32]
+        $MinMemory = 0
+    )
+
+    if(!$SQL)
+    {
+        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    }
+
+    If($SQL)
+    {
+        switch($Ensure)
+        {
+            "Absent"
+            {
+                $MaxMemory = 2147483647
+                $MinMemory = 0
+            }
+
+            "Present"
+            {
+                if ($DynamicAlloc)
+                {
+                    $MaxMemory = Get-MaxMemoryDynamic $SQL.PhysicalMemory
+                    $MinMemory = 128
+
+                    New-VerboseMessage -Message "Dynamic Max Memory is $MaxMemory"
+                }
+            }
+        }
+
+        try
+        {            
+            $SQL.Configuration.MaxServerMemory.ConfigValue = $MaxMemory
+            $SQL.Configuration.MinServerMemory.ConfigValue = $MinMemory
+            $SQL.alter()
+
+            New-VerboseMessage -Message "SQL Server Memory has been capped to $MaxMemory. MinMemory set to $MinMemory."
+        }
+        catch
+        {
+            New-VerboseMessage -Message "Failed setting Min and Max SQL Memory"
+        }
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $SQLInstanceName,
+
+        [System.String]
+        $SQLServer = $env:COMPUTERNAME,
+
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = 'Present',
+
+        [System.Boolean]
+        $DynamicAlloc = $false,
+
+        [System.Int32]
+        $MaxMemory = 0,
+
+        [System.Int32]
+        $MinMemory
+    )
+
+    if(!$SQL)
+    {
+        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    }
+
+    if($SQL)
+    {
+        $getMinMemory = $sql.Configuration.MinServerMemory.ConfigValue
+        $getMaxMemory = $sql.Configuration.MaxServerMemory.ConfigValue
     }
 
     switch($Ensure)
     {
         "Absent"
         {
-            if ($GetMaxMemory  -eq 2147483647)
+            if ($getMaxMemory -ne 2147483647)
             {
-                New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
-                return $true
+                New-VerboseMessage -Message "Current Max Memory is $getMaxMemory. Expected 2147483647"
+                return $false
             }
-            else 
+
+            if ($getMinMemory -ne 0)
             {
-                New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
+                New-VerboseMessage -Message "Current Min Memory is $getMinMemory. Expected 0"
                 return $false
             }
         }
+
         "Present"
-        {      
-       
-             If ($DynamicAlloc)
-             {
-                 if ($GetMaxMemory  -eq 2147483647)
-                 {
-                     New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
-                     return $false
-                 }
-                 else 
-                 {
-                     New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
-                     return $true
-                 }
-             }
-             else
-             {
-                 If(($MinMemory -ge 0 -and $MinMemory -ne $GetMinMemory) -or $MaxMemory -ne $GetMaxMemory)
-                 {
-                    New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
+        {
+            if ($DynamicAlloc)
+            {
+                $MaxMemory = Get-MaxMemoryDynamic $SQL.PhysicalMemory
+                $MinMemory = 128
+
+                New-VerboseMessage -Message "Dynamic Max Memory is $MaxMemory"
+            }
+
+            if($MaxMemory -ne $getMaxMemory)
+            {
+                New-VerboseMessage -Message "Current Max Memory is $getMaxMemory, expected $MaxMemory"
+                return $false
+            }
+
+            if($PSBoundParameters.ContainsKey('MinMemory'))
+            {
+                if($MinMemory -ne $getMinMemory)
+                {
+                    New-VerboseMessage -Message "Current Min Memory is $getMinMemory, expected $MinMemory"
                     return $false
-                 }
-                 else
-                 {
-                    New-VerboseMessage -Message "Current Max Memory is $GetMaxMemory. Min Memory is $GetMinMemory"
-                    return $true
-                 }
-             }
+                }
+            }
         }
     }
+
+    $true
 }
 
+function Get-MaxMemoryDynamic
+{
+    param(
+        $PhysicalMemory
+    )
+
+    if ($PhysicalMemory -ge 128000)
+    {
+        #Server mem - 10GB
+        $maxMemory = $PhysicalMemory - 10000 
+    }
+    elseif ($PhysicalMemory -ge 32000 -and $PhysicalMemory -lt 128000) 
+    {
+        #Server mem - 4GB 
+        $maxMemory = $PhysicalMemory - 4000
+    }
+    elseif ($PhysicalMemory -ge 16000)
+    {
+        #Server mem - 2GB 
+        $maxMemory = $PhysicalMemory - 2000
+    }
+    else
+    {
+        #Server mem - 1GB 
+        $maxMemory = $PhysicalMemory - 1000
+    }
+
+    $maxMemory
+}
 
 Export-ModuleMember -Function *-TargetResource
-

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
@@ -3,9 +3,9 @@
 class MSFT_xSQLServerMemory : OMI_BaseResource
 {
     [Write, Description("An enumerated value that describes if Min and Max memory is configured"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("Flag to Dynamically allocate SQL memory based on Best Practices")] Boolean DynamicAlloc;
-    [Write, Description("Minimum memory value to set SQL Server memory to")] Sint32 MinMemory;
-    [Write, Description("Maximum memory value to set SQL Server memory to")] Sint32 MaxMemory;
+    [Write, Description("Flag to Dynamically allocate SQL memory based on Best Practices")] Boolean DynamicAlloc;
+    [Write, Description("Minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server")] Sint32 MinMemory;
+    [Write, Description("Maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server")] Sint32 MaxMemory;
     [Write, Description("SQL Server to configure memory on")] String SQLServer;
     [Key, Description("SQL Instance to configure memory on")] String SQLInstanceName;
 };

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ###xSQLServerMemory
 * **Ensure**: An enumerated value that describes if Min and Max memory is configured
-* **DyamicAlloc**: (key) Flag to indicate if Memory is dynamically configured
+* **DyamicAlloc**: Flag to indicate if Memory is dynamically configured
 * **MinMemory**: Minimum memory value to set SQL Server memory to
 * **MaxMemory**: Maximum memory value to set SQL Server memory to
 * **SQLServer**: The SQL Server for the database
@@ -350,7 +350,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Changes to xSQLServerLogin
    - Fixed an issue when dropping logins.
    - BREAKING CHANGE: Fixed an issue where it was not possible to add the same login to two instances on the same server.
-
+* Changes to xSQLServerMemory
+   - Removed DyamicAlloc from being a key (default value false)
+   - Improvements to code
+   
 ### 1.8.0.0
 
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.


### PR DESCRIPTION
I had this for some time as a fork.
I think the code looks better and fixes some of the logic around the min/max checking.
I removed DyamicAlloc from being a key (default value false)
This code doesn't fix any particular issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/122)

<!-- Reviewable:end -->
