### PR TITLE
Fix Ensure equal Present in xSQLServerRole resource (Fixes #151,#165)

### DIFF
--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
@@ -1,7 +1,4 @@
-$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-Write-Debug -Message "CurrentPath: $currentPath"
-
-Import-Module -Name $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'xSQLServerHelper.psm1') -Force
 
 function Get-TargetResource
 {

--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
@@ -89,6 +89,7 @@ function Set-TargetResource
 
     if ($sql)
     {
+        Write-Verbose "Setting SQL Server roles for $Name on SQL Server $SQLServer."
         if ($Ensure -eq 'Present')
         {
             Add-SqlServerRoleMember -SQL $sql -LoginName $Name -ServerRole $ServerRole

--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure,
+        $Ensure = "Present",
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -76,7 +76,7 @@ function Set-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure,
+        $Ensure = "Present",
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -121,7 +121,7 @@ function Test-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure,
+        $Ensure = "Present",
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -138,10 +138,14 @@ function Test-TargetResource
     )
 
     Write-Verbose -Message "Testing SQL roles for login $Name"
+     
     $currentValues = Get-TargetResource @PSBoundParameters
-    
-    $result = ($currentValues.Ensure -eq $Ensure) -and ($currentValues.ServerRole -eq $ServerRole) -and ($currentValues.Name -eq $Name)
-    $result    
+    $PSBoundParameters.Ensure = $Ensure
+    return Test-SQLDscParameterState -CurrentValues $CurrentValues `
+                                     -DesiredValues $PSBoundParameters `
+                                     -ValuesToCheck @("Name", 
+                                                      "ServerRole",
+                                                      "Ensure")
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
@@ -1,11 +1,7 @@
 $currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 Write-Debug -Message "CurrentPath: $currentPath"
 
-# Load Common Code
-Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
-
-# DSC resource to manage SQL logins in server role
-# NOTE: This resource requires WMF5 and PsDscRunAsCredential
+Import-Module -Name $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
 
 function Get-TargetResource
 {
@@ -19,7 +15,7 @@ function Get-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -40,26 +36,26 @@ function Get-TargetResource
     if ($sql)
     {
         Write-Verbose "Getting SQL Server roles for $Name on SQL Server $SQLServer."
-        $confirmSqlServerRole = Confirm-SqlServerRole -SQL $sql -LoginName $Name -ServerRole $ServerRole
+        $confirmSqlServerRole = Confirm-SqlServerRoleMember -SQL $sql -LoginName $Name -ServerRole $ServerRole
         if ($confirmSqlServerRole)
         {
-            $Ensure = "Present"
+            $Ensure = 'Present'
         }
         else
         {
-            $Ensure = "Absent"
+            $Ensure = 'Absent'
         }
     }
     else
     {
-        $Ensure = "Absent"
+        $Ensure = 'Absent'
     }
 
     $returnValue = @{
-        Ensure = $Ensure
-        Name = $Name
-        ServerRole = $ServerRole
-        SQLServer = $SQLServer
+        Ensure          = $Ensure
+        Name            = $Name
+        ServerRole      = $ServerRole
+        SQLServer       = $SQLServer
         SQLInstanceName = $SQLInstanceName
     }
     $returnValue
@@ -76,7 +72,7 @@ function Set-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -96,14 +92,14 @@ function Set-TargetResource
 
     if ($sql)
     {
-        if ($Ensure -eq "Present")
+        if ($Ensure -eq 'Present')
         {
-            Add-SqlServerRole -SQL $sql -LoginName $Name -ServerRole $ServerRole
+            Add-SqlServerRoleMember -SQL $sql -LoginName $Name -ServerRole $ServerRole
             New-VerboseMessage -Message "SQL Roles for $Name, successfullly added"
         }
         else
         {
-            Remove-SqlServerRole -SQL $sql -LoginName $Name -ServerRole $ServerRole
+            Remove-SqlServerRoleMember -SQL $sql -LoginName $Name -ServerRole $ServerRole
             New-VerboseMessage -Message "SQL Roles for $Name, successfullly removed"
         }
     }
@@ -121,7 +117,7 @@ function Test-TargetResource
 
         [ValidateSet("Present","Absent")]
         [System.String]
-        $Ensure = "Present",
+        $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
@@ -143,9 +139,9 @@ function Test-TargetResource
     $PSBoundParameters.Ensure = $Ensure
     return Test-SQLDscParameterState -CurrentValues $CurrentValues `
                                      -DesiredValues $PSBoundParameters `
-                                     -ValuesToCheck @("Name", 
-                                                      "ServerRole",
-                                                      "Ensure")
+                                     -ValuesToCheck @('Name', 
+                                                      'ServerRole',
+                                                      'Ensure')
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.psm1
@@ -10,12 +10,12 @@ function Get-TargetResource
         [System.String]
         $Name,
 
-        [ValidateSet("Present","Absent")]
+        [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
+        [ValidateSet('bulkadmin','dbcreator','diskadmin','processadmin','public','securityadmin','serveradmin','setupadmin','sysadmin')]
         [System.String[]]
         $ServerRole,
 
@@ -67,12 +67,12 @@ function Set-TargetResource
         [System.String]
         $Name,
 
-        [ValidateSet("Present","Absent")]
+        [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
+        [ValidateSet('bulkadmin','dbcreator','diskadmin','processadmin','public','securityadmin','serveradmin','setupadmin','sysadmin')]
         [System.String[]]
         $ServerRole,
 
@@ -113,12 +113,12 @@ function Test-TargetResource
         [System.String]
         $Name,
 
-        [ValidateSet("Present","Absent")]
+        [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet("bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin")]
+        [ValidateSet('bulkadmin','dbcreator','diskadmin','processadmin','public','securityadmin','serveradmin','setupadmin','sysadmin')]
         [System.String[]]
         $ServerRole,
 

--- a/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.schema.mof
+++ b/DSCResources/MSFT_xSQLServerRole/MSFT_xSQLServerRole.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xSQLServerRole : OMI_BaseResource
 {
     [Key, Description("The name of the SQL login.  If LoginType='WindowsUser' or 'WindowsGroup', this is also the name of the user or group in format DOMAIN\name.")] String Name;
-    [Write, Description("Present to ensure that the login has the defined roles, or absent to ensure that these roles are not defined for the login."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Present to ensure that the login has the defined roles, or absent to ensure that these roles are not defined for the login. Default value is 'Present'"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Required, Description("Type of SQL role to add"), ValueMap{"bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin"}, Values{"bulkadmin","dbcreator","diskadmin","processadmin","public","securityadmin","serveradmin","setupadmin","sysadmin"}] String ServerRole[];
     [Required, Description("The SQL Server for the login.")] String SQLServer;
     [Key, Description("The SQL instance for the login.")] String SQLInstanceName;

--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xSQLServerRole
 * **Name**: (Key) Name of the SQL Login to create
+* **Ensure**: If the values should be present or absent. Valid values are 'Present' or 'Absent'.
 * **ServerRole**: Type of SQL role to add.(bulkadmin, dbcreator, diskadmin, processadmin , public, securityadmin, serveradmin , setupadmin, sysadmin)
 * **SQLServer**: SQL Server where login should be created
-* **SQLInstance**: SQL Instance for the login
+* **SQLInstance**: (Key) SQL Instance for the login
 
 ### xSQLServerDatabaseRole
 * **Name**: (Key) Name of the SQL Login or the role on the database

--- a/README.md
+++ b/README.md
@@ -353,9 +353,13 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Fixes in xSQLServerConfiguration
   - Added support for clustered SQL instances
   - BREAKING CHANGE: Updated parameters to align with other resources (SQLServer / SQLInstanceName)
-* Created unit tests for xSQLServerConfiguration resource
+* Added tests for resources
+  - xSQLServerConfiguration
 * Fixes in xSQLAOGroupJoin
   - Availability Group name now appears in the error message for a failed Availability Group join attempt.
+* Fixes in xSQLServerRole
+  - Updated Ensure parameter to 'Present' default value
+  - Renamed helper functions *-SqlServerRole to *-SqlServerRoleMember
 
 ### 3.0.0.0
 * xSQLServerHelper

--- a/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
@@ -20,7 +20,7 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
         & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
     }
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
     $TestEnvironment = Initialize-TestEnvironment `
         -DSCModuleName $script:DSCModuleName `
@@ -64,7 +64,7 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     Name = 'UnknownUser'
                 }
                 
-                Mock -CommandName Confirm-SqlServerRole -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
 
                 $result = Get-TargetResource @testParameters
 
@@ -78,9 +78,9 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result.Name | Should Be $testParameters.Name
                 }
 
-                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRole' {
+                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
                 }
             }
         
@@ -91,7 +91,7 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     Ensure = 'Present'
                 }
                 
-                Mock -CommandName Confirm-SqlServerRole -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
 
                 $result = Get-TargetResource @testParameters
 
@@ -105,15 +105,15 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result.Name | Should Be $testParameters.Name
                 }
 
-                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRole' {
+                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
                 }
             }
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "$($script:DSCResourceName)\Test-TargetResource" {
             Mock -CommandName Connect-SQL -MockWith {
                 return New-Object Object | 
@@ -127,7 +127,7 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
             Context 'When the system is not in the desired state' {            
                 It 'Should return the test as false when desired loginName does not exist' {
 
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
 
                     $testParameters = $defaultParameters
                     $testParameters += @{
@@ -139,12 +139,12 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
                 }
 
                 It 'Should return the test as false when non-desired loginName exist' {
 
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
 
                     $testParameters = $defaultParameters
                     $testParameters += @{
@@ -156,14 +156,14 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 }
             }
 
             Context 'When the system is in the desired state' {
                 It 'Should return the test as true when desired loginName exist' {
 
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
 
                     $testParameters = $defaultParameters
                     $testParameters += @{
@@ -175,12 +175,12 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result | Should Be $true
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 }
                             
                 It 'Should return the test as true when non-desired loginName does not exist' {
 
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
 
                     $testParameters = $defaultParameters
                     $testParameters += @{
@@ -192,13 +192,13 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     $result | Should Be $true
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 }
             }
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "$($script:DSCResourceName)\Set-TargetResource" {
             Mock -CommandName Connect-SQL -MockWith {
                 return New-Object Object | 
@@ -216,19 +216,19 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     Ensure = 'Present'
                 }
 
-                It 'Should call the mock function Connect-SQL and Add-SqlServerRole' {
+                It 'Should call the mock function Connect-SQL and Add-SqlServerRoleMember' {
                     
-                    Mock -CommandName Add-SqlServerRole -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Add-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
                     
                     Set-TargetResource @testParameters
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                    Assert-MockCalled Add-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 }
 
                 It 'Should return the state as present when desired loginName in server role successfully added' {
                     
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
 
                     $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Present'
@@ -242,19 +242,19 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     Ensure = 'Absent'
                 }
 
-                It 'Should call the mock function Connect-SQL and Remove-SqlServerRole' {
+                It 'Should call the mock function Connect-SQL and Remove-SqlServerRoleMember' {
 
-                    Mock -CommandName Remove-SqlServerRole -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Remove-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
 
                     Set-TargetResource @testParameters
                     
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Remove-SqlServerRole -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                    Assert-MockCalled Remove-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
                 }
 
                 It 'Should return the state as absent when desired loginName in server role successfully dropped' {
                     
-                    Mock -CommandName Confirm-SqlServerRole -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
 
                     $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'absent'

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -674,14 +674,14 @@ function Remove-SqlDatabase
     (   
         [ValidateNotNull()] 
         [System.Object]
-        $SQL,
+        $Sql,
         
         [ValidateNotNull()] 
         [System.String]
         $Name
     )
     
-    $getDatabase = $SQL.Databases[$Name]
+    $getDatabase = $Sql.Databases[$Name]
     if ($getDatabase)
     {
         New-VerboseMessage -Message "Deleting to SQL the database $Name"
@@ -693,14 +693,32 @@ function Remove-SqlDatabase
     }    
 }
 
-function Add-SqlServerRole
+<#
+.SYNOPSIS
+
+This cmdlet is used to add a loginName with a specified server role
+
+.PARAMETER Sql
+
+This is an object of the SQL server that contains the result of Connect-SQL
+
+.PARAMETER LoginName 
+
+This is the name of the SQL login
+
+.PARAMETER ServerRole
+
+This is the type of SQL role to add
+
+#>
+function Add-SqlServerRoleMember
 {
     [CmdletBinding()]    
     param
     (   
         [ValidateNotNull()] 
         [System.Object]
-        $SQL,
+        $Sql,
         
         [ValidateNotNull()] 
         [System.String]
@@ -712,7 +730,7 @@ function Add-SqlServerRole
 
     )
     
-    $sqlRole = $SQL.Roles
+    $sqlRole = $Sql.Roles
     if ($sqlRole)
     {
         try
@@ -734,14 +752,32 @@ function Add-SqlServerRole
     }
 }
 
-function Remove-SqlServerRole
+<#
+.SYNOPSIS
+
+This cmdlet is used to remove a specified server role of a loginName 
+
+.PARAMETER Sql
+
+This is an object of the SQL server that contains the result of Connect-SQL
+
+.PARAMETER LoginName 
+
+This is the name of the SQL login
+
+.PARAMETER ServerRole
+
+This is the type of SQL role to remove
+
+#>
+function Remove-SqlServerRoleMember
 {
     [CmdletBinding()]    
     param
     (   
         [ValidateNotNull()] 
         [System.Object]
-        $SQL,
+        $Sql,
         
         [ValidateNotNull()] 
         [System.String]
@@ -753,7 +789,7 @@ function Remove-SqlServerRole
 
     )
     
-    $sqlRole = $SQL.Roles
+    $sqlRole = $Sql.Roles
     if ($sqlRole)
     {
         try
@@ -775,14 +811,32 @@ function Remove-SqlServerRole
     }
 }
 
-function Confirm-SqlServerRole
+<#
+.SYNOPSIS
+
+This cmdlet is used to confirm a loginName with a specified server role
+
+.PARAMETER Sql
+
+This is an object of the SQL server that contains the result of Connect-SQL
+
+.PARAMETER LoginName 
+
+This is the name of the SQL login
+
+.PARAMETER ServerRole
+
+This is the type of SQL role to confirm
+
+#>
+function Confirm-SqlServerRoleMember
 {
     [CmdletBinding()]    
     param
     (   
         [ValidateNotNull()] 
         [System.Object]
-        $SQL,
+        $Sql,
         
         [ValidateNotNull()] 
         [System.String]
@@ -794,7 +848,7 @@ function Confirm-SqlServerRole
 
     )
     
-    $sqlRole = $SQL.Roles
+    $sqlRole = $Sql.Roles
     if ($sqlRole)
     {
         foreach ($currentServerRole in $ServerRole)


### PR DESCRIPTION
Fixes #151 and #165

Change xSQLServerRole Resource:
defaults to Ensure = Present

- [x] Change details added to Unreleased section of readme.md?
- [x] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/154)

<!-- Reviewable:end -->
