### PR TITLE
BREAKING CHANGE: Updated xSQLServerConfiguration to support clustered instances (Fixes #144)

### DIFF
--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -21,7 +21,8 @@ Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAct
     The desired value of the SQL configuration option
 
     .PARAMETER RestartService
-    Determines whether the instance should be restarted after updating the configuration option
+    *** Not used in this function ***
+    Determines whether the instance should be restarted after updating the configuration option.
 #>
 function Get-TargetResource
 {

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -12,7 +12,7 @@ Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAct
     Hostname of the SQL Server to be configured
     
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued. Default is 'MSSQLServer'
+    Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be checked
@@ -56,7 +56,7 @@ function Get-TargetResource
         $RestartTimeout = 120
     )
 
-    if (! $sql)
+    if (!$sql)
     {
         $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
     }
@@ -87,7 +87,7 @@ function Get-TargetResource
     Hostname of the SQL Server to be configured
     
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued. Default is 'MSSQLServer'
+    Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be set
@@ -128,7 +128,7 @@ function Set-TargetResource
         $RestartTimeout = 120
     )
 
-    if (! $sql)
+    if (!$sql)
     {
         $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
     }
@@ -167,7 +167,7 @@ function Set-TargetResource
     Hostname of the SQL Server to be configured
     
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued. Default is 'MSSQLServer'
+    Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be tested
@@ -225,7 +225,7 @@ function Test-TargetResource
     Hostname of the SQL Server to be configured
     
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued. Default is 'MSSQLServer'
+    Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER Timeout
     Timeout value for restarting the SQL services

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -36,7 +36,7 @@ Function Get-TargetResource
 
     if (! $sql)
     {
-        $sql = Connect-SQL -SQLServer $SQLServer -SQLInstance $SQLInstance
+        $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstance
     }
 
     ## get the configuration option
@@ -89,7 +89,7 @@ Function Set-TargetResource
 
     if (! $sql)
     {
-        $sql = Connect-SQL -SQLServer $SQLServer -SQLInstance $SQLInstance
+        $sql = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstance
     }
 
     ## get the configuration option
@@ -148,7 +148,7 @@ Function Test-TargetResource
         $RestartService = $false
     )
 
-    $state = Get-TargetResource -InstanceName $InstanceName -OptionName $OptionName -OptionValue $OptionValue
+    $state = Get-TargetResource -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -OptionName $OptionName -OptionValue $OptionValue -RestartService $RestartService
 
     return ($state.OptionValue -eq $OptionValue)
 }

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -169,10 +169,10 @@ Function Restart-SqlService
     {
         ## Get the cluster resources
         New-VerboseMessage -Message "Getting cluster resource for SQL Server" 
-        $SqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server' AND Name LIKE '%$($ServerObject.InstanceName)%'"
+        $SqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server' AND Name LIKE '%$($ServerObject.ServiceName)%'"
 
         New-VerboseMessage -Message "Getting cluster resource for SQL Server Agent"
-        $AgentService = Get-WmiObject -Namespace root/MSCLuster -Class MSCluster_Resource -Filter "Type = 'SQL Server Agent' AND Name LIKE '%$($ServerObject.InstanceName)%'"
+        $AgentService = Get-WmiObject -Namespace root/MSCLuster -Class MSCluster_Resource -Filter "Type = 'SQL Server Agent' AND Name LIKE '%$($ServerObject.ServiceName)%'"
 
         ## Stop the SQL Server resource
         New-VerboseMessage -Message "SQL Server resource --> Offline"

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -48,9 +48,10 @@ Function Get-TargetResource
     }
 
     $returnValue = @{
-        InstanceName   = $InstanceName
-        OptionName     = $option.DisplayName
-        OptionValue    = $option.ConfigValue
+        SqlServer = $SQLServer
+        SQLInstanceName = $SQLInstanceName
+        OptionName = $option.DisplayName
+        OptionValue = $option.ConfigValue
         RestartService = $RestartService
     }
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -260,11 +260,10 @@ function Restart-SqlService
         New-VerboseMessage -Message 'SQL Server service restarting'
         $sqlService | Restart-Service -Force
 
-        ## Start the SQL Server Agent service
-        if ($agentService)
-        {
-            New-VerboseMessage -Message 'Starting SQL Server Agent'
-            $agentService | Start-Service 
+        ## Start dependent services
+        $agentService | ForEach-Object {
+            New-VerboseMessage -Message "Starting $($_.DisplayName)"
+            $_ | Start-Service
         }
     }
 #>

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -54,7 +54,7 @@ function Get-TargetResource
     }
 
     ## get the configuration option
-    $option = $sql.Configuration.Properties | where { $_.DisplayName -eq $optionName }
+    $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $optionName }
     
     if(!$option)
     {
@@ -119,7 +119,7 @@ function Set-TargetResource
     }
 
     ## get the configuration option
-    $option = $sql.Configuration.Properties | where {$_.DisplayName -eq $optionName}
+    $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $optionName }
 
     if(!$option)
     {
@@ -226,9 +226,10 @@ function Restart-SqlService
 
     ## get the instance name from the Server object
     $instanceName = $ServerObject.ServiceName
+    
+    ## sometimes default instances do not return a value
     if (! $instanceName)
     {
-        ## sometimes default instances do not return a value
         ## specify the default instance name
         $instanceName = "MSSQLSERVER"
     }

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -155,7 +155,7 @@ function Set-TargetResource
     }
     else
     {
-        Write-Warning 'Configuration option has been updated, but a manual restart of SQL Server is required for it to take effect.'
+        New-WarningMessage -ErrorType 'ConfigurationRestartRequred' -FormatArgs $OptionName
     }
 }
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -155,7 +155,7 @@ function Set-TargetResource
     }
     else
     {
-        New-WarningMessage -ErrorType 'ConfigurationRestartRequred' -FormatArgs $OptionName
+        New-WarningMessage -WarningType 'ConfigurationRestartRequired' -FormatArgs $OptionName
     }
 }
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -1,10 +1,7 @@
-﻿$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-Write-Verbose -Message "CurrentPath: $currentPath"
-
-# Load Common Code
-$helperModule = $currentPath | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath "xSQLServerHelper.psm1"
-Import-Module $helperModule -ErrorAction Stop
-
+﻿# Load Common Code
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+                               -ChildPath 'xSQLServerHelper.psm1') `
+                               -Force
 <#
     .SYNOPSIS
     Gets the current value of a SQL configuration option

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -140,7 +140,7 @@ function Set-TargetResource
     }
     else
     {
-        Write-Warning 'Configuration option has been updated. SQL Server restart is required!'
+        Write-Warning 'Configuration option has been updated, but a manual restart of SQL Server is required for it to take effect.'
     }
 }
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -32,7 +32,7 @@ Import-Module $helperModule -ErrorAction Stop
 function Get-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([Hashtable])]
     param(
         [Parameter(Mandatory = $true)]
         [String]
@@ -46,13 +46,13 @@ function Get-TargetResource
         $OptionName,
 
         [Parameter(Mandatory = $true)]
-        [int]
+        [Int32]
         $OptionValue,
 
-        [bool]
+        [Boolean]
         $RestartService = $false,
 
-        [int]
+        [Int32]
         $RestartTimeout = 120
     )
 
@@ -117,13 +117,13 @@ function Set-TargetResource
         $OptionName,
 
         [Parameter(Mandatory = $true)]
-        [int]
+        [Int32]
         $OptionValue,
 
-        [bool]
+        [Boolean]
         $RestartService = $false,
 
-        [int]
+        [Int32]
         $RestartTimeout = 120
     )
 
@@ -185,7 +185,7 @@ function Set-TargetResource
 function Test-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([bool])]
+    [OutputType([Boolean])]
     param(
         [Parameter(Mandatory = $true)]
         [String]
@@ -199,13 +199,13 @@ function Test-TargetResource
         $OptionName,
 
         [Parameter(Mandatory = $true)]
-        [int]
+        [Int32]
         $OptionValue,
 
-        [bool]
+        [Boolean]
         $RestartService = $false,
 
-        [int]
+        [Int32]
         $RestartTimeout = 120
     )
 
@@ -251,7 +251,7 @@ function Restart-SqlService
         [String]
         $SQLInstanceName = 'MSSQLSERVER',
 
-        [int]
+        [Int32]
         $Timeout = 120
     )
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -222,34 +222,34 @@ function Restart-SqlService
     {
         ## Get the cluster resources
         New-VerboseMessage -Message 'Getting cluster resource for SQL Server' 
-        $SqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server' AND Name LIKE '%$($ServerObject.ServiceName)%'"
+        $sqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server' AND Name LIKE '%$($ServerObject.ServiceName)%'"
 
         New-VerboseMessage -Message 'Getting cluster resource for SQL Server Agent'
-        $AgentService = Get-WmiObject -Namespace root/MSCLuster -Class MSCluster_Resource -Filter "Type = 'SQL Server Agent' AND Name LIKE '%$($ServerObject.ServiceName)%'"
+        $agentService = Get-WmiObject -Namespace root/MSCLuster -Class MSCluster_Resource -Filter "Type = 'SQL Server Agent' AND Name LIKE '%$($ServerObject.ServiceName)%'"
 
         ## Stop the SQL Server resource
         New-VerboseMessage -Message 'SQL Server resource --> Offline'
-        $SqlService.TakeOffline(120)
+        $sqlService.TakeOffline(120)
 
         ## Start the SQL Agent resource
         New-VerboseMessage -Message 'SQL Server Agent --> Online'
-        $AgentService.BringOnline(120)
+        $agentService.BringOnline(120)
     }
     else
     {
         New-VerboseMessage -Message 'Getting SQL Service information'
-        $SqlService = Get-Service -DisplayName "SQL Server ($($ServerObject.ServiceName))"
-        $AgentService = $SqlService.DependentServices | Where-Object { $_.StartType -ne ''}
+        $sqlService = Get-Service -DisplayName "SQL Server ($($ServerObject.ServiceName))"
+        $agentService = $sqlService.DependentServices | Where-Object { $_.StartType -ne ''}
 
         ## Restart the SQL Server service
         New-VerboseMessage -Message 'SQL Server service restarting'
-        $SqlService | Restart-Service -Force
+        $sqlService | Restart-Service -Force
 
         ## Start the SQL Server Agent service
-        if ($AgentService)
+        if ($agentService)
         {
             New-VerboseMessage -Message 'Starting SQL Server Agent'
-            $AgentService | Start-Service 
+            $agentService | Start-Service 
         }
     }
 }

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -188,8 +188,10 @@ function Test-TargetResource
         $RestartService = $false
     )
 
-    $state = Get-TargetResource -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -OptionName $OptionName -OptionValue $OptionValue -RestartService $RestartService
+    ## Get the current state of the configuration item
+    $state = Get-TargetResource @PSBoundParameters
 
+    ## return whether the value matches the desired state
     return ($state.OptionValue -eq $OptionValue)
 }
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -61,15 +61,13 @@ function Get-TargetResource
         New-TerminatingError -Message "Specified option '$OptionName' was not found!"
     }
 
-    $returnValue = @{
+     return @{
         SqlServer = $SQLServer
         SQLInstanceName = $SQLInstanceName
         OptionName = $option.DisplayName
         OptionValue = $option.ConfigValue
         RestartService = $RestartService
     }
-
-    return $returnValue
 }
 
 <#

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -262,10 +262,12 @@ function Restart-SqlService
     {
         ## Get the cluster resources
         New-VerboseMessage -Message 'Getting cluster resource for SQL Server' 
-        $sqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server'" | Where-Object { $_.PrivateProperties.InstanceName -eq $serverObject.ServiceName }
+        $sqlService = Get-WmiObject -Namespace root/MSCluster -Class MSCluster_Resource -Filter "Type = 'SQL Server'" | 
+                        Where-Object { $_.PrivateProperties.InstanceName -eq $serverObject.ServiceName }
 
         New-VerboseMessage -Message 'Getting active cluster resource SQL Server Agent'
-        $agentService = Get-WmiObject -Namespace root/MSCluster -Query "ASSOCIATORS OF {$sqlService} WHERE ResultClass = MSCluster_Resource" | Where-Object { ($_.Type -eq "SQL Server Agent") -and ($_.State -eq 2) }
+        $agentService = Get-WmiObject -Namespace root/MSCluster -Query "ASSOCIATORS OF {$sqlService} WHERE ResultClass = MSCluster_Resource" | 
+                            Where-Object { ($_.Type -eq "SQL Server Agent") -and ($_.State -eq 2) }
 
         ## Build a listing of resources being acted upon
         $resourceNames = @($sqlService.Name, ($agentService | Select -ExpandProperty Name)) -join ","

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -228,8 +228,13 @@ function Test-TargetResource
     Timeout value for restarting the SQL services
 
     .EXAMPLE
-    $server = Connect-SQL -SQLServer $env:ComputerName
-    Restart-SqlService -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    Restart-SqlService -SQLServer localhost
+
+    .EXAMPLE
+    Restart-SqlService -SQLServer localhost -SQLInstanceName 'NamedInstance'
+
+    .EXAMPLE
+    Restart-SqlService -SQLServer CLU01 -Timeout 300
 #>
 function Restart-SqlService
 {

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -1,5 +1,5 @@
 ﻿$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-New-VerboseMessage -Message -Message "CurrentPath: $currentPath"
+Write-Verbose -Message "CurrentPath: $currentPath"
 
 # Load Common Code
 Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -58,7 +58,7 @@ function Get-TargetResource
     
     if(!$option)
     {
-        throw "Specified option '$OptionName' was not found!"
+        New-TerminatingError -Message "Specified option '$OptionName' was not found!"
     }
 
     $returnValue = @{
@@ -125,7 +125,7 @@ function Set-TargetResource
 
     if(!$option)
     {
-        throw "Specified option '$OptionName' was not found!"
+        New-TerminatingError -Message "Specified option '$OptionName' was not found!"
     }
 
     $option.ConfigValue = $OptionValue

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -32,15 +32,15 @@ function Get-TargetResource
         [String]
         $SQLServer,
 
-        [parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $SQLInstanceName = 'MSSQLSERVER',
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $OptionName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.Int32]
         $OptionValue,
 
@@ -99,15 +99,15 @@ function Set-TargetResource
         [String]
         $SQLServer,
 
-        [parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $SQLInstanceName = 'MSSQLSERVER',
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $OptionName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.Int32]
         $OptionValue,
 
@@ -174,15 +174,15 @@ function Test-TargetResource
         [String]
         $SQLServer,
 
-        [parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [System.String]
         $SQLInstanceName = 'MSSQLSERVER',
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $OptionName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.Int32]
         $OptionValue,
 

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -6,4 +6,5 @@ class MSFT_xSQLServerConfiguration : OMI_BaseResource
     [Key, Description("The name of the SQL configuration option to be checked")] String OptionName;
     [Required, Description("The desired value of the SQL configuration option")] Sint32 OptionValue;
     [Write, Description("Determines whether the instance should be restarted after updating the configuration option")] Boolean RestartService;
+    [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] Sint32 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -1,7 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerConfiguration")]
 class MSFT_xSQLServerConfiguration : OMI_BaseResource
 {
-    [Key, Description("SQL Server instance name of which configuration will be managed")] String InstanceName;
+    [Key, Description("The SQL Server for the configuration option.")] String SQLServer;
+    [Write, Description("The SQL instance for the configuration option.")] String SQLInstanceName;
     [Key, Description("SQL Server configuration option to be set")] String OptionName;
     [Required, Description("Configuration option value to be set")] Sint32 OptionValue;
     [Write, Description("Controls if affected SQL Service should be restarted automatically")] Boolean RestartService;

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerConfiguration")]
 class MSFT_xSQLServerConfiguration : OMI_BaseResource
 {
-    [Key, Description("The SQL Server for the configuration option.")] String SQLServer;
+    [Key, Description("The hostname of the SQL Server to configure.")] String SQLServer;
     [Write, Description("The SQL instance for the configuration option.")] String SQLInstanceName;
     [Key, Description("SQL Server configuration option to be set")] String OptionName;
     [Required, Description("Configuration option value to be set")] Sint32 OptionValue;

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -1,9 +1,9 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerConfiguration")]
 class MSFT_xSQLServerConfiguration : OMI_BaseResource
 {
-    [Key, Description("The hostname of the SQL Server to configure.")] String SQLServer;
-    [Write, Description("The SQL instance for the configuration option.")] String SQLInstanceName;
-    [Key, Description("SQL Server configuration option to be set")] String OptionName;
-    [Required, Description("Configuration option value to be set")] Sint32 OptionValue;
-    [Write, Description("Controls if affected SQL Service should be restarted automatically")] Boolean RestartService;
+    [Key, Description("The hostname of the SQL Server to be configured")] String SQLServer;
+    [Write, Description("Name of the SQL instance to be configured. Default is 'MSSQLServer'")] String SQLInstanceName;
+    [Key, Description("The name of the SQL configuration option to be checked")] String OptionName;
+    [Required, Description("The desired value of the SQL configuration option")] Sint32 OptionValue;
+    [Write, Description("Determines whether the instance should be restarted after updating the configuration option")] Boolean RestartService;
 };

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_xSQLServerConfiguration : OMI_BaseResource
 {
     [Key, Description("The hostname of the SQL Server to be configured")] String SQLServer;
-    [Write, Description("Name of the SQL instance to be configured. Default is 'MSSQLServer'")] String SQLInstanceName;
+    [Write, Description("Name of the SQL instance to be configured. Default is 'MSSQLSERVER'")] String SQLInstanceName;
     [Key, Description("The name of the SQL configuration option to be checked")] String OptionName;
     [Required, Description("The desired value of the SQL configuration option")] Sint32 OptionValue;
     [Write, Description("Determines whether the instance should be restarted after updating the configuration option")] Boolean RestartService;

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **RetryCount**: Maximum number of retries to check availability group creation
 
 ###xSQLServerConfiguration
-* **InstanceName**: (Key) name of SQL Server instance for which configuration options will be configured.
+* **SQLServer**: (Key) The SQL Server for the configuration option.
+* **SQLInstanceName**: (Write) The SQL instance for the configuration option.
 * **OptionName**: (Key) SQL Server option name. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx) or run sp_configure.
 * **OptionValue**: (Required) SQL Server option value to be set.
 * **RestartService**: Default false. If true will restart SQL Service instance service after update.
@@ -360,6 +361,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Fixes in xSQLServerConfiguration
   - Added support for clustered SQL instances
   - BREAKING CHANGE: Updated parameters to align with other resources (SQLServer / SQLInstanceName)
+* Created unit tests for resource
 
 ### 2.0.0.0
 * Added resources

--- a/README.md
+++ b/README.md
@@ -280,11 +280,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **RetryCount**: Maximum number of retries to check availability group creation
 
 ###xSQLServerConfiguration
-* **SQLServer**: (Key) The SQL Server for the configuration option.
-* **SQLInstanceName**: (Write) The SQL instance for the configuration option.
-* **OptionName**: (Key) SQL Server option name. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx) or run sp_configure.
-* **OptionValue**: (Required) SQL Server option value to be set.
-* **RestartService**: Default false. If true will restart SQL Service instance service after update.
+* **SQLServer**: (Key) The hostname of the SQL Server to be configured
+* **SQLInstanceName**: (Write) Name of the SQL instance to be configured. Default is 'MSSQLServer'
+* **OptionName**: (Key) The name of the SQL configuration option to be checked. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx) or run sp_configure.
+* **OptionValue**: (Required) The desired value of the SQL configuration option
+* **RestartService**: Determines whether the instance should be restarted after updating the configuration option
 
 ### xSQLServerPermission
 * **InstanceName** The SQL Server instance name.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
    - 1-SetDatabaseOwner.ps1
  * Added tests for resources
    - MSFT_xSQLServerDatabaseOwner.Tests.Tests.ps1
+* Fixes in xSQLServerConfiguration
+  - Added support for clustered SQL instances
+  - BREAKING CHANGE: Updated parameters to align with other resources (SQLServer / SQLInstanceName)
 
 ### 2.0.0.0
 * Added resources

--- a/README.md
+++ b/README.md
@@ -281,10 +281,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ###xSQLServerConfiguration
 * **SQLServer**: (Key) The hostname of the SQL Server to be configured
-* **SQLInstanceName**: (Write) Name of the SQL instance to be configured. Default is 'MSSQLServer'
+* **SQLInstanceName**: (Write) Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
 * **OptionName**: (Key) The name of the SQL configuration option to be checked. For all possible values reference [MSDN](https://msdn.microsoft.com/en-us/library/ms189631.aspx) or run sp_configure.
 * **OptionValue**: (Required) The desired value of the SQL configuration option
 * **RestartService**: Determines whether the instance should be restarted after updating the configuration option
+* **RestartTimeout**: The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.
 
 ### xSQLServerPermission
 * **InstanceName** The SQL Server instance name.
@@ -361,7 +362,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Fixes in xSQLServerConfiguration
   - Added support for clustered SQL instances
   - BREAKING CHANGE: Updated parameters to align with other resources (SQLServer / SQLInstanceName)
-* Created unit tests for resource
+* Created unit tests for xSQLServerConfiguration resource
 
 ### 2.0.0.0
 * Added resources

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -2,8 +2,6 @@
 $script:DSCModuleName      = 'xSQLServer'
 $script:DSCResourceName    = 'MSFT_xSQLServerConfiguration'
 
-#region HEADER
-
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
@@ -18,7 +16,14 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCResourceName $script:DSCResourceName `
     -TestType Unit 
 
-#endregion HEADER
+$defaultState = @{
+    SQLServer = "CLU01"
+    SQLInstanceName = "ClusteredInstance"
+    OptionName = "user connections"
+    OptionValue = 0
+    RestartService = $false
+    RestartTimeout = 120
+}
 
 $desiredState = @{
     SQLServer = "CLU01"
@@ -26,6 +31,7 @@ $desiredState = @{
     OptionName = "user connections"
     OptionValue = 500
     RestartService = $false
+    RestartTimeout = 120
 }
 
 $desiredStateRestart = @{
@@ -34,6 +40,7 @@ $desiredStateRestart = @{
     OptionName = "user connections"
     OptionValue = 5000
     RestartService = $true
+    RestartTimeout = 120
 }
 
 $dynamicOption = @{
@@ -42,6 +49,7 @@ $dynamicOption = @{
     OptionName = "show advanced options"
     OptionValue = 0
     RestartService = $false
+    RestartTimeout = 120
 }
 
 $invalidOption = @{
@@ -50,81 +58,129 @@ $invalidOption = @{
     OptionName = "Does Not Exist"
     OptionValue = 1
     RestartService = $false
+    RestartTimeout = 120
 }
 
 ## compile the SMO stub
-Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+#Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
-# Begin Testing
 try
 {
-    #region Test getting the current state
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
 
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
-        Mock -CommandName New-TerminatingError -MockWith {} -ModuleName $script:DSCResourceName
-
-        Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{ 
-                Configuration = @{
-                    Properties = @(
-                        @{
-                            DisplayName = "user connections"
-                            ConfigValue = 0
-                        }
-                    )
-                }
-            }
-
-            ## add the Alter method
-            $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
-
-            return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'The system is not in the desired state' {
+
+            Mock -CommandName Connect-SQL -MockWith {
+                $mock = New-Object PSObject -Property @{ 
+                    Configuration = @{
+                        Properties = @(
+                            @{
+                                DisplayName = "user connections"
+                                ConfigValue = 0
+                            }
+                        )
+                    }
+                }
+
+                ## add the Alter method
+                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+                return $mock
+            } -ModuleName $script:DSCResourceName -Verifiable
+
             ## Get the current state
             $result = Get-TargetResource @desiredState
-
-            It 'Should return the same values as passed for property SQLServer' {
+            
+            It 'Should return the same values as passed' {
                 $result.SQLServer | Should Be $desiredState.SQLServer
-            }
-
-            It 'Should return the same values as passed for property SQLInstanceName' {
                 $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
-            }
-
-            It 'Should return the same values as passed for property OptionName' {
                 $result.OptionName | Should Be $desiredState.OptionName
-            }
-
-            It 'Should return the same values as passed for property OptionValue' {
                 $result.OptionValue | Should Not Be $desiredState.OptionValue
-            }
-
-            It 'Should return the same values as passed for property RestartService' {
                 $result.RestartService | Should Be $desiredState.RestartService
-            }
-
-            It 'Should cause Test-TargetResource to return false' {
-                Test-TargetResource @desiredState | Should be $false
+                $result.RestartTimeout | Should Be $desiredState.RestartTimeout
             }
 
             It 'Should call Connect-SQL mock when getting the current state' {
-                Get-TargetResource @desiredState
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Describe -Times 2
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
+        }
+
+        Context 'The system is in the desired state' {
+
+            Mock -CommandName Connect-SQL -MockWith {
+                $mock = New-Object PSObject -Property @{ 
+                    Configuration = @{
+                        Properties = @(
+                            @{
+                                DisplayName = "user connections"
+                                ConfigValue = 500
+                            }
+                        )
+                    }
+                }
+
+                ## add the Alter method
+                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+                return $mock
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            ## Get the current state
+            $result = Get-TargetResource @desiredState
+
+            It 'Should return the same values as passed' {
+                $result.SQLServer | Should Be $desiredState.SQLServer
+                $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
+                $result.OptionName | Should Be $desiredState.OptionName
+                $result.OptionValue | Should Be $desiredState.OptionValue
+                $result.RestartService | Should Be $desiredState.RestartService
+                $result.RestartTimeout | Should Be $desiredState.RestartTimeout
+            }
+
+            It 'Should call Connect-SQL mock when getting the current state' {
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
+            }
+        }
+
+        Context 'Invalid data is supplied' {
+
+            Mock -CommandName Connect-SQL -MockWith {
+                $mock = New-Object PSObject -Property @{ 
+                    Configuration = @{
+                        Properties = @(
+                            @{
+                                DisplayName = "user connections"
+                                ConfigValue = 0
+                            }
+                        )
+                    }
+                }
+
+                ## add the Alter method
+                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+                return $mock
+            } -ModuleName $script:DSCResourceName -Verifiable
 
             It 'Should call New-TerminatingError mock when a bad option name is specified' {
                 { Get-TargetResource @invalidOption } | Should Throw
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope Describe -Times 1
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
             }
-        }   
-    }
-    #endregion Test getting the current state
 
-    #region Test testing the current state
+            It 'Should throw the correct error type' {
+                { Get-TargetResource @invalidOption } | Should Throw 'ConfigurationOptionNotFound'
+            }
+
+            It 'Should call Connect-SQL mock when getting the state' {
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 2
+            }
+        }
+    }
+
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
         
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
@@ -147,14 +203,15 @@ try
             return $mock
         } -ModuleName $script:DSCResourceName -Verifiable
 
-        ## Test-TargetResource should return true when in the desired state
+        It 'Should cause Test-TargetResource to return false when not in the desired state' {
+            Test-TargetResource @defaultState | Should be $false
+        }
+
         It 'Should cause Test-TargetResource method to return true' {
             Test-TargetResource @desiredState | Should be $true
         }
     }
-    #endregion Test testing the current state
 
-    #region Test setting the desired state
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
@@ -198,7 +255,9 @@ try
             return $mock
         } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq "CLU02" }
 
-        Mock -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -MockWith {} -Verifiable
+        Mock -CommandName Restart-SqlService -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock -CommandName New-WarningMessage -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'Change the system to the desired state' {
             It 'Should not restart SQL for a dynamic option' {
@@ -213,17 +272,17 @@ try
             
             It 'Should warn about restart when required, but not requested' {
                 Set-TargetResource @desiredState
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-WarningMessage -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
             }
 
             It 'Should call Connect-SQL to get option values' {
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Describe -Times 3
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 3
             }
         }
     }
-    #endregion Test setting the desired state
 
-    #region Non-Exported Function Unit Tests
     InModuleScope $script:DSCResourceName {
         Describe 'Testing Restart-SqlService' {
 
@@ -231,23 +290,31 @@ try
 
             Context 'Restart-SqlService standalone instance' {
 
-                Mock -ModuleName $script:DSCResourceName -CommandName Connect-SQL -MockWith {
+                Mock -CommandName Connect-SQL -MockWith {
                     return @{
                         Name = "MSSQLSERVER"
                         InstanceName = ""
                         ServiceName = "MSSQLSERVER"
                     }
-                } -Verifiable -ParameterFilter { $SQLInstanceName -eq "MSSQLSERVER" }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "MSSQLSERVER" }
 
-                Mock -ModuleName $script:DSCResourceName -CommandName Connect-SQL -MockWith {
+                Mock -CommandName Connect-SQL -MockWith {
                     return @{
                         Name = "NOAGENT"
                         InstanceName = "NOAGENT"
                         ServiceName = "NOAGENT"
                     }
-                } -Verifiable -ParameterFilter { $SQLInstanceName -eq "NOAGENT" }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "NOAGENT" }
 
-                ## Mock Get-Service
+                Mock -CommandName Connect-SQL -MockWith {
+                    return @{
+                        Name = "STOPPEDAGENT"
+                        InstanceName = "STOPPEDAGENT"
+                        ServiceName = "STOPPEDAGENT"
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "STOPPEDAGENT" }
+
+                ## SQL instance with running SQL Agent Service
                 Mock -CommandName Get-Service {
                     return @{
                         Name = "MSSQLSERVER"
@@ -263,7 +330,7 @@ try
                     }
                 } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (MSSQLSERVER)" }
 
-                ## Mock Get-Service for non-clustered, no agent instance
+                ## SQL instance with no installed SQL Agent Service
                 Mock -CommandName Get-Service {
                     return @{
                         Name = 'MSSQL$NOAGENT'
@@ -272,48 +339,86 @@ try
                     }
                 } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (NOAGENT)" }
 
+                ## SQL instance with stopped SQL Agent Service
+                Mock -CommandName Get-Service {
+                    return @{
+                        Name = 'MSSQL$STOPPEDAGENT'
+                        DisplayName = 'Microsoft SQL Server (STOPPEDAGENT)'
+                        DependentServices = @(
+                            @{ 
+                                Name = 'SQLAGENT$STOPPEDAGENT'
+                                DisplayName = 'SQL Server Agent (STOPPEDAGENT)'
+                                Status = 'Stopped'
+                                DependentServices = @()
+                            }
+                        )
+                    }
+                } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (STOPPEDAGENT)" }
+
                 Mock -CommandName Restart-Service {} -Verifiable
 
                 Mock -CommandName Start-Service {} -Verifiable
 
-                It 'Should not throw an exception when restarting a default instance' {
+                It 'Should restart SQL Service and running SQL Agent service' {
                     { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "MSSQLSERVER" } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 1
                 }
 
-                It 'Should not throw an exception when restarting an instance with no SQL Agent' {
+                It 'Should restart SQL Service and not try to restart missing SQL Agent service' {
                     { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "NOAGENT" } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
                 }
 
-                It 'Should use mock methods a specific number of times' {
-                    Assert-MockCalled -CommandName Get-Service -Scope Context -Exactly -Times 2
-                    Assert-MockCalled -CommandName Restart-Service -Scope Context -Exactly -Times 2
-                    Assert-MockCalled -CommandName Start-Service -Scope Context -Exactly -Times 1
+                It 'Should restart SQL Service and not try to restart stopped SQL Agent service' {
+                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "STOPPEDAGENT" } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 0
                 }
             }
 
             Context 'Restart-SqlService clustered instance' {
                 
-                Mock -ModuleName $script:DSCResourceName -CommandName Connect-SQL -MockWith {
+                Mock -CommandName Connect-SQL -MockWith {
                     return @{
                         Name = "MSSQLSERVER"
                         InstanceName = ""
                         ServiceName = "MSSQLSERVER"
                         IsClustered = $true
                     }
-                } -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "MSSQLSERVER") }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "MSSQLSERVER") }
 
-                Mock -ModuleName $script:DSCResourceName -CommandName Connect-SQL -MockWith {
+                Mock -CommandName Connect-SQL -MockWith {
                     return @{
                         Name = "NAMEDINSTANCE"
                         InstanceName = "NAMEDINSTANCE"
                         ServiceName = "NAMEDINSTANCE"
                         IsClustered = $true
                     }
-                } -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "NAMEDINSTANCE") }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "NAMEDINSTANCE") }
+
+                Mock -CommandName Connect-SQL -MockWith {
+                    return @{
+                        Name = "STOPPEDAGENT"
+                        InstanceName = "STOPPEDAGENT"
+                        ServiceName = "STOPPEDAGENT"
+                        IsClustered = $true
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "STOPPEDAGENT") }
 
                 ## Mock Get-WmiObject for SQL Instance
                 Mock -CommandName Get-WmiObject {
-                    return @("MSSQLSERVER","NAMEDINSTANCE") | ForEach-Object {
+                    return @("MSSQLSERVER","NAMEDINSTANCE","STOPPEDAGENT") | ForEach-Object {
                         $mock = New-Object PSObject -Property @{
                             Name = "SQL Server ($($_))"
                             PrivateProperties = @{
@@ -322,6 +427,7 @@ try
                         }
 
                         $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $TimeOut ) }
+                        $mock | Add-Member -MemberType ScriptMethod -Name BringOnline -Value { param ( [int] $Timeout ) }
 
                         return $mock
                     }
@@ -329,39 +435,57 @@ try
 
                 ## Mock Get-WmiObject for SQL Agent
                 Mock -CommandName Get-WmiObject {
-                    return @("MSSQLSERVER","NAMEDINSTANCE") | ForEach-Object {
+                    if ($Query -imatch "SQL Server \((\w+)\)")
+                    {
+                        $serviceName = $Matches[1]
+
                         $mock = New-Object PSObject -Property @{
-                            Name = "SQL Server Agent (MSSQLSERVER)"
+                            Name = "SQL Server Agent ($serviceName)"
                             Type = "SQL Server Agent"
+                            State = (@{ $true = 3; $false = 2 }[($serviceName -eq "STOPPEDAGENT")])
                         }
 
-                        $mock | Add-Member -MemberType ScriptMethod -Name BringOnline -Value { param ( [int] $TimeOut ) }
+                        $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $TimeOut ) }
+                        $mock | Add-Member -MemberType ScriptMethod -Name BringOnline -Value { param ( [int] $Timeout ) }
 
-                        return $mock
+                        return $mock 
                     }
                 } -Verifiable -ParameterFilter { $Query -match "^ASSOCIATORS OF" }
 
-                It 'Should not throw an exception when restarting a default instance' {
+                It 'Should restart SQL Server and SQL Agent resources for a clustered default instance' {
                     { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "MSSQLSERVER" } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2
+
+                    ## 5 Verbose Messages equates to Get SQL, Get Agent, Stop SQL, Start SQL, Start Agent
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Exactly -Times 5
                 }
 
-                It 'Should not throw an exception when restarting a named instance' {
+                It 'Should restart SQL Server and SQL Agent resources for a clustered named instance' {
                     { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "NAMEDINSTANCE" } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2
+
+                    ## 5 Verbose Messages equates to Get SQL, Get Agent, Stop SQL, Start SQL, Start Agent
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Exactly -Times 5
                 }
 
-                It 'Should use mock methods a specific number of times' {
-                    Assert-MockCalled -Scope Context -CommandName Get-WmiObject -Exactly -Times 4
+                It 'Should not try to restart a SQL Agent resource that is not online' {
+                    { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "STOPPEDAGENT" } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2
+
+                    ## 4 Verbose Messages equates to Get SQL, Get Agent, Stop SQL, Start SQL
+                    Assert-MockCalled -CommandName New-VerboseMessage -Scope It -Exactly -Times 4
                 }
             }
         }
     }
-    #endregion Non-Exported Function Unit Tests
 }
 finally
 {
-    #region FOOTER
-
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
-    #endregion
 }

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -107,7 +107,7 @@ try
                 $result.RestartService | Should Be $desiredState.RestartService
             }
 
-            It 'Test method returns false' {
+            It 'Should cause Test-TargetResource to return false' {
                 Test-TargetResource @desiredState | Should be $false
             }
 
@@ -148,7 +148,7 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         ## Test-TargetResource should return true when in the desired state
-        It 'Test method returns true' {
+        It 'Should cause Test-TargetResource method to return true' {
             Test-TargetResource @desiredState | Should be $true
         }
     }

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -28,6 +28,9 @@ $desiredState = @{
     RestartService = $False
 }
 
+## compile the SMO stub
+Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
 # Begin Testing
 try
 {
@@ -127,9 +130,6 @@ try
     #region Non-Exported Function Unit Tests
     InModuleScope $script:DSCResourceName {
         Describe "Testing Restart-SqlService" {
-            
-            ## compile the SMO stub
-            Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
             Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -426,7 +426,7 @@ try
                             }
                         }
 
-                        $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $TimeOut ) }
+                        $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $Timeout ) }
                         $mock | Add-Member -MemberType ScriptMethod -Name BringOnline -Value { param ( [int] $Timeout ) }
 
                         return $mock
@@ -445,7 +445,7 @@ try
                             State = (@{ $true = 3; $false = 2 }[($serviceName -eq "STOPPEDAGENT")])
                         }
 
-                        $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $TimeOut ) }
+                        $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $Timeout ) }
                         $mock | Add-Member -MemberType ScriptMethod -Name BringOnline -Value { param ( [int] $Timeout ) }
 
                         return $mock 

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -129,7 +129,7 @@ try
         Describe "Testing Restart-SqlService" {
             
             ## compile the SMO stub
-            Add-Type -Path .\Stubs\SMO.cs
+            Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
             Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -57,27 +57,27 @@ try
             return $mock
         } -ModuleName $script:DSCResourceName -Verifiable
 
-        Context "Validate returned properties" {
+        Context 'Validate returned properties' {
             ## Get the current state
             $result = Get-TargetResource @desiredState
 
-            It "Property: SQLServer" {
+            It 'Property: SQLServer' {
                 $result.SQLServer | Should Be $desiredState.SQLServer
             }
 
-            It "Property: SQLInstanceName" {
+            It 'Property: SQLInstanceName' {
                 $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
             }
 
-            It "Property: OptionName" {
+            It 'Property: OptionName' {
                 $result.OptionName | Should Be $desiredState.OptionName
             }
 
-            It "Property: OptionValue" {
+            It 'Property: OptionValue' {
                 $result.OptionValue | Should Not Be $desiredState.OptionValue
             }
 
-            It "Property: RestartService" {
+            It 'Property: RestartService' {
                 $result.RestartService | Should Be $desiredState.RestartService
             }
         }
@@ -129,11 +129,11 @@ try
 
     #region Non-Exported Function Unit Tests
     InModuleScope $script:DSCResourceName {
-        Describe "Testing Restart-SqlService" {
+        Describe 'Testing Restart-SqlService' {
 
             Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
-            Context "Standalone Service Restart" {
+            Context 'Standalone Service Restart' {
 
                 ## Mock Get-Service
                 Mock -CommandName Get-Service {
@@ -163,7 +163,7 @@ try
 
                 Mock -CommandName Start-Service {} -Verifiable
 
-                It "Restart instance" {
+                It 'Restart instance' {
                     $Sql = New-Object Microsoft.SqlServer.Management.Smo.Server 
                     $Sql.Name = "MSSQLSERVER"
                     $Sql.InstanceName = ""
@@ -173,7 +173,7 @@ try
                     { Restart-SqlService -ServerObject $Sql } | Should Not Throw
                 }
 
-                It "Restart instance without Agent" {
+                It 'Restart instance without Agent' {
                     $Sql = New-Object Microsoft.Sqlserver.Management.Smo.Server
                     $Sql.Name = "NOAGENT"
                     $Sql.InstanceName = "NOAGENT"
@@ -182,14 +182,14 @@ try
                     { Restart-SqlService -ServerObject $Sql } | Should Not Throw
                 }
 
-                It "Assert Restart-SqlService called Mocks" {
+                It 'Assert Restart-SqlService called Mocks' {
                     Assert-MockCalled -CommandName Get-Service -Scope Context -Times 2
                     Assert-MockCalled -CommandName Restart-Service -Scope Context -Times 2
                     Assert-MockCalled -CommandName Start-Service -Scope Context -Times 1
                 }
             }
 
-            Context "Clustered Service Restart" {
+            Context 'Clustered Service Restart' {
                 
                 ## Mock Get-WmiObject for SQL Instance
                 Mock -CommandName Get-WmiObject {
@@ -213,7 +213,7 @@ try
                     return $mock
                 } -Verifiable -ParameterFilter { $Filter -imatch "Type = 'SQL Server Agent'" }
 
-                It "Restart default instance" {
+                It 'Restart default instance' {
                     $Sql = New-Object Microsoft.SqlServer.Management.Smo.Server 
                     $Sql.Name = "MSSQLSERVER"
                     $Sql.InstanceName = ""
@@ -223,7 +223,7 @@ try
                     { Restart-SqlService -ServerObject $Sql } | Should Not Throw
                 }
 
-                It "Restart named instance" {
+                It 'Restart named instance' {
                     $Sql = New-Object Microsoft.SqlServer.Management.Smo.Server 
                     $Sql.Name = "NAMEDINSTANCE"
                     $Sql.InstanceName = ""
@@ -233,7 +233,7 @@ try
                     { Restart-SqlService -ServerObject $Sql } | Should Not Throw
                 }
 
-                It "Assert Restart-SqlService called Mock" {
+                It 'Assert Restart-SqlService called Mock' {
                     Assert-MockCalled -Scope Context -CommandName Get-WmiObject -Times 4
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -17,45 +17,45 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Unit 
 
 $defaultState = @{
-    SQLServer = "CLU01"
-    SQLInstanceName = "ClusteredInstance"
-    OptionName = "user connections"
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
     OptionValue = 0
     RestartService = $false
     RestartTimeout = 120
 }
 
 $desiredState = @{
-    SQLServer = "CLU01"
-    SQLInstanceName = "ClusteredInstance"
-    OptionName = "user connections"
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
     OptionValue = 500
     RestartService = $false
     RestartTimeout = 120
 }
 
 $desiredStateRestart = @{
-    SQLServer = "CLU01"
-    SQLInstanceName = "ClusteredInstance"
-    OptionName = "user connections"
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
     OptionValue = 5000
     RestartService = $true
     RestartTimeout = 120
 }
 
 $dynamicOption = @{
-    SQLServer = "CLU02"
-    SQLInstanceName = "ClusteredInstance"
-    OptionName = "show advanced options"
+    SQLServer = 'CLU02'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'show advanced options'
     OptionValue = 0
     RestartService = $false
     RestartTimeout = 120
 }
 
 $invalidOption = @{
-    SQLServer = "CLU01"
-    SQLInstanceName = "MSSQLSERVER"
-    OptionName = "Does Not Exist"
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'MSSQLSERVER'
+    OptionName = 'Does Not Exist'
     OptionValue = 1
     RestartService = $false
     RestartTimeout = 120
@@ -79,7 +79,7 @@ try
                     Configuration = @{
                         Properties = @(
                             @{
-                                DisplayName = "user connections"
+                                DisplayName = 'user connections'
                                 ConfigValue = 0
                             }
                         )
@@ -116,7 +116,7 @@ try
                     Configuration = @{
                         Properties = @(
                             @{
-                                DisplayName = "user connections"
+                                DisplayName = 'user connections'
                                 ConfigValue = 500
                             }
                         )
@@ -153,7 +153,7 @@ try
                     Configuration = @{
                         Properties = @(
                             @{
-                                DisplayName = "user connections"
+                                DisplayName = 'user connections'
                                 ConfigValue = 0
                             }
                         )
@@ -167,16 +167,9 @@ try
             } -ModuleName $script:DSCResourceName -Verifiable
 
             It 'Should call New-TerminatingError mock when a bad option name is specified' {
-                { Get-TargetResource @invalidOption } | Should Throw
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
-            }
-
-            It 'Should throw the correct error type' {
                 { Get-TargetResource @invalidOption } | Should Throw 'ConfigurationOptionNotFound'
-            }
-
-            It 'Should call Connect-SQL mock when getting the state' {
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 2
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
     }
@@ -190,7 +183,7 @@ try
                 Configuration = @{
                     Properties = @(
                         @{
-                            DisplayName = "user connections"
+                            DisplayName = 'user connections'
                             ConfigValue = 500
                         }
                     )
@@ -222,7 +215,7 @@ try
                 Configuration = @{
                     Properties = @(
                         @{
-                            DisplayName = "user connections"
+                            DisplayName = 'user connections'
                             ConfigValue = 0
                             IsDynamic = $false
                         }
@@ -234,14 +227,14 @@ try
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq "CLU01" }
+        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU01' }
 
         Mock -CommandName Connect-SQL -MockWith {
             $mock = New-Object PSObject -Property @{ 
                 Configuration = @{
                     Properties = @(
                         @{
-                            DisplayName = "show advanced options"
+                            DisplayName = 'show advanced options'
                             ConfigValue = 1
                             IsDynamic = $true
                         }
@@ -253,7 +246,7 @@ try
             $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
             return $mock
-        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq "CLU02" }
+        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU02' }
 
         Mock -CommandName Restart-SqlService -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
@@ -292,43 +285,43 @@ try
 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "MSSQLSERVER"
-                        InstanceName = ""
-                        ServiceName = "MSSQLSERVER"
+                        Name = 'MSSQLSERVER'
+                        InstanceName = ''
+                        ServiceName = 'MSSQLSERVER'
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "MSSQLSERVER" }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq 'MSSQLSERVER' }
 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "NOAGENT"
-                        InstanceName = "NOAGENT"
-                        ServiceName = "NOAGENT"
+                        Name = 'NOAGENT'
+                        InstanceName = 'NOAGENT'
+                        ServiceName = 'NOAGENT'
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "NOAGENT" }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq 'NOAGENT' }
 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "STOPPEDAGENT"
-                        InstanceName = "STOPPEDAGENT"
-                        ServiceName = "STOPPEDAGENT"
+                        Name = 'STOPPEDAGENT'
+                        InstanceName = 'STOPPEDAGENT'
+                        ServiceName = 'STOPPEDAGENT'
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq "STOPPEDAGENT" }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLInstanceName -eq 'STOPPEDAGENT' }
 
                 ## SQL instance with running SQL Agent Service
                 Mock -CommandName Get-Service {
                     return @{
-                        Name = "MSSQLSERVER"
-                        DisplayName = "Microsoft SQL Server (MSSQLSERVER)"
+                        Name = 'MSSQLSERVER'
+                        DisplayName = 'Microsoft SQL Server (MSSQLSERVER)'
                         DependentServices = @(
                             @{ 
-                                Name = "SQLSERVERAGENT"
-                                DisplayName = "SQL Server Agent (MSSQLSERVER)"
-                                Status = "Running"
+                                Name = 'SQLSERVERAGENT'
+                                DisplayName = 'SQL Server Agent (MSSQLSERVER)'
+                                Status = 'Running'
                                 DependentServices = @()
                             }
                         )
                     }
-                } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (MSSQLSERVER)" }
+                } -Verifiable -ParameterFilter { $DisplayName -eq 'SQL Server (MSSQLSERVER)' }
 
                 ## SQL instance with no installed SQL Agent Service
                 Mock -CommandName Get-Service {
@@ -337,7 +330,7 @@ try
                         DisplayName = 'Microsoft SQL Server (NOAGENT)'
                         DependentServices = @()
                     }
-                } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (NOAGENT)" }
+                } -Verifiable -ParameterFilter { $DisplayName -eq 'SQL Server (NOAGENT)' }
 
                 ## SQL instance with stopped SQL Agent Service
                 Mock -CommandName Get-Service {
@@ -353,14 +346,14 @@ try
                             }
                         )
                     }
-                } -Verifiable -ParameterFilter { $DisplayName -eq "SQL Server (STOPPEDAGENT)" }
+                } -Verifiable -ParameterFilter { $DisplayName -eq 'SQL Server (STOPPEDAGENT)' }
 
                 Mock -CommandName Restart-Service {} -Verifiable
 
                 Mock -CommandName Start-Service {} -Verifiable
 
                 It 'Should restart SQL Service and running SQL Agent service' {
-                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "MSSQLSERVER" } | Should Not Throw
+                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName 'MSSQLSERVER' } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
@@ -369,7 +362,7 @@ try
                 }
 
                 It 'Should restart SQL Service and not try to restart missing SQL Agent service' {
-                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "NOAGENT" } | Should Not Throw
+                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName 'NOAGENT' } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
@@ -378,7 +371,7 @@ try
                 }
 
                 It 'Should restart SQL Service and not try to restart stopped SQL Agent service' {
-                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName "STOPPEDAGENT" } | Should Not Throw
+                    { Restart-SqlService -SQLServer $env:ComputerName -SQLInstanceName 'STOPPEDAGENT' } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-Service -Scope It -Exactly -Times 1
@@ -391,34 +384,34 @@ try
                 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "MSSQLSERVER"
-                        InstanceName = ""
-                        ServiceName = "MSSQLSERVER"
+                        Name = 'MSSQLSERVER'
+                        InstanceName = ''
+                        ServiceName = 'MSSQLSERVER'
                         IsClustered = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "MSSQLSERVER") }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq 'CLU01') -and ($SQLInstanceName -eq 'MSSQLSERVER') }
 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "NAMEDINSTANCE"
-                        InstanceName = "NAMEDINSTANCE"
-                        ServiceName = "NAMEDINSTANCE"
+                        Name = 'NAMEDINSTANCE'
+                        InstanceName = 'NAMEDINSTANCE'
+                        ServiceName = 'NAMEDINSTANCE'
                         IsClustered = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "NAMEDINSTANCE") }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq 'CLU01') -and ($SQLInstanceName -eq 'NAMEDINSTANCE') }
 
                 Mock -CommandName Connect-SQL -MockWith {
                     return @{
-                        Name = "STOPPEDAGENT"
-                        InstanceName = "STOPPEDAGENT"
-                        ServiceName = "STOPPEDAGENT"
+                        Name = 'STOPPEDAGENT'
+                        InstanceName = 'STOPPEDAGENT'
+                        ServiceName = 'STOPPEDAGENT'
                         IsClustered = $true
                     }
-                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq "CLU01") -and ($SQLInstanceName -eq "STOPPEDAGENT") }
+                } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { ($SQLServer -eq 'CLU01') -and ($SQLInstanceName -eq 'STOPPEDAGENT') }
 
                 ## Mock Get-WmiObject for SQL Instance
                 Mock -CommandName Get-WmiObject {
-                    return @("MSSQLSERVER","NAMEDINSTANCE","STOPPEDAGENT") | ForEach-Object {
+                    return @('MSSQLSERVER','NAMEDINSTANCE','STOPPEDAGENT') | ForEach-Object {
                         $mock = New-Object PSObject -Property @{
                             Name = "SQL Server ($($_))"
                             PrivateProperties = @{
@@ -435,14 +428,14 @@ try
 
                 ## Mock Get-WmiObject for SQL Agent
                 Mock -CommandName Get-WmiObject {
-                    if ($Query -imatch "SQL Server \((\w+)\)")
+                    if ($Query -imatch 'SQL Server \((\w+)\)')
                     {
                         $serviceName = $Matches[1]
 
                         $mock = New-Object PSObject -Property @{
                             Name = "SQL Server Agent ($serviceName)"
-                            Type = "SQL Server Agent"
-                            State = (@{ $true = 3; $false = 2 }[($serviceName -eq "STOPPEDAGENT")])
+                            Type = 'SQL Server Agent'
+                            State = (@{ $true = 3; $false = 2 }[($serviceName -eq 'STOPPEDAGENT')])
                         }
 
                         $mock | Add-Member -MemberType ScriptMethod -Name TakeOffline -Value { param ( [int] $Timeout ) }
@@ -450,10 +443,10 @@ try
 
                         return $mock 
                     }
-                } -Verifiable -ParameterFilter { $Query -match "^ASSOCIATORS OF" }
+                } -Verifiable -ParameterFilter { $Query -match '^ASSOCIATORS OF' }
 
                 It 'Should restart SQL Server and SQL Agent resources for a clustered default instance' {
-                    { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "MSSQLSERVER" } | Should Not Throw
+                    { Restart-SqlService -SQLServer 'CLU01' -SQLInstanceName 'MSSQLSERVER' } | Should Not Throw
                     
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2
@@ -463,7 +456,7 @@ try
                 }
 
                 It 'Should restart SQL Server and SQL Agent resources for a clustered named instance' {
-                    { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "NAMEDINSTANCE" } | Should Not Throw
+                    { Restart-SqlService -SQLServer 'CLU01' -SQLInstanceName 'NAMEDINSTANCE' } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2
@@ -473,7 +466,7 @@ try
                 }
 
                 It 'Should not try to restart a SQL Agent resource that is not online' {
-                    { Restart-SqlService -SQLServer "CLU01" -SQLInstanceName "STOPPEDAGENT" } | Should Not Throw
+                    { Restart-SqlService -SQLServer 'CLU01' -SQLInstanceName 'STOPPEDAGENT' } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-WmiObject -Scope It -Exactly -Times 2

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -130,6 +130,8 @@ namespace Microsoft.SqlServer.Management.Smo
         public string Name;
         public string DisplayName;
         public string InstanceName;
+        public string ServiceName;
+        public bool IsClustered = false;
         public bool IsHadrEnabled = false;
 
         public Server(){} 

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -33,5 +33,6 @@ PrincipalNotFound = Principal {0} does not exist.
 PermissionMissingEnsure = Ensure is not set. No change can be made.
 
 # Configuration
-ConfigurationOptionNotFound = Specified option {0} could not be found.
+ConfigurationOptionNotFound = Specified option '{0}' could not be found.
+ConfigurationRestartRequired = Configuration option '{0}' has been updated, but a manual restart of SQL Server is required for it to take effect.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -31,4 +31,7 @@ EndpointErrorVerifyExist = Unexpected result when trying to verify existence of 
 PermissionGetError = Unexpected result when trying to get permissions for {0}.
 PrincipalNotFound = Principal {0} does not exist.
 PermissionMissingEnsure = Ensure is not set. No change can be made.
+
+# Configuration
+ConfigurationOptionNotFound = Specified option {0} could not be found.
 '@

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -128,6 +128,55 @@ function New-TerminatingError
     return $errorRecord
 }
 
+<#
+    .SYNOPSIS
+    Displays a localized warning message
+
+    .PARAMETER WarningType
+    String containing the key of the localized warning message
+    
+    .PARAMETER FormatArgs
+    Collection of strings to replace format objects in warning message.
+#>
+function New-WarningMessage
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $WarningType,
+
+        [Parameter(Mandatory = $false)]
+        [String[]]
+        $FormatArgs
+    )
+
+    ## Attempt to get the string from the localized data
+    $warningMessage = $LocalizedData.$WarningType
+
+    ## Ensure there is a message present in the localization file
+    if (!$warningMessage)
+    {
+        $errorParams = @{
+            ErrorType = 'NoKeyFound'
+            FormatArgs = $WarningType
+            ErrorCategory = 'InvalidArgument'
+            TargetObject = 'New-WarningMessage'
+        }
+
+        ## Raise an error indicating the localization data is not present
+        throw New-TerminatingError @errorParams 
+    }
+
+    ## Apply formatting
+    $warningMessage = $warningMessage -f $FormatArgs
+
+    ## Write the message as a warning
+    Write-Warning -Message $warningMessage
+}
+
 function New-VerboseMessage
 {
     [CmdletBinding()]

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -148,7 +148,6 @@ function New-WarningMessage
         [String]
         $WarningType,
 
-        [Parameter(Mandatory = $false)]
         [String[]]
         $FormatArgs
     )


### PR DESCRIPTION
The xSQLServerConfiguration resource only supported changing configuration values for the local computer, not for clustered instances. This PR makes the following changes:
- Updated MOF and resource parameters to be consistent with other resources [**BREAKING CHANGE**]
- Now using helper function Connect-SQL
- Created new internal restart function that supports clusters
- Removed unused internal functions and objects
- Created unit tests per template (Issue #92)
- Updated README to reflect changes

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/143)

<!-- Reviewable:end -->
