### PR TITLE
xSQLAOGroupJoin: Fix missing AG name in error message (fixes #194)

### DIFF
--- a/DSCResources/MSFT_xSQLAOGroupJoin/MSFT_xSQLAOGroupJoin.psm1
+++ b/DSCResources/MSFT_xSQLAOGroupJoin/MSFT_xSQLAOGroupJoin.psm1
@@ -94,7 +94,7 @@ function Set-TargetResource
              New-VerboseMessage -Message "Joined $SQLServer\$SQLInstanceName to $AvailabilityGroupName"       
             }
         Catch
-            {Throw "Unable to Join $AvailabilityGroup on $SQLServer\$SQLInstanceName"
+            {Throw "Unable to Join $AvailabilityGroupName on $SQLServer\$SQLInstanceName"
              Exit
             }
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   - Added support for clustered SQL instances
   - BREAKING CHANGE: Updated parameters to align with other resources (SQLServer / SQLInstanceName)
 * Created unit tests for xSQLServerConfiguration resource
+* Fixes in xSQLAOGroupJoin
+  - Availability Group name now appears in the error message for a failed Availability Group join attempt.
 
 ### 3.0.0.0
 * xSQLServerHelper


### PR DESCRIPTION
There is a bug where the Availability Group name is not output in verbose logging. This is due to the wrong variable used ($AvailabilityGroup contains $null since it's never initialized). 

We should use variable $AvailabilityGroupName instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/192)
<!-- Reviewable:end -->
