### PR TITLE
xSQLAlias: Replace WMI with CIM

### DIFF
--- a/DSCResources/MSFT_xSQLAlias/MSFT_xSQLAlias.psm1
+++ b/DSCResources/MSFT_xSQLAlias/MSFT_xSQLAlias.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
         return a value in the format 'DBNMPNTW,\\ServerName\PIPE\sql\query' or 'DBMSSOCN,ServerName.company.local,1433'
     #>
     $itemValue = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\MSSQLServer\Client\ConnectTo' -Name $Name -ErrorAction SilentlyContinue
-    if ((Get-WmiOSArchitecture) -eq '64-bit')
+    if ((Get-OSArchitecture) -eq '64-bit')
     {
         Write-Verbose "64-bit Operating System. Also get the client alias $Name from Wow6432Node"
         
@@ -125,7 +125,7 @@ function Set-TargetResource
         }
 
         # If this is a 64-bit OS then also update Wow6432Node
-        if ((Get-WmiOSArchitecture) -eq '64-bit')
+        if ((Get-OSArchitecture) -eq '64-bit')
         {
             if ($PSCmdlet.ShouldProcess($Name, 'Setting the client alias (32-bit)'))
             {
@@ -150,7 +150,7 @@ function Set-TargetResource
         }
             
         # If this is a 64-bit OS then also remove from Wow6432Node
-        if ((Get-WmiOSArchitecture) -eq '64-bit' -and (Test-Path -Path $registryPathWow6432Node))
+        if ((Get-OSArchitecture) -eq '64-bit' -and (Test-Path -Path $registryPathWow6432Node))
         {
             if ($PSCmdlet.ShouldProcess($Name, 'Remove the client alias (32-bit)'))
             {
@@ -237,9 +237,9 @@ function Test-TargetResource
     return $result
 }
 
-function Get-WmiOSArchitecture
+function Get-OSArchitecture
 {
-    return (Get-WmiObject -Class win32_OperatingSystem).OSArchitecture
+    return (Get-CimInstance -ClassName win32_OperatingSystem).OSArchitecture
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Created unit tests for xSQLServerConfiguration resource
 * Fixes in xSQLAOGroupJoin
   - Availability Group name now appears in the error message for a failed Availability Group join attempt.
+* Fixes in xSQLAlias
+  - Updated code to utilize CIM rather than WMI
+  - Renamed internal function to remove WMI reference
+  - Updated unit tests for CIM changes
 
 ### 3.0.0.0
 * xSQLServerHelper

--- a/Tests/Unit/MSFT_xSqlAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_xSqlAlias.Tests.ps1
@@ -89,10 +89,10 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         # Mocking 64-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is in the desired present state for 64-bit OS using TCP' {
             $testParameters = @{
@@ -124,7 +124,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -168,7 +168,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -209,7 +209,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -253,7 +253,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -265,10 +265,10 @@ try
         }
 
         # Mocking 32-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is in the desired present state for 32-bit OS using TCP' {
             $testParameters = @{
@@ -300,7 +300,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -346,7 +346,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -397,10 +397,10 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         # Mocking 64-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is in the desired present state for 64-bit OS using Named Pipes' {
             $testParameters = @{
@@ -435,7 +435,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -479,7 +479,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -523,7 +523,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -535,10 +535,10 @@ try
         }
 
         # Mocking 32-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is in the desired present state for 32-bit OS using Named Pipes' {
             $testParameters = @{
@@ -573,7 +573,7 @@ try
             }
 
             It 'Should call the mocked functions exactly 1 time each' {
-                Assert-MockCalled Get-WmiObject -ParameterFilter { $Class -eq 'win32_OperatingSystem' } `
+                Assert-MockCalled Get-CimInstance -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
@@ -600,10 +600,10 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         # Mocking 64-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
         
         Context 'When the system is not in the desired state for 64-bit OS using TCP' {
             It 'Should call mocked functions Test-Path, New-Item and Set-ItemProperty twice each when desired state should be present for protocol TCP' {
@@ -655,10 +655,10 @@ try
         }
 
         # Mocking 32-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is not in the desired state for 32-bit OS using TCP' {
             It 'Should call mocked functions Test-Path, New-Item and Set-ItemProperty once each when desired state should be present for protocol TCP' {
@@ -729,10 +729,10 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable
 
         # Mocking 64-bit OS
-        Mock -CommandName Get-WmiObject -MockWith {
+        Mock -CommandName Get-CimInstance -MockWith {
             return New-Object Object | 
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
-        } -ParameterFilter { $Class -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
+        } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When the system is in the desired state (when using TCP)' {
             It 'Should return state as present ($true)' {


### PR DESCRIPTION
This PR makes the following changes:

- All usage of *-WMIObject have been replaced by CIM cmdlets (Issue #203)
- Updated unit tests to validate CIM changes
- Renamed internal function Get-WmiOSArchitecture to Get-OSArchitecture to remove WMI reference
- Updated README to reflect changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/215)
<!-- Reviewable:end -->
