### PR TITLE
BREAKING CHANGE: Changes to xSQLServerDatabaseOwner

### DIFF
--- a/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
@@ -5,7 +5,6 @@ Write-Verbose -Message "CurrentPath: $currentPath"
 Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
 
 # DSC resource to manage SQL database roles
-
 # NOTE: This resource requires WMF5 and PsDscRunAsCredential
 
 function Get-TargetResource
@@ -29,29 +28,26 @@ function Get-TargetResource
         $SQLInstanceName = "MSSQLSERVER"
     )
 
-    if(!$SQL)
-    {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    }
+    $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
 
-    if($SQL)
+    if ($sql)
     {
-        # Check database exists
-        if(!($SQLDatabase = $SQL.Databases[$Database]))
+        # Getting Owner of Database        
+        $getSqlDatabaseOwner = Get-SqlDatabaseOwner -SQL $sql -Name $Name -Database $Database
+
+        if ($getSqlDatabaseOwner)
         {
-            throw New-TerminatingError -ErrorType NoDatabase -FormatArgs @($Database,$SQLServer,$SQLInstanceName) -ErrorCategory InvalidResult
+            Write-Verbose "Owner for SQL Database name $Database is $getSqlDatabaseOwner"
         }
-
-        $Name = $SQLDatabase.Owner
-    }
-    else
-    {
-        $Name = $null
+        else
+        {
+            $null = $getSqlDatabaseOwner
+        }
     }
 
     $returnValue = @{
         Database = $Database
-        Name = $Name
+        Name = $getSqlDatabaseOwner
         SQLServer = $SQLServer
         SQLInstanceName = $SQLInstanceName
     }
@@ -80,20 +76,19 @@ function Set-TargetResource
         $SQLInstanceName = "MSSQLSERVER"
     )
 
-    if(!$SQL)
-    {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    }
+    $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
 
-    if($SQL)
+    if($sql)
     {
-        $SQLDatabase = $SQL.Databases[$Database]
-        $SQLDatabase.SetOwner($Name)
-    }
-
-    if(!(Test-TargetResource @PSBoundParameters))
-    {
-        throw New-TerminatingError -ErrorType TestFailedAfterSet -ErrorCategory InvalidResult
+        # Setting Owner of Database
+        try 
+        {
+            Set-SqlDatabaseOwner -SQL $sql -Name $Name -Database $Database
+        }       
+        catch
+        {
+            throw [Exception] ("Failed to setting the owner of database $Database")
+        }
     }
 }
 
@@ -119,8 +114,10 @@ function Test-TargetResource
         $SQLInstanceName = "MSSQLSERVER"
     )
 
-    $result = ((Get-TargetResource @PSBoundParameters).Name -eq $Name)
+    Write-Verbose -Message "Testing owner $Name of database $Database"
+    $currentValues = Get-TargetResource @PSBoundParameters
     
+    $result = ($currentValues.Database -eq $Database) -and ($currentValues.Name -eq $Name)
     $result
 }
 

--- a/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
@@ -115,11 +115,11 @@ function Test-TargetResource
     )
 
     Write-Verbose -Message "Testing owner $Name of database $Database"
+     
     $currentValues = Get-TargetResource @PSBoundParameters
-    
-    $result = ($currentValues.Database -eq $Database) -and ($currentValues.Name -eq $Name)
-    $result
+    return Test-SQLDscParameterState -CurrentValues $CurrentValues `
+                                     -DesiredValues $PSBoundParameters `
+                                     -ValuesToCheck @("Name", "Database")
 }
-
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabaseOwner/MSFT_xSQLServerDatabaseOwner.psm1
@@ -33,7 +33,7 @@ function Get-TargetResource
     if ($sql)
     {
         # Getting Owner of Database        
-        $getSqlDatabaseOwner = Get-SqlDatabaseOwner -SQL $sql -Name $Name -Database $Database
+        $getSqlDatabaseOwner = Get-SqlDatabaseOwner -SQL $sql -Database $Database
 
         if ($getSqlDatabaseOwner)
         {

--- a/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -1,0 +1,40 @@
+<#
+.EXAMPLE
+    This example shows how to ensure that the user account CONTOSO\SQLAdmin
+    is "Owner" of SQL database "AdventureWorks". 
+#>
+
+    Configuration Example 
+    {
+        param(
+            [Parameter(Mandatory = $true)]
+            [PSCredential]
+            $SysAdminAccount
+        )
+        
+        Import-DscResource -ModuleName xSqlServer
+
+        node localhost 
+        {
+            xSQLServerLogin Add_SqlServerLogin_SQLAdmin
+            {
+                DependsOn = '[xSqlServerSetup]SETUP_SqlMSSQLSERVER'
+                Ensure = 'Present'
+                Name = 'CONTOSO\SQLAdmin'
+                LoginType = 'WindowsUser'        
+                SQLServer = 'SQLServer'
+                SQLInstanceName = 'DSC'
+                PsDscRunAsCredential = $SysAdminAccount
+            }
+
+            xSQLServerDatabaseOwner Set_SqlDatabaseOwner_SQLAdmin
+            {
+                DependsOn = '[xSQLServerLogin]Add_SqlServerLogin_SQLAdmin'
+                Name = 'CONTOSO\SQLAdmin'
+                Database = 'AdventureWorks'
+                SQLServer = 'SQLServer'
+                SQLInstanceName = 'DSC'
+                PsDscRunAsCredential = $SysAdminAccount
+            }
+        }
+    }

--- a/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -6,12 +6,14 @@
 
     Configuration Example 
     {
-        param(
+        param
+        (
             [Parameter(Mandatory = $true)]
-            [PSCredential]
+            [System.Management.Automation.PSCredential]
+            [System.Management.Automation.Credential()]
             $SysAdminAccount
         )
-        
+
         Import-DscResource -ModuleName xSqlServer
 
         node localhost 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,16 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* xSQLServerHelper
+  - added functions
+    - Test-SQLDscParameterState
+    - Get-SqlDatabaseOwner
+    - Set-SqlDatabaseOwner
+* Examples
+  - xSQLServerDatabaseOwner
+   - 1-SetDatabaseOwner.ps1
+ * Added tests for resources
+   - MSFT_xSQLServerDatabaseOwner.Tests.Tests.ps1
 
 ### 2.0.0.0
 * Added resources

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -65,10 +65,28 @@ try
                     $result.Name | Should Be $null
                 }
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
+                It "Should return false from the test method" {
+                    Test-TargetResource @testParameters | Should Be $false
+                }
+
+                It "Should throw when the set method is called" {
+                    { Set-TargetResource @testParameters } | Should Throw
+                }
+            }
+
+            Context 'When the specified login does not exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'UnknownDatabase'
+                }
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith { return exception }
+
+                $result = Get-TargetResource @testParameters
+
+                It 'Should return the name as null from the get method' {
+                    $result.Name | Should Be $null
                 }
 
                 It "Should return false from the test method" {
@@ -95,12 +113,6 @@ try
                     $result.Name | Should Be $null
                 }
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
-                }
-
                 It "Should return false from the test method" {
                     Test-TargetResource @testParameters | Should Be $false
                 }
@@ -123,12 +135,6 @@ try
 
                 It 'Should return the name of the owner from the get method' {
                     $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
                 }
 
                 It "Should return true from the test method" {

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -242,19 +242,6 @@ try
                 Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
             }
-            
-            $testParameters.Database = 'UnknownDatabase'
-
-            It 'Should throw an error when desired database does not exist' {
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                    return Throw
-                } -ModuleName $script:DSCResourceName -Verifiable
-                
-                { Set-TargetResource @testParameters } | Should Throw "Failed to setting the owner of database UnknownDatabase"
-                
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
         }
 
         Assert-VerifiableMocks

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -142,12 +142,11 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is not in the desired state' {
-
             It 'Should return the state as false when desired login is not the database owner' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Database = 'AdventureWorks'
-                Name = 'CONTOSO\SqlServiceAcct'
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                    Name = 'CONTOSO\SqlServiceAcct'
                 }       
 
                 Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
@@ -158,7 +157,7 @@ try
                 $result | Should Be $false
 
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
         }
 
@@ -178,7 +177,7 @@ try
                 $result | Should Be $true
 
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
         }
 
@@ -202,33 +201,24 @@ try
                 Name = 'CONTOSO\SqlServiceAcct'
             }
 
-            It 'Should throw an error when desired database does not exist' {
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                    return Throw
-                } -ModuleName $script:DSCResourceName -Verifiable
-                
-                { Set-TargetResource @testParameters } | Should Throw
-                
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should throw an error when desired login name does not exist' {
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                    return Throw
-                } -ModuleName $script:DSCResourceName -Verifiable
-                
-                { Set-TargetResource @testParameters } | Should Throw
-                
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
             It 'Should call the function Set-SqlDatabaseOwner when desired login is not the database owner' {
                 Mock -CommandName Set-SqlDatabaseOwner -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
                 
                 Set-TargetResource @testParameters
                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+            
+            $testParameters.Database = 'UnknownDatabase'
+
+            It 'Should throw an error when desired database does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw "Failed to setting the owner of database UnknownDatabase"
+                
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
@@ -241,28 +231,6 @@ try
                 Name = 'CONTOSO\SqlServiceAcct'
             }
 
-            It 'Should throw an error when desired database does not exist' {
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                    return Throw
-                } -ModuleName $script:DSCResourceName -Verifiable
-                
-                { Set-TargetResource @testParameters } | Should Throw
-                
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should throw an error when desired login name does not exist' {
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                    return Throw
-                } -ModuleName $script:DSCResourceName -Verifiable
-                
-                { Set-TargetResource @testParameters } | Should Throw
-                
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
             It 'Should not call the function Set-SqlDatabaseOwner when desired login is the database owner' {
                 Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
                     'CONTOSO\SqlServiceAcct' 
@@ -273,6 +241,19 @@ try
                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+            
+            $testParameters.Database = 'UnknownDatabase'
+
+            It 'Should throw an error when desired database does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw "Failed to setting the owner of database UnknownDatabase"
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
         }
 

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -1,0 +1,150 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerDatabaseOwner'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'MSSQLSERVER'
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName) - $($script:DSCModuleName)" {
+        InModuleScope $script:DSCResourceName {
+            $defaultParameters = @{
+                SQLInstanceName = $instanceName
+                SQLServer = $nodeName
+                Name = 'SQLAdmin'
+            }
+
+            Mock -CommandName Connect-SQL -MockWith {
+                return New-Object Object | 
+                    Add-Member ScriptProperty Databases {
+                        return @{
+                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                        }
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            Context 'When the specified database does not exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'UnknownDatabase'
+                }
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith { return exception }
+
+                $result = Get-TargetResource @testParameters
+
+                It 'Should return the name as null from the get method' {
+                    $result.Name | Should Be $null
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result.SQLServer | Should Be $testParameters.SQLServer
+                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                    $result.Database | Should Be $testParameters.Database
+                }
+
+                It "Should return false from the test method" {
+                    Test-TargetResource @testParameters | Should Be $false
+                }
+
+                It "Should throw when the set method is called" {
+                    { Set-TargetResource @testParameters } | Should Throw
+                }
+            }
+
+            Context 'When the specified name is not the owner of the database and should be' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                }
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith { }
+
+                $result = Get-TargetResource @testParameters
+
+                It 'Should return the name as null from the get method' {
+                    $result.Name | Should Be $null
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result.SQLServer | Should Be $testParameters.SQLServer
+                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                    $result.Database | Should Be $testParameters.Database
+                }
+
+                It "Should return false from the test method" {
+                    Test-TargetResource @testParameters | Should Be $false
+                }
+
+                It "Calls the mock function Set-SqlDatabaseOwner from the set method" {
+                    Set-TargetResource @testParameters
+                    Assert-MockCalled Set-SqlDatabaseOwner
+                }
+            }
+    
+            Context 'When the specified name is the owner of the database and should be' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                }
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $testParameters.Name }
+    
+                $result = Get-TargetResource @testParameters
+
+                It 'Should return the name of the owner from the get method' {
+                    $result.Name | Should Be $testParameters.Name
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result.SQLServer | Should Be $testParameters.SQLServer
+                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                    $result.Database | Should Be $testParameters.Database
+                }
+
+                It "Should return true from the test method" {
+                    Test-TargetResource @testParameters | Should Be $true
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -13,11 +13,9 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
-$TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
-
+$TestEnvironment = Initialize-TestEnvironment -DSCModuleName $script:DSCModuleName `
+                                              -DSCResourceName $script:DSCResourceName `
+                                              -TestType Unit 
 #endregion HEADER
 
 # Begin Testing
@@ -28,122 +26,257 @@ try
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
-    $nodeName = 'localhost'
-    $instanceName = 'MSSQLSERVER'
+    $defaultParameters = @{
+        SQLInstanceName = 'MSSQLSERVER'
+        SQLServer = 'localhost'
+    }
 
     #endregion Pester Test Initialization
 
-    Describe "$($script:DSCResourceName) - $($script:DSCModuleName)" {
-        InModuleScope $script:DSCResourceName {
-            $defaultParameters = @{
-                SQLInstanceName = $instanceName
-                SQLServer = $nodeName
-                Name = 'SQLAdmin'
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
             }
 
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                return $null
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            Context 'When the specified database does not exist' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'UnknownDatabase'
-                }
+            $result = Get-TargetResource @testParameters
 
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith { return exception }
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name as null from the get method' {
-                    $result.Name | Should Be $null
-                }
-
-                It "Should return false from the test method" {
-                    Test-TargetResource @testParameters | Should Be $false
-                }
-
-                It "Should throw when the set method is called" {
-                    { Set-TargetResource @testParameters } | Should Throw
-                }
+            It 'Should return the name as null from the get method' {
+                $result.Name | Should Be $null
             }
 
-            Context 'When the specified login does not exist' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'UnknownDatabase'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith { return exception }
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name as null from the get method' {
-                    $result.Name | Should Be $null
-                }
-
-                It "Should return false from the test method" {
-                    Test-TargetResource @testParameters | Should Be $false
-                }
-
-                It "Should throw when the set method is called" {
-                    { Set-TargetResource @testParameters } | Should Throw
-                }
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
             }
 
-            Context 'When the specified name is not the owner of the database and should be' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $null }
-                Mock -CommandName Set-SqlDatabaseOwner -MockWith { }
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name as null from the get method' {
-                    $result.Name | Should Be $null
-                }
-
-                It "Should return false from the test method" {
-                    Test-TargetResource @testParameters | Should Be $false
-                }
-
-                It "Calls the mock function Set-SqlDatabaseOwner from the set method" {
-                    Set-TargetResource @testParameters
-                    Assert-MockCalled Set-SqlDatabaseOwner
-                }
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                 Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
-    
-            Context 'When the specified name is the owner of the database and should be' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return $testParameters.Name }
-    
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name of the owner from the get method' {
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It "Should return true from the test method" {
-                    Test-TargetResource @testParameters | Should Be $true
-                }
-            }
-
-            Assert-VerifiableMocks
         }
+
+        Context 'When the specified database does not exist' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'UnknownDatabase'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                return $null
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the name as null from the get method' {
+                $result.Name | Should Be $null
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
+            }
+
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                 Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { return 'CONTOSO\SqlServiceAcct' } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the name of the owner from the get method' {
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
+            }
+
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                 Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                 Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+
+            It 'Should return the state as false when desired login is not the database owner' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+                }       
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    return $null
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return the state as true when desired login is the database owner' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                    Name = 'CONTOSO\SqlServiceAcct'
+                } 
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    'CONTOSO\SqlServiceAcct' 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            It 'Should throw an error when desired database does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw an error when desired login name does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the function Set-SqlDatabaseOwner when desired login is not the database owner' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+                
+                Set-TargetResource @testParameters
+               
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            It 'Should throw an error when desired database does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw an error when desired login name does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the function Set-SqlDatabaseOwner when desired login is the database owner' {
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    'CONTOSO\SqlServiceAcct' 
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                $result = Get-TargetResource @testParameters
+             
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
     }
 }
 finally

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -157,7 +157,7 @@ This is a PSBoundParametersDictionary of the desired values for the resource
 
 .PARAMETER ValuesToCheck
 
-This is a list of which properties in the desired values list should be checkked.
+This is a list of which properties in the desired values list should be checked.
 If this is empty then all values in DesiredValues are checked.
 
 #>
@@ -819,11 +819,13 @@ function Get-SqlDatabaseOwner
         }
         else
         {
-            Write-Error -Message "SQL Database name $Database does not exist" -Category InvalidData
+            $null = $Name
+            Throw "SQL Database name $Database does not exist"
         }
     }
     else
     {
+        $null = $Name
         Write-Verbose -Message 'Failed getting SQL databases'
     }
 

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -142,6 +142,25 @@ function New-VerboseMessage
 
 }
 
+<#
+.SYNOPSIS
+
+This method is used to compare current and desired values for any DSC resource
+
+.PARAMETER CurrentValues
+
+This is hashtable of the current values that are applied to the resource
+
+.PARAMETER DesiredValues 
+
+This is a PSBoundParametersDictionary of the desired values for the resource
+
+.PARAMETER ValuesToCheck
+
+This is a list of which properties in the desired values list should be checkked.
+If this is empty then all values in DesiredValues are checked.
+
+#>
 function Test-SQLDscParameterState 
 {
     [CmdletBinding()]
@@ -762,6 +781,20 @@ function Confirm-SqlServerRole
     return $confirmServerRole
 }
 
+<#
+.SYNOPSIS
+
+This cmdlet is used to return the owner of a SQL database
+
+.PARAMETER SQL
+
+This is an object of the SQL server that contains the result of Connect-SQL
+
+.PARAMETER Database
+
+This is the SQL database that will be checking
+
+#>
 function Get-SqlDatabaseOwner
 {
     [CmdletBinding()]    
@@ -797,6 +830,24 @@ function Get-SqlDatabaseOwner
     $Name
 }
 
+<#
+.SYNOPSIS
+
+This cmdlet is used to configure the owner of a SQL database
+
+.PARAMETER SQL
+
+This is an object of the SQL server that contains the result of Connect-SQL
+
+.PARAMETER Name 
+
+This is the name of the desired owner for the SQL database
+
+.PARAMETER Database
+
+This is the SQL database that will be setting
+
+#>
 function Set-SqlDatabaseOwner
 {
     [CmdletBinding()]    

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -819,13 +819,13 @@ function Get-SqlDatabaseOwner
         }
         else
         {
-            $null = $Name
-            Throw "SQL Database name $Database does not exist"
+            throw New-TerminatingError -ErrorType FailedToGetOwnerDatabase `
+                                       -FormatArgs @($Database) `
+                                       -ErrorCategory InvalidOperation
         }
     }
     else
     {
-        $null = $Name
         Write-Verbose -Message 'Failed getting SQL databases'
     }
 

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -147,15 +147,15 @@ function Test-SQLDscParameterState
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true, Position=1)]  
+        [Parameter(Mandatory = $true)]  
         [HashTable]
         $CurrentValues,
         
-        [parameter(Mandatory = $true, Position=2)]  
+        [Parameter(Mandatory = $true)]  
         [Object]
         $DesiredValues,
 
-        [parameter(Mandatory = $false, Position=3)] 
+        [Parameter(Mandatory = $false)] 
         [Array]
         $ValuesToCheck
     )
@@ -241,47 +241,32 @@ function Test-SQLDscParameterState
                         switch ($desiredType.Name) 
                         {
                             "String" {
-                                if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) `
-                                -and [string]::IsNullOrEmpty($DesiredValues.$fieldName)) 
-                                {} 
-                                else 
+                                if (-not [String]::IsNullOrEmpty($CurrentValues.$fieldName) -or `
+                                    -not [String]::IsNullOrEmpty($DesiredValues.$fieldName))
                                 {
-                                    Write-Verbose -Message ("String value for property " + `
-                                                            "$fieldName does not match. " + `
-                                                            "Current state is " + `
-                                                            "'$($CurrentValues.$fieldName)' " + `
-                                                            "and desired state is " + `
-                                                            "'$($DesiredValues.$fieldName)'")
+                                    Write-Verbose -Message ("String value for property $fieldName does not match. " + `
+                                                            "Current state is '$($CurrentValues.$fieldName)' " + `
+                                                            "and Desired state is '$($DesiredValues.$fieldName)'")
                                     $returnValue = $false
                                 }
                             }
                             "Int32" {
-                                if (($DesiredValues.$fieldName -eq 0) `
-                                -and ($null -eq $CurrentValues.$fieldName)) 
-                                {} 
-                                else 
-                                {
-                                    Write-Verbose -Message ("Int32 value for property " + `
-                                                            "$fieldName does not match. " + `
-                                                            "Current state is " + `
-                                                            "'$($CurrentValues.$fieldName)' " + `
-                                                            "and desired state is " + `
-                                                            "'$($DesiredValues.$fieldName)'")
+                                if (-not ($DesiredValues.$fieldName -eq 0) -or `
+                                    -not ($null -eq $CurrentValues.$fieldName))
+                                { 
+                                    Write-Verbose -Message ("Int32 value for property " + "$fieldName does not match. " + `
+                                                            "Current state is " + "'$($CurrentValues.$fieldName)' " + `
+                                                            "and desired state is " + "'$($DesiredValues.$fieldName)'")
                                     $returnValue = $false
                                 }
                             }
                             "Int16" {
-                                if (($DesiredValues.$fieldName -eq 0) `
-                                -and ($null -eq $CurrentValues.$fieldName)) 
-                                {} 
-                                else 
-                                {
-                                    Write-Verbose -Message ("Int16 value for property " + `
-                                                            "$fieldName does not match. " + `
-                                                            "Current state is " + `
-                                                            "'$($CurrentValues.$fieldName)' " + `
-                                                            "and desired state is " + `
-                                                            "'$($DesiredValues.$fieldName)'")
+                                if (-not ($DesiredValues.$fieldName -eq 0) -or `
+                                    -not ($null -eq $CurrentValues.$fieldName))
+                                { 
+                                    Write-Verbose -Message ("Int32 value for property " + "$fieldName does not match. " + `
+                                                            "Current state is " + "'$($CurrentValues.$fieldName)' " + `
+                                                            "and desired state is " + "'$($DesiredValues.$fieldName)'")
                                     $returnValue = $false
                                 }
                             }

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -627,10 +627,6 @@ function Get-SqlDatabaseOwner
         [ValidateNotNull()] 
         [System.Object]
         $SQL,
-        
-        [ValidateNotNull()] 
-        [System.String]
-        $Name,
 
         [ValidateNotNull()] 
         [System.String]
@@ -680,18 +676,27 @@ function Set-SqlDatabaseOwner
     
     Write-Verbose 'Getting SQL Databases'
     $sqlDatabase = $sql.Databases
-    if ($sqlDatabase)
+    $sqlLogins = $sql.Logins
+
+    if ($sqlDatabase -and $sqlLogins)
     {
         if ($sqlDatabase[$Database])
         {
-            try
+            if ($sqlLogins[$Name])
             {
-                $sqlDatabase[$Database].SetOwner($Name)
-                New-VerboseMessage -Message "Owner of SQL Database name $Database is now $Name"
+                try
+                {
+                    $sqlDatabase[$Database].SetOwner($Name)
+                    New-VerboseMessage -Message "Owner of SQL Database name $Database is now $Name"
+                }
+                catch
+                {
+                    throw [Exception] ("Failed setting owner $Name for SQL Database $Database")
+                }
             }
-            catch
+            else
             {
-                throw [Exception] ("Failed setting owner $Name for SQL Database $Database")
+                Write-Verbose "SQL Login name $Name does not exist"
             }
         }
         else
@@ -701,6 +706,6 @@ function Set-SqlDatabaseOwner
     }
     else
     {
-        Write-Verbose 'Failed getting SQL databases'
+        Write-Verbose 'Failed getting SQL databases and logins'
     }
 }

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -172,7 +172,7 @@ function Test-SQLDscParameterState
 
     if (($DesiredValues.GetType().Name -eq "CimInstance") -and ($null -eq $ValuesToCheck)) 
     {
-        throw ("If 'DesiredValues' is a Hashtable then property 'ValuesToCheck' must contain " + `
+        throw ("If 'DesiredValues' is a CimInstance then property 'ValuesToCheck' must contain " + `
                "a value")
     }
 
@@ -791,7 +791,7 @@ function Get-SqlDatabaseOwner
         $Database
     )
     
-    Write-Verbose 'Getting SQL Databases'
+    Write-Verbose -Message 'Getting SQL Databases'
     $sqlDatabase = $SQL.Databases
     if ($sqlDatabase)
     {
@@ -801,14 +801,12 @@ function Get-SqlDatabaseOwner
         }
         else
         {
-            Write-Verbose "SQL Database name $Database does not exist"
-            $null = $Name
+            Write-Error -Message "SQL Database name $Database does not exist" -Category InvalidData
         }
     }
     else
     {
-        Write-Verbose 'Failed getting SQL databases'
-        $null = $Name
+        Write-Verbose -Message 'Failed getting SQL databases'
     }
 
     $Name
@@ -832,7 +830,7 @@ function Set-SqlDatabaseOwner
         $Database
     )
     
-    Write-Verbose 'Getting SQL Databases'
+    Write-Verbose -Message 'Getting SQL Databases'
     $sqlDatabase = $SQL.Databases
     $sqlLogins = $SQL.Logins
 
@@ -849,21 +847,21 @@ function Set-SqlDatabaseOwner
                 }
                 catch
                 {
-                    throw [Exception] ("Failed setting owner $Name for SQL Database $Database")
+                    throw New-TerminatingError -ErrorType FailedToSetOwnerDatabase -ErrorCategory InvalidOperation -InnerException $_.Exception
                 }
             }
             else
             {
-                Write-Verbose "SQL Login name $Name does not exist"
+                Write-Error -Message "SQL Login name $Name does not exist" -Category InvalidData
             }
         }
         else
         {
-            Write-Verbose "SQL Database name $Database does not exist"
+            Write-Error -Message "SQL Database name $Database does not exist" -Category InvalidData
         }
     }
     else
     {
-        Write-Verbose 'Failed getting SQL databases and logins'
+        Write-Verbose -Message 'Failed getting SQL databases and logins'
     }
 }

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -618,3 +618,89 @@ function Confirm-SqlServerRole
 
     return $confirmServerRole
 }
+
+function Get-SqlDatabaseOwner
+{
+    [CmdletBinding()]    
+    param
+    (   
+        [ValidateNotNull()] 
+        [System.Object]
+        $SQL,
+        
+        [ValidateNotNull()] 
+        [System.String]
+        $Name,
+
+        [ValidateNotNull()] 
+        [System.String]
+        $Database
+    )
+    
+    Write-Verbose 'Getting SQL Databases'
+    $sqlDatabase = $sql.Databases
+    if ($sqlDatabase)
+    {
+        if ($sqlDatabase[$Database])
+        {
+            $Name = $sqlDatabase[$Database].Owner
+        }
+        else
+        {
+            Write-Verbose "SQL Database name $Database does not exist"
+            $null = $Name
+        }
+    }
+    else
+    {
+        Write-Verbose 'Failed getting SQL databases'
+        $null = $Name
+    }
+
+    $Name
+}
+
+function Set-SqlDatabaseOwner
+{
+    [CmdletBinding()]    
+    param
+    (   
+        [ValidateNotNull()] 
+        [System.Object]
+        $SQL,
+        
+        [ValidateNotNull()] 
+        [System.String]
+        $Name,
+
+        [ValidateNotNull()] 
+        [System.String]
+        $Database
+    )
+    
+    Write-Verbose 'Getting SQL Databases'
+    $sqlDatabase = $sql.Databases
+    if ($sqlDatabase)
+    {
+        if ($sqlDatabase[$Database])
+        {
+            try
+            {
+                $sqlDatabase[$Database].SetOwner($Name)
+                New-VerboseMessage -Message "Owner of SQL Database name $Database is now $Name"
+            }
+            catch
+            {
+                throw [Exception] ("Failed setting owner $Name for SQL Database $Database")
+            }
+        }
+        else
+        {
+            Write-Verbose "SQL Database name $Database does not exist"
+        }
+    }
+    else
+    {
+        Write-Verbose 'Failed getting SQL databases'
+    }
+}

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -634,7 +634,7 @@ function Get-SqlDatabaseOwner
     )
     
     Write-Verbose 'Getting SQL Databases'
-    $sqlDatabase = $sql.Databases
+    $sqlDatabase = $SQL.Databases
     if ($sqlDatabase)
     {
         if ($sqlDatabase[$Database])
@@ -675,8 +675,8 @@ function Set-SqlDatabaseOwner
     )
     
     Write-Verbose 'Getting SQL Databases'
-    $sqlDatabase = $sql.Databases
-    $sqlLogins = $sql.Logins
+    $sqlDatabase = $SQL.Databases
+    $sqlLogins = $SQL.Logins
 
     if ($sqlDatabase -and $sqlLogins)
     {

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -128,7 +128,6 @@ function New-TerminatingError
     return $errorRecord
 }
 
-
 function New-VerboseMessage
 {
     [CmdletBinding()]
@@ -141,6 +140,165 @@ function New-VerboseMessage
     )
     Write-Verbose -Message ((Get-Date -format yyyy-MM-dd_HH-mm-ss) + ": $Message");
 
+}
+
+function Test-SQLDscParameterState 
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true, Position=1)]  
+        [HashTable]
+        $CurrentValues,
+        
+        [parameter(Mandatory = $true, Position=2)]  
+        [Object]
+        $DesiredValues,
+
+        [parameter(Mandatory = $false, Position=3)] 
+        [Array]
+        $ValuesToCheck
+    )
+
+    $returnValue = $true
+
+    if (($DesiredValues.GetType().Name -ne "HashTable") `
+        -and ($DesiredValues.GetType().Name -ne "CimInstance") `
+        -and ($DesiredValues.GetType().Name -ne "PSBoundParametersDictionary")) 
+    {
+        throw ("Property 'DesiredValues' in Test-SQLDscParameterState must be either a " + `
+               "Hashtable or CimInstance. Type detected was $($DesiredValues.GetType().Name)")
+    }
+
+    if (($DesiredValues.GetType().Name -eq "CimInstance") -and ($null -eq $ValuesToCheck)) 
+    {
+        throw ("If 'DesiredValues' is a Hashtable then property 'ValuesToCheck' must contain " + `
+               "a value")
+    }
+
+    if (($null -eq $ValuesToCheck) -or ($ValuesToCheck.Count -lt 1)) 
+    {
+        $KeyList = $DesiredValues.Keys
+    } 
+    else 
+    {
+        $KeyList = $ValuesToCheck
+    }
+
+    $KeyList | ForEach-Object -Process {
+        if (($_ -ne "Verbose")) 
+        {
+            if (($CurrentValues.ContainsKey($_) -eq $false) `
+            -or ($CurrentValues.$_ -ne $DesiredValues.$_) `
+            -or (($DesiredValues.ContainsKey($_) -eq $true) -and ($DesiredValues.$_.GetType().IsArray))) 
+            {
+                if ($DesiredValues.GetType().Name -eq "HashTable" -or `
+                    $DesiredValues.GetType().Name -eq "PSBoundParametersDictionary") 
+                {
+                    
+                    $CheckDesiredValue = $DesiredValues.ContainsKey($_)
+                } 
+                else 
+                {
+                    $CheckDesiredValue = Test-SPDSCObjectHasProperty $DesiredValues $_
+                }
+
+                if ($CheckDesiredValue) 
+                {
+                    $desiredType = $DesiredValues.$_.GetType()
+                    $fieldName = $_
+                    if ($desiredType.IsArray -eq $true) 
+                    {
+                        if (($CurrentValues.ContainsKey($fieldName) -eq $false) `
+                        -or ($null -eq $CurrentValues.$fieldName)) 
+                        {
+                            Write-Verbose -Message ("Expected to find an array value for " + `
+                                                    "property $fieldName in the current " + `
+                                                    "values, but it was either not present or " + `
+                                                    "was null. This has caused the test method " + `
+                                                    "to return false.")
+                            $returnValue = $false
+                        } 
+                        else 
+                        {
+                            $arrayCompare = Compare-Object -ReferenceObject $CurrentValues.$fieldName `
+                                                           -DifferenceObject $DesiredValues.$fieldName
+                            if ($null -ne $arrayCompare) 
+                            {
+                                Write-Verbose -Message ("Found an array for property $fieldName " + `
+                                                        "in the current values, but this array " + `
+                                                        "does not match the desired state. " + `
+                                                        "Details of the changes are below.")
+                                $arrayCompare | ForEach-Object -Process {
+                                    Write-Verbose -Message "$($_.InputObject) - $($_.SideIndicator)"
+                                }
+                                $returnValue = $false
+                            }
+                        }
+                    } 
+                    else 
+                    {
+                        switch ($desiredType.Name) 
+                        {
+                            "String" {
+                                if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) `
+                                -and [string]::IsNullOrEmpty($DesiredValues.$fieldName)) 
+                                {} 
+                                else 
+                                {
+                                    Write-Verbose -Message ("String value for property " + `
+                                                            "$fieldName does not match. " + `
+                                                            "Current state is " + `
+                                                            "'$($CurrentValues.$fieldName)' " + `
+                                                            "and desired state is " + `
+                                                            "'$($DesiredValues.$fieldName)'")
+                                    $returnValue = $false
+                                }
+                            }
+                            "Int32" {
+                                if (($DesiredValues.$fieldName -eq 0) `
+                                -and ($null -eq $CurrentValues.$fieldName)) 
+                                {} 
+                                else 
+                                {
+                                    Write-Verbose -Message ("Int32 value for property " + `
+                                                            "$fieldName does not match. " + `
+                                                            "Current state is " + `
+                                                            "'$($CurrentValues.$fieldName)' " + `
+                                                            "and desired state is " + `
+                                                            "'$($DesiredValues.$fieldName)'")
+                                    $returnValue = $false
+                                }
+                            }
+                            "Int16" {
+                                if (($DesiredValues.$fieldName -eq 0) `
+                                -and ($null -eq $CurrentValues.$fieldName)) 
+                                {} 
+                                else 
+                                {
+                                    Write-Verbose -Message ("Int16 value for property " + `
+                                                            "$fieldName does not match. " + `
+                                                            "Current state is " + `
+                                                            "'$($CurrentValues.$fieldName)' " + `
+                                                            "and desired state is " + `
+                                                            "'$($DesiredValues.$fieldName)'")
+                                    $returnValue = $false
+                                }
+                            }
+                            default {
+                                Write-Verbose -Message ("Unable to compare property $fieldName " + `
+                                                        "as the type ($($desiredType.Name)) is " + `
+                                                        "not handled by the " + `
+                                                        "Test-SQLDscParameterState cmdlet")
+                                $returnValue = $false
+                            }
+                        }
+                    }
+                }            
+            }
+        } 
+    }
+    return $returnValue
 }
 
 function Grant-ServerPerms


### PR DESCRIPTION
- Added tests for resources
 - xSQLServerDatabaseOwner

- Fixes and enhancements in xSQLServerDatabaseOwner 
 - BREAKING CHANGE: Fixed so the same owner can now be added in one or more databases, and/or one or more instances. Now the parameters SQLServer and SQLInstanceName are mandatory.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/138)
<!-- Reviewable:end -->
