### PR TITLE
xSQLServerSetup: Using Start-Process instead of StartWin32Process (fixes #93 #126 #41)

### DIFF
--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -798,11 +798,10 @@ function Set-TargetResource
             $Log = $Log.Replace((Get-Variable -Name $LogVar).Value.GetNetworkCredential().Password,"********")
         }
     }
-    Write-Verbose "Arguments: $Log"
 
-    $Process = StartWin32Process -Path $Path -Arguments $Arguments
-    Write-Verbose $Process
-    WaitForWin32ProcessEnd -Path $Path -Arguments $Arguments
+    Write-Verbose "Arguments: $Log"
+    $Process = Start-Process -FilePath $Path -ArgumentList $Arguments -PassThru -Wait -NoNewWindow
+    Write-Information "setup exited with code $($Process.ExitCode)"
 
     if($ForceReboot -or ((Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name 'PendingFileRenameOperations' -ErrorAction SilentlyContinue) -ne $null))
     {


### PR DESCRIPTION
The SQL Server setup is run through a weird system of start a process and then polling for the process to complete.
It's not clear why this has been done. No comments to explain the decision of not using the standard Start-Process cmdlet with the -Wait flag.
This approach didn't work for me and the DSC configuration process got stuck at this step.
To make it work I replaced the StartWin32Process with the standard Start-Process.
Any comment on this would be appreciated.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/123)

<!-- Reviewable:end -->
