### PR TITLE
Improvements how tests are initiated in AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Improvements how tests are initiated in AppVeyor
+  - Removed previous workaround (issue #201) from unit tests.
+  - Changes in appveyor.yml so that SQL modules are removed before common test is run.
+
 ## 4.0.0.0
 
 - Fixes in xSQLServerConfiguration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ one resource, then the functions can also be placed in the common [xSQLServerHel
 
 ### Tests
 
-For a review of a Pull Request (PR) to start, all tests must pass without error. If you need help to figure why some test don't pass, just write a comment in the Pull Request (PR), or submit an issue, and somebody will come along an assist.
+For a review of a Pull Request (PR) to start, all tests must pass without error. If you need help to figure why some test don't pass, just write a comment in the Pull Request (PR), or submit an issue, and somebody will come along and assist.
 
 #### Using SMO stub classes
 
@@ -82,4 +82,4 @@ There are [stub classes](https://github.com/PowerShell/xSQLServer/blob/dev/Tests
 #### AppVeyor
 
 AppVeyor is the platform where the tests is run when sending in a Pull Request (PR). All tests are run on a clean AppVeyor build worker for each push to the Pull Request (PR).
-The tests that are run on the build worker are common tests, unit test and integration tests (with some limitations).
+The tests that are run on the build worker are common tests, unit tests and integration tests (with some limitations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,28 +73,13 @@ one resource, then the functions can also be placed in the common [xSQLServerHel
 
 ### Tests
 
+For a review of a Pull Request (PR) to start, all tests must pass without error. If you need help to figure why some test don't pass, just write a comment in the Pull Request (PR), or submit an issue, and somebody will come along an assist.
+
 #### Using SMO stub classes
 
 There are [stub classes](https://github.com/PowerShell/xSQLServer/blob/dev/Tests/Unit/Stubs/SMO.cs) for the SMO classes which can be used and improved on when creating tests where SMO classes are used in the code being tested.
 
 #### AppVeyor
 
-AppVeyor is the platform where the tests is run when sending in a Pull Request (PR). Due to a change in the build worker that AppVeyor provides it has already have the SMO assemblies loaded, which make our stub SMO classes unable to be initiated.
-To get around this we need to get a clean PowerShell environment to run our tests in. One way is to use `Start-Job`. So this change needs to be done to the unit test template before sending in a Pull Request (PR).
-
-```powershell
-#
-    AppVeyor build worker loads the SMO assembly which makes the SMO stub classes unable to be initiated.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-
-    # Unit test template goes here
-}
-
-$testJob | Receive-Job -Wait
-```
+AppVeyor is the platform where the tests is run when sending in a Pull Request (PR). All tests are run on a clean AppVeyor build worker for each push to the Pull Request (PR).
+The tests that are run on the build worker are common tests, unit test and integration tests (with some limitations).

--- a/Tests/Unit/MSFT_xSQLAOGroupEnsure.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLAOGroupEnsure.Tests.ps1
@@ -2,339 +2,327 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param ()
 
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-    $script:DSCModuleName      = 'xSQLServer' 
-    $script:DSCResourceName    = 'MSFT_xSQLAOGroupEnsure' 
+$script:DSCModuleName      = 'xSQLServer' 
+$script:DSCResourceName    = 'MSFT_xSQLAOGroupEnsure' 
 
-    #region HEADER
+#region HEADER
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
-    }
-
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
-
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
-
-    #endregion HEADER
-
-    try
-    {
-
-        #region Pester Test Initialization
-
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
-        $mockpassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-        $mockusername = "dba" 
-        $mockcredential = New-Object System.Management.Automation.PSCredential($mockusername,$mockpassword)
-
-        #endregion Pester Test Initialization
-        
-        #region Get-TargetResource
-        Describe 'Get-TargetResource' {
-            Mock -CommandName Connect-SQL -MockWith {
-                # build a custom object to return which is close to the real SMO object
-                $smoObj = [PSCustomObject] @{
-                    SQLServer = 'Node01'
-                    SQLInstanceName = 'Prd01'
-                    ClusterName = 'Clust01'
-                }
-
-                # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
-                $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
-                    'AG01' = @{
-                        AvailabilityGroupListeners = @{ 
-                            name = 'AgList01'
-                            availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
-                            portnumber = 5022
-                        }
-                        
-                        AvailabilityDatabases = @(
-                            @{
-                                name='AdventureWorks'
-                            } 
-                        )
-                    }
-                }
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
-                $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {
-                    return $true 
-                } -Force
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {
-                    return 'AG01'
-                } -Force
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {
-                    return $true
-                } -Force
-
-                return $smoObj
-            }  -ModuleName $script:DSCResourceName
-            
-            Context "When the system is in the desired state" {
-                $SqlAOGroup = Get-TargetResource -Ensure 'Present' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
-        
-                It 'Should return hashtable with Ensure = $true'{
-                    $SqlAOGroup.Ensure | Should Be $true
-                }
-            }
-        
-            Context "When the system is not in the desired state" {
-                $SqlAOGroup = Get-TargetResource -Ensure 'Absent' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
-        
-                It 'Should return hashtable with Ensure = $false' {
-                    $SqlAOGroup.Ensure | Should Be $false
-                }
-            }
-        }
-        #endregion Get-TargetResource
-
-        #region Test-TargetResource
-        Describe 'Test-TargetResource' {
-            Mock -CommandName Connect-SQL -MockWith {
-                # build a custom object to return which is close to the real SMO object
-                $smoObj = [PSCustomObject] @{
-                    SQLServer = 'Node01'
-                    SQLInstanceName = 'Prd01'
-                    ClusterName = 'Clust01'
-                }
-
-                # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
-                $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
-                    'AG01' = @{
-                        AvailabilityGroupListeners = @{ 
-                            name = 'AgList01'
-                            availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
-                            portnumber = 5022
-                        }
-                        
-                        AvailabilityDatabases = @(
-                            @{
-                                name='AdventureWorks'
-                            }
-                        )
-                    }
-                }
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
-                $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {
-                    return $true
-                } -Force
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {
-                    return 'AG01'
-                } -Force
-
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {
-                    return $true
-                } -Force
-
-                return $smoObj
-            } -ModuleName $script:DSCResourceName
-        
-            Context "When the system is in the desired state" {
-                $SqlAOGroupTest = Test-TargetResource -Ensure 'Present' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
-        
-                It 'Should return $true'{
-                    $SqlAOGroupTest | Should Be $true
-                }
-            }
-        
-            Context "When the system is not in the desired state" {
-                $SqlAOGroupTest = Test-TargetResource -Ensure 'Absent' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
-        
-                It 'Should return $false' {
-                    $SqlAOGroupTest | Should Be $false
-                }
-            }
-        }
-        #endregion Test-TargetResource
-
-        Describe 'Set-TargetResource' {
-            # Mocking the module FailoverCluster, to be able to mock the function Get-ClusterNode
-            Get-Module -Name FailoverClusters | Remove-Module
-            New-Module -Name FailoverClusters  -ScriptBlock {
-                # This was generated by Write-ModuleStubFile function from the folder Tests\Unit\Stubs
-                function Get-ClusterNode {
-                    [CmdletBinding(DefaultParameterSetName='InputObject', HelpUri='http://go.microsoft.com/fwlink/?LinkId=216215')]
-                    param(
-                        [Parameter(Position=0)]
-                        [ValidateNotNullOrEmpty()]
-                        [System.Collections.Specialized.StringCollection]
-                        ${Name},
-
-                        [Parameter(ParameterSetName='InputObject', ValueFromPipeline=$true)]
-                        [ValidateNotNull()]
-                        [psobject]
-                        ${InputObject},
-
-                        [ValidateNotNullOrEmpty()]
-                        [string]
-                        ${Cluster}
-                    )
-
-                    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
-                }
-            
-                Export-ModuleMember -Function *-Cluster*
-            } | Import-Module -Force
-
-            Mock Grant-ServerPerms -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-            Mock New-ListenerADObject -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-            Mock Get-ClusterNode -MockWith {
-                $clusterNode = @(
-                    [PSCustomObject] @{
-                        Name = 'Node01'
-                    }, 
-                    [PSCustomObject] @{
-                        Name = 'Node02'
-                    },
-                    [PSCustomObject] @{
-                        Name = 'Node03'
-                    },
-                    [PSCustomObject] @{
-                        Name = 'Node04'
-                    }
-                )
-                return $clusterNode
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Mock Connect-SQL -MockWith {
-                # build a custom object to return which is close to the real SMO object
-                $smoObj = [PSCustomObject] @{
-                    SQLServer = 'Node01'
-                    SQLInstanceName = 'Prd01'
-                    ClusterName = 'Clust01'
-                }
-
-                # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
-                $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
-                    'AG01' = @{
-                        AvailabilityGroupListeners = @{ 
-                            name = 'AgList01'
-                            availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
-                            portnumber = 5022
-                        }
-
-                        AvailabilityDatabases = @(
-                            @{
-                                name='AdventureWorks'
-                            }
-                        )
-                    }
-                }
-
-                $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {return $true} -Force
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {return 'AG01'} -Force
-                $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {return $true} -Force
-
-                return $smoObj
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Mock New-Object -MockWith {
-                Param($TypeName)
-                Switch ($TypeName)
-                {
-                    'Microsoft.SqlServer.Management.Smo.AvailabilityGroup' {
-                        $object = [PSCustomObject] @{
-                                    Name = "MockedObject"
-                                    AutomatedBackupPreference = ''
-                                    FailureConditionLevel = ''
-                                    HealthCheckTimeout = ''
-                                    AvailabilityReplicas = [System.Collections.ArrayList] @()
-                                    AvailabilityGroupListeners = [System.Collections.ArrayList] @()
-                                }
-                        $object | Add-Member -MemberType ScriptMethod -Name Create -Value {return $true}
-                    }
-
-                    'Microsoft.SqlServer.Management.Smo.AvailabilityReplica' {
-                        $object = [PSCustomObject] @{
-                                    Name = "MockedObject"
-                                    EndpointUrl = ''
-                                    FailoverMode = ''
-                                    AvailabilityMode = ''
-                                    BackupPriority = 0
-                                    ConnectionModeInPrimaryRole = ''
-                                    ConnectionModeInSecondaryRole = ''
-                                }
-                    }
-
-                    'Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener' {
-                        $object = [PSCustomObject] @{
-                                    Name = "MockedObject"
-                                    PortNumber = ''
-                                    AvailabilityGroupListenerIPAddresses = [System.Collections.ArrayList] @()
-                                }
-                    }
-
-                    'Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress' {
-                        $object = [PSCustomObject] @{
-                                    Name = "MockedObject"
-                                    IsDHCP = ''
-                                    IPAddress = ''
-                                    SubnetMask = ''
-                                }
-                    }
-
-                    Default {
-                        $object = [PSCustomObject] @{
-                                    Name = "MockedObject"
-                                }
-                    }
-                }
-
-                return $object
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context "When the system is not in the desired state" {
-                $params = @{
-                    Ensure = 'Present'
-                    AvailabilityGroupName = 'AG01'
-                    AvailabilityGroupNameListener = 'AgList01'
-                    AvailabilityGroupNameIP = '192.168.0.1'
-                    AvailabilityGroupSubMask = '255.255.255.0'
-                    AvailabilityGroupPort = 1433
-                    ReadableSecondary = 'ReadOnly'
-                    AutoBackupPreference = 'Primary'
-                    SQLServer = 'localhost'
-                    SQLInstanceName = 'MSSQLSERVER'
-                    SetupCredential = $mockcredential
-                }
-
-                It 'Should not throw when calling Set-method' {
-                    { Set-TargetResource @Params } | Should Not Throw
-                }
-            }
-        }
-    }
-    finally
-    {
-        #region FOOTER
-
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
-
-        #endregion
-    }
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-$testJob | Receive-Job -Wait
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+try
+{
+
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $mockpassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+    $mockusername = "dba" 
+    $mockcredential = New-Object System.Management.Automation.PSCredential($mockusername,$mockpassword)
+
+    #endregion Pester Test Initialization
+    
+    #region Get-TargetResource
+    Describe 'Get-TargetResource' {
+        Mock -CommandName Connect-SQL -MockWith {
+            # build a custom object to return which is close to the real SMO object
+            $smoObj = [PSCustomObject] @{
+                SQLServer = 'Node01'
+                SQLInstanceName = 'Prd01'
+                ClusterName = 'Clust01'
+            }
+
+            # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
+            $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
+                'AG01' = @{
+                    AvailabilityGroupListeners = @{ 
+                        name = 'AgList01'
+                        availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
+                        portnumber = 5022
+                    }
+                    
+                    AvailabilityDatabases = @(
+                        @{
+                            name='AdventureWorks'
+                        } 
+                    )
+                }
+            }
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
+            $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {
+                return $true 
+            } -Force
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {
+                return 'AG01'
+            } -Force
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {
+                return $true
+            } -Force
+
+            return $smoObj
+        }  -ModuleName $script:DSCResourceName
+        
+        Context "When the system is in the desired state" {
+            $SqlAOGroup = Get-TargetResource -Ensure 'Present' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
+    
+            It 'Should return hashtable with Ensure = $true'{
+                $SqlAOGroup.Ensure | Should Be $true
+            }
+        }
+    
+        Context "When the system is not in the desired state" {
+            $SqlAOGroup = Get-TargetResource -Ensure 'Absent' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
+    
+            It 'Should return hashtable with Ensure = $false' {
+                $SqlAOGroup.Ensure | Should Be $false
+            }
+        }
+    }
+    #endregion Get-TargetResource
+
+    #region Test-TargetResource
+    Describe 'Test-TargetResource' {
+        Mock -CommandName Connect-SQL -MockWith {
+            # build a custom object to return which is close to the real SMO object
+            $smoObj = [PSCustomObject] @{
+                SQLServer = 'Node01'
+                SQLInstanceName = 'Prd01'
+                ClusterName = 'Clust01'
+            }
+
+            # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
+            $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
+                'AG01' = @{
+                    AvailabilityGroupListeners = @{ 
+                        name = 'AgList01'
+                        availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
+                        portnumber = 5022
+                    }
+                    
+                    AvailabilityDatabases = @(
+                        @{
+                            name='AdventureWorks'
+                        }
+                    )
+                }
+            }
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
+            $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {
+                return $true
+            } -Force
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {
+                return 'AG01'
+            } -Force
+
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {
+                return $true
+            } -Force
+
+            return $smoObj
+        } -ModuleName $script:DSCResourceName
+    
+        Context "When the system is in the desired state" {
+            $SqlAOGroupTest = Test-TargetResource -Ensure 'Present' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
+    
+            It 'Should return $true'{
+                $SqlAOGroupTest | Should Be $true
+            }
+        }
+    
+        Context "When the system is not in the desired state" {
+            $SqlAOGroupTest = Test-TargetResource -Ensure 'Absent' -AvailabilityGroupName 'AG01' -SQLServer 'localhost' -SQLInstanceName 'MSSQLSERVER' -SetupCredential $mockcredential
+    
+            It 'Should return $false' {
+                $SqlAOGroupTest | Should Be $false
+            }
+        }
+    }
+    #endregion Test-TargetResource
+
+    Describe 'Set-TargetResource' {
+        # Mocking the module FailoverCluster, to be able to mock the function Get-ClusterNode
+        Get-Module -Name FailoverClusters | Remove-Module
+        New-Module -Name FailoverClusters  -ScriptBlock {
+            # This was generated by Write-ModuleStubFile function from the folder Tests\Unit\Stubs
+            function Get-ClusterNode {
+                [CmdletBinding(DefaultParameterSetName='InputObject', HelpUri='http://go.microsoft.com/fwlink/?LinkId=216215')]
+                param(
+                    [Parameter(Position=0)]
+                    [ValidateNotNullOrEmpty()]
+                    [System.Collections.Specialized.StringCollection]
+                    ${Name},
+
+                    [Parameter(ParameterSetName='InputObject', ValueFromPipeline=$true)]
+                    [ValidateNotNull()]
+                    [psobject]
+                    ${InputObject},
+
+                    [ValidateNotNullOrEmpty()]
+                    [string]
+                    ${Cluster}
+                )
+
+                throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+            }
+        
+            Export-ModuleMember -Function *-Cluster*
+        } | Import-Module -Force
+
+        Mock Grant-ServerPerms -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock New-ListenerADObject -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock Get-ClusterNode -MockWith {
+            $clusterNode = @(
+                [PSCustomObject] @{
+                    Name = 'Node01'
+                }, 
+                [PSCustomObject] @{
+                    Name = 'Node02'
+                },
+                [PSCustomObject] @{
+                    Name = 'Node03'
+                },
+                [PSCustomObject] @{
+                    Name = 'Node04'
+                }
+            )
+            return $clusterNode
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock Connect-SQL -MockWith {
+            # build a custom object to return which is close to the real SMO object
+            $smoObj = [PSCustomObject] @{
+                SQLServer = 'Node01'
+                SQLInstanceName = 'Prd01'
+                ClusterName = 'Clust01'
+            }
+
+            # add the AvailabilityGroups entry as this is an ArrayList and allows us the functionality later
+            $smoObj | Add-Member -MemberType NoteProperty -Name 'AvailabilityGroups' -Value @{
+                'AG01' = @{
+                    AvailabilityGroupListeners = @{ 
+                        name = 'AgList01'
+                        availabilitygrouplisteneripaddresses = [System.Collections.ArrayList] @(@{IpAddress = '192.168.0.1'; SubnetMask = '255.255.255.0'})
+                        portnumber = 5022
+                    }
+
+                    AvailabilityDatabases = @(
+                        @{
+                            name='AdventureWorks'
+                        }
+                    )
+                }
+            }
+
+            $smoObj.AvailabilityGroups | Add-Member -MemberType ScriptMethod -Name 'Add' -Value {return $true} -Force
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType NoteProperty -Name Name -Value 'AG01' -Force
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name ToString -Value {return 'AG01'} -Force
+            $smoObj.AvailabilityGroups['AG01'] | Add-Member -MemberType ScriptMethod -Name Drop -Value {return $true} -Force
+
+            return $smoObj
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock New-Object -MockWith {
+            Param($TypeName)
+            Switch ($TypeName)
+            {
+                'Microsoft.SqlServer.Management.Smo.AvailabilityGroup' {
+                    $object = [PSCustomObject] @{
+                                Name = "MockedObject"
+                                AutomatedBackupPreference = ''
+                                FailureConditionLevel = ''
+                                HealthCheckTimeout = ''
+                                AvailabilityReplicas = [System.Collections.ArrayList] @()
+                                AvailabilityGroupListeners = [System.Collections.ArrayList] @()
+                            }
+                    $object | Add-Member -MemberType ScriptMethod -Name Create -Value {return $true}
+                }
+
+                'Microsoft.SqlServer.Management.Smo.AvailabilityReplica' {
+                    $object = [PSCustomObject] @{
+                                Name = "MockedObject"
+                                EndpointUrl = ''
+                                FailoverMode = ''
+                                AvailabilityMode = ''
+                                BackupPriority = 0
+                                ConnectionModeInPrimaryRole = ''
+                                ConnectionModeInSecondaryRole = ''
+                            }
+                }
+
+                'Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener' {
+                    $object = [PSCustomObject] @{
+                                Name = "MockedObject"
+                                PortNumber = ''
+                                AvailabilityGroupListenerIPAddresses = [System.Collections.ArrayList] @()
+                            }
+                }
+
+                'Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress' {
+                    $object = [PSCustomObject] @{
+                                Name = "MockedObject"
+                                IsDHCP = ''
+                                IPAddress = ''
+                                SubnetMask = ''
+                            }
+                }
+
+                Default {
+                    $object = [PSCustomObject] @{
+                                Name = "MockedObject"
+                            }
+                }
+            }
+
+            return $object
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context "When the system is not in the desired state" {
+            $params = @{
+                Ensure = 'Present'
+                AvailabilityGroupName = 'AG01'
+                AvailabilityGroupNameListener = 'AgList01'
+                AvailabilityGroupNameIP = '192.168.0.1'
+                AvailabilityGroupSubMask = '255.255.255.0'
+                AvailabilityGroupPort = 1433
+                ReadableSecondary = 'ReadOnly'
+                AutoBackupPreference = 'Primary'
+                SQLServer = 'localhost'
+                SQLInstanceName = 'MSSQLSERVER'
+                SetupCredential = $mockcredential
+            }
+
+            It 'Should not throw when calling Set-method' {
+                { Set-TargetResource @Params } | Should Not Throw
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -1,633 +1,205 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerAvailabilityGroupListener'
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerAvailabilityGroupListener'
 
-    #region HEADER
+#region HEADER
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    # Loading stub cmdlets
+    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+
+    # Static parameter values
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $availabilityGroup = 'AG01'
+    $listnerName = 'AGListner'
+    
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $listnerName
+        AvailabilityGroup = $availabilityGroup
     }
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    #endregion Pester Test Initialization
 
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
 
-    #endregion HEADER
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
 
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
 
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
 
-        # Loading stub cmdlets
-        Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+            It 'Should not return any IP addresses' {
+                $result.IpAddress | Should Be $null
+            }
 
-        # Static parameter values
-        $nodeName = 'localhost'
-        $instanceName = 'DEFAULT'
-        $availabilityGroup = 'AG01'
-        $listnerName = 'AGListner'
-        
-        $defaultParameters = @{
-            InstanceName = $instanceName
-            NodeName = $nodeName 
-            Name = $listnerName
-            AvailabilityGroup = $availabilityGroup
+            It 'Should not return port' {
+                $result.Port | Should Be 0
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
         }
 
-        #endregion Pester Test Initialization
+        Context 'When the system is in the desired state, without DHCP' {
+            $testParameters = $defaultParameters
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Context 'When the system is not in the desired state' {
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5030
+            }
+
+            It 'Should return that DHCP is not used' {
+                $result.DHCP | Should Be $false
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Context 'When the system is in the desired state, with DHCP' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5031 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+            }
+
+            It 'Should return correct IP address' {
+                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+            }
+
+            It 'Should return correct port' {
+                $result.Port | Should Be 5031
+            }
+
+            It 'Should return that DHCP is used' {
+                $result.DHCP | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state (for static IP)' {
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
                 $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
 
                 Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-        
-                $result = Get-TargetResource @testParameters
 
-                It 'Should return the desired state as absent' {
-                    $result.Ensure | Should Be 'Absent'
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $testParameters.NodeName
-                    $result.InstanceName | Should Be $testParameters.InstanceName
-                    $result.Name | Should Be $testParameters.Name
-                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-                }
-
-                It 'Should not return any IP addresses' {
-                    $result.IpAddress | Should Be $null
-                }
-
-                It 'Should not return port' {
-                    $result.Port | Should Be 0
-                }
-
-                It 'Should return that DHCP is not used' {
-                    $result.DHCP | Should Be $false
-                }
-
-                It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
-            }
-
-            Context 'When the system is in the desired state, without DHCP' {
-                $testParameters = $defaultParameters
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-        
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the desired state as present' {
-                    $result.Ensure | Should Be 'Present'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $testParameters.NodeName
-                    $result.InstanceName | Should Be $testParameters.InstanceName
-                    $result.Name | Should Be $testParameters.Name
-                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-                }
-
-                It 'Should return correct IP address' {
-                    $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
-                }
-
-                It 'Should return correct port' {
-                    $result.Port | Should Be 5030
-                }
-
-                It 'Should return that DHCP is not used' {
-                    $result.DHCP | Should Be $false
-                }
-
-                It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
-            }
-
-            Context 'When the system is in the desired state, with DHCP' {
-                $testParameters = $defaultParameters
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5031 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-        
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the desired state as present' {
-                    $result.Ensure | Should Be 'Present'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $testParameters.NodeName
-                    $result.InstanceName | Should Be $testParameters.InstanceName
-                    $result.Name | Should Be $testParameters.Name
-                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-                }
-
-                It 'Should return correct IP address' {
-                    $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
-                }
-
-                It 'Should return correct port' {
-                    $result.Port | Should Be 5031
-                }
-
-                It 'Should return that DHCP is used' {
-                    $result.DHCP | Should Be $true
-                }
-
-                It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Context 'When the system is not in the desired state (for static IP)' {
-                It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is absent when IP address is different' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is absent when DHCP is absent but should be present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $true
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is absent when DHCP is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        DHCP = $true
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is absent when port is different' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is not in the desired state (for DHCP)' {
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is absent when DHCP is present but should be absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.100/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is absent when IP address is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is absent when port is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Port = 5030
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is in the desired state (for static IP)' {
-                It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is present when IP address is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is present when port is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Port = 5030
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is in the desired state (for DHCP)' {
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $true
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return that desired state is present when DHCP is the only set parameter' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        DHCP = $true
-                    }            
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-            Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-            Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                    Set-TargetResource @testParameters | Out-Null
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should throw when trying to change an existing IP address' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '10.0.0.1/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    { Set-TargetResource @testParameters } | Should Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should throw when trying to change from static IP to DHCP' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $true
-                    }            
-
-                    { Set-TargetResource @testParameters } | Should Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    Set-TargetResource @testParameters | Out-Null
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                    return New-Object Object | 
-                        Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                            return @(
-                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
-                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
-                                )
-                            )
-                        } -PassThru -Force 
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
-
-                    Set-TargetResource @testParameters | Out-Null
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
             Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
@@ -646,51 +218,467 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                     } -PassThru -Force 
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            Context 'When the system is in the desired state' {
-                It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }            
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }            
 
-                    Set-TargetResource @testParameters | Out-Null
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                    }            
-
-                    Set-TargetResource @testParameters | Out-Null
-
-                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            Assert-VerifiableMocks
+            It 'Should return that desired state is absent when IP address is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is absent but should be present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when port is different' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
         }
+
+        Context 'When the system is not in the desired state (for DHCP)' {
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when DHCP is present but should be absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.100/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is absent when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is absent when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state (for static IP)' {
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when IP address is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when port is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Port = 5030
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state (for DHCP)' {
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $true -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return that desired state is present when DHCP is the only set parameter' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    DHCP = $true
+                }            
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
     }
-    finally
-    {
-        #region FOOTER
 
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
-        #endregion
+        Context 'When the system is not in the desired state' {
+            It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should throw when trying to change an existing IP address' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '10.0.0.1/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should throw when trying to change from static IP to DHCP' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $true
+                }            
+
+                { Set-TargetResource @testParameters } | Should Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object | 
+                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru | 
+                                Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.10.45/255.255.252.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+            return New-Object Object | 
+                Add-Member NoteProperty PortNumber 5030 -PassThru | 
+                Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                    return @(
+                        # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                        (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                            Add-Member NoteProperty IsDHCP $false -PassThru | 
+                            Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                            Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                        )
+                    )
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is in the desired state' {
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                    DHCP = $false
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    IpAddress = '192.168.0.1/255.255.255.0'
+                    Port = 5030
+                }            
+
+                Set-TargetResource @testParameters | Out-Null
+
+                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
     }
 }
+finally
+{
+    #region FOOTER
 
-$testJob | Receive-Job -Wait
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -1,191 +1,114 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerConfiguration'
 
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerConfiguration'
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
-    }
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+$defaultState = @{
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
+    OptionValue = 0
+    RestartService = $false
+    RestartTimeout = 120
+}
 
-    $defaultState = @{
-        SQLServer = 'CLU01'
-        SQLInstanceName = 'ClusteredInstance'
-        OptionName = 'user connections'
-        OptionValue = 0
-        RestartService = $false
-        RestartTimeout = 120
-    }
+$desiredState = @{
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
+    OptionValue = 500
+    RestartService = $false
+    RestartTimeout = 120
+}
 
-    $desiredState = @{
-        SQLServer = 'CLU01'
-        SQLInstanceName = 'ClusteredInstance'
-        OptionName = 'user connections'
-        OptionValue = 500
-        RestartService = $false
-        RestartTimeout = 120
-    }
+$desiredStateRestart = @{
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'user connections'
+    OptionValue = 5000
+    RestartService = $true
+    RestartTimeout = 120
+}
 
-    $desiredStateRestart = @{
-        SQLServer = 'CLU01'
-        SQLInstanceName = 'ClusteredInstance'
-        OptionName = 'user connections'
-        OptionValue = 5000
-        RestartService = $true
-        RestartTimeout = 120
-    }
+$dynamicOption = @{
+    SQLServer = 'CLU02'
+    SQLInstanceName = 'ClusteredInstance'
+    OptionName = 'show advanced options'
+    OptionValue = 0
+    RestartService = $false
+    RestartTimeout = 120
+}
 
-    $dynamicOption = @{
-        SQLServer = 'CLU02'
-        SQLInstanceName = 'ClusteredInstance'
-        OptionName = 'show advanced options'
-        OptionValue = 0
-        RestartService = $false
-        RestartTimeout = 120
-    }
+$invalidOption = @{
+    SQLServer = 'CLU01'
+    SQLInstanceName = 'MSSQLSERVER'
+    OptionName = 'Does Not Exist'
+    OptionValue = 1
+    RestartService = $false
+    RestartTimeout = 120
+}
 
-    $invalidOption = @{
-        SQLServer = 'CLU01'
-        SQLInstanceName = 'MSSQLSERVER'
-        OptionName = 'Does Not Exist'
-        OptionValue = 1
-        RestartService = $false
-        RestartTimeout = 120
-    }
+## compile the SMO stub
+#Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
 
-    ## compile the SMO stub
-    #Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+try
+{
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
 
-    try
-    {
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
-            Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+        Context 'The system is not in the desired state' {
 
-            Context 'The system is not in the desired state' {
-
-                Mock -CommandName Connect-SQL -MockWith {
-                    $mock = New-Object PSObject -Property @{ 
-                        Configuration = @{
-                            Properties = @(
-                                @{
-                                    DisplayName = 'user connections'
-                                    ConfigValue = 0
-                                }
-                            )
-                        }
+            Mock -CommandName Connect-SQL -MockWith {
+                $mock = New-Object PSObject -Property @{ 
+                    Configuration = @{
+                        Properties = @(
+                            @{
+                                DisplayName = 'user connections'
+                                ConfigValue = 0
+                            }
+                        )
                     }
-
-                    ## add the Alter method
-                    $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
-
-                    return $mock
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                ## Get the current state
-                $result = Get-TargetResource @desiredState
-                
-                It 'Should return the same values as passed' {
-                    $result.SQLServer | Should Be $desiredState.SQLServer
-                    $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
-                    $result.OptionName | Should Be $desiredState.OptionName
-                    $result.OptionValue | Should Not Be $desiredState.OptionValue
-                    $result.RestartService | Should Be $desiredState.RestartService
-                    $result.RestartTimeout | Should Be $desiredState.RestartTimeout
                 }
 
-                It 'Should call Connect-SQL mock when getting the current state' {
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
-                }
+                ## add the Alter method
+                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+                return $mock
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            ## Get the current state
+            $result = Get-TargetResource @desiredState
+            
+            It 'Should return the same values as passed' {
+                $result.SQLServer | Should Be $desiredState.SQLServer
+                $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
+                $result.OptionName | Should Be $desiredState.OptionName
+                $result.OptionValue | Should Not Be $desiredState.OptionValue
+                $result.RestartService | Should Be $desiredState.RestartService
+                $result.RestartTimeout | Should Be $desiredState.RestartTimeout
             }
 
-            Context 'The system is in the desired state' {
-
-                Mock -CommandName Connect-SQL -MockWith {
-                    $mock = New-Object PSObject -Property @{ 
-                        Configuration = @{
-                            Properties = @(
-                                @{
-                                    DisplayName = 'user connections'
-                                    ConfigValue = 500
-                                }
-                            )
-                        }
-                    }
-
-                    ## add the Alter method
-                    $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
-
-                    return $mock
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                ## Get the current state
-                $result = Get-TargetResource @desiredState
-
-                It 'Should return the same values as passed' {
-                    $result.SQLServer | Should Be $desiredState.SQLServer
-                    $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
-                    $result.OptionName | Should Be $desiredState.OptionName
-                    $result.OptionValue | Should Be $desiredState.OptionValue
-                    $result.RestartService | Should Be $desiredState.RestartService
-                    $result.RestartTimeout | Should Be $desiredState.RestartTimeout
-                }
-
-                It 'Should call Connect-SQL mock when getting the current state' {
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
-                }
-            }
-
-            Context 'Invalid data is supplied' {
-
-                Mock -CommandName Connect-SQL -MockWith {
-                    $mock = New-Object PSObject -Property @{ 
-                        Configuration = @{
-                            Properties = @(
-                                @{
-                                    DisplayName = 'user connections'
-                                    ConfigValue = 0
-                                }
-                            )
-                        }
-                    }
-
-                    ## add the Alter method
-                    $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
-
-                    return $mock
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                It 'Should call New-TerminatingError mock when a bad option name is specified' {
-                    { Get-TargetResource @invalidOption } | Should Throw 'ConfigurationOptionNotFound'
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
-                }
+            It 'Should call Connect-SQL mock when getting the current state' {
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
 
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            
-            Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
+        Context 'The system is in the desired state' {
 
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object PSObject -Property @{ 
@@ -205,19 +128,24 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                 return $mock
             } -ModuleName $script:DSCResourceName -Verifiable
 
-            It 'Should cause Test-TargetResource to return false when not in the desired state' {
-                Test-TargetResource @defaultState | Should be $false
+            ## Get the current state
+            $result = Get-TargetResource @desiredState
+
+            It 'Should return the same values as passed' {
+                $result.SQLServer | Should Be $desiredState.SQLServer
+                $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
+                $result.OptionName | Should Be $desiredState.OptionName
+                $result.OptionValue | Should Be $desiredState.OptionValue
+                $result.RestartService | Should Be $desiredState.RestartService
+                $result.RestartTimeout | Should Be $desiredState.RestartTimeout
             }
 
-            It 'Should cause Test-TargetResource method to return true' {
-                Test-TargetResource @desiredState | Should be $true
+            It 'Should call Connect-SQL mock when getting the current state' {
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
 
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
-
-            Mock -CommandName New-TerminatingError -MockWith {} -ModuleName $script:DSCResourceName
+        Context 'Invalid data is supplied' {
 
             Mock -CommandName Connect-SQL -MockWith {
                 $mock = New-Object PSObject -Property @{ 
@@ -226,7 +154,6 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                             @{
                                 DisplayName = 'user connections'
                                 ConfigValue = 0
-                                IsDynamic = $false
                             }
                         )
                     }
@@ -236,59 +163,119 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                 $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
 
                 return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU01' }
+            } -ModuleName $script:DSCResourceName -Verifiable
 
-            Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{ 
-                    Configuration = @{
-                        Properties = @(
-                            @{
-                                DisplayName = 'show advanced options'
-                                ConfigValue = 1
-                                IsDynamic = $true
-                            }
-                        )
-                    }
-                }
-
-                ## add the Alter method
-                $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
-
-                return $mock
-            } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU02' }
-
-            Mock -CommandName Restart-SqlService -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-            Mock -CommandName New-WarningMessage -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'Change the system to the desired state' {
-                It 'Should not restart SQL for a dynamic option' {
-                    Set-TargetResource @dynamicOption
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should restart SQL for a non-dynamic option' {
-                    Set-TargetResource @desiredStateRestart
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
-                }
-                
-                It 'Should warn about restart when required, but not requested' {
-                    Set-TargetResource @desiredState
-
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-WarningMessage -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should call Connect-SQL to get option values' {
-                    Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 3
-                }
+            It 'Should call New-TerminatingError mock when a bad option name is specified' {
+                { Get-TargetResource @invalidOption } | Should Throw 'ConfigurationOptionNotFound'
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-TerminatingError -Scope It -Times 1
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 1
             }
         }
     }
-    finally
-    {
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        
+        Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
+
+        Mock -CommandName Connect-SQL -MockWith {
+            $mock = New-Object PSObject -Property @{ 
+                Configuration = @{
+                    Properties = @(
+                        @{
+                            DisplayName = 'user connections'
+                            ConfigValue = 500
+                        }
+                    )
+                }
+            }
+
+            ## add the Alter method
+            $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+            return $mock
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        It 'Should cause Test-TargetResource to return false when not in the desired state' {
+            Test-TargetResource @defaultState | Should be $false
+        }
+
+        It 'Should cause Test-TargetResource method to return true' {
+            Test-TargetResource @desiredState | Should be $true
+        }
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
+
+        Mock -CommandName New-TerminatingError -MockWith {} -ModuleName $script:DSCResourceName
+
+        Mock -CommandName Connect-SQL -MockWith {
+            $mock = New-Object PSObject -Property @{ 
+                Configuration = @{
+                    Properties = @(
+                        @{
+                            DisplayName = 'user connections'
+                            ConfigValue = 0
+                            IsDynamic = $false
+                        }
+                    )
+                }
+            }
+
+            ## add the Alter method
+            $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+            return $mock
+        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU01' }
+
+        Mock -CommandName Connect-SQL -MockWith {
+            $mock = New-Object PSObject -Property @{ 
+                Configuration = @{
+                    Properties = @(
+                        @{
+                            DisplayName = 'show advanced options'
+                            ConfigValue = 1
+                            IsDynamic = $true
+                        }
+                    )
+                }
+            }
+
+            ## add the Alter method
+            $mock.Configuration | Add-Member -MemberType ScriptMethod -Name Alter -Value {}
+
+            return $mock
+        } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU02' }
+
+        Mock -CommandName Restart-SqlService -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock -CommandName New-WarningMessage -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'Change the system to the desired state' {
+            It 'Should not restart SQL for a dynamic option' {
+                Set-TargetResource @dynamicOption
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should restart SQL for a non-dynamic option' {
+                Set-TargetResource @desiredStateRestart
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
+            }
+            
+            It 'Should warn about restart when required, but not requested' {
+                Set-TargetResource @desiredState
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-WarningMessage -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should call Connect-SQL to get option values' {
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope Context -Times 3
+            }
+        }
     }
 }
-
-$testJob | Receive-Job -Wait
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -1,229 +1,216 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerDatabase'
 
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerDatabase'
+#region HEADER
 
-    #region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'MSSQLSERVER'
+
+    $defaultParameters = @{
+        SQLInstanceName = $instanceName
+        SQLServer = $nodeName
     }
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    #endregion Pester Test Initialization
 
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
 
-    #endregion HEADER
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'UnknownDatabase'
+            }
 
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
+            $result = Get-TargetResource @testParameters
 
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+            It 'Should return the state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
 
-        $nodeName = 'localhost'
-        $instanceName = 'MSSQLSERVER'
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
 
-        $defaultParameters = @{
-            SQLInstanceName = $instanceName
-            SQLServer = $nodeName
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+    
+        Context 'When the system is in the desired state for a database' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'AdventureWorks'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
         }
 
-        #endregion Pester Test Initialization
+        Assert-VerifiableMocks
+    }
+    
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
+        Context 'When the system is not in the desired state' {
+            It 'Should return the state as absent when desired database does not exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'UnknownDatabase'
                 }
 
-                $result = Get-TargetResource @testParameters
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should return the state as absent' {
-                    $result.Ensure | Should Be 'Absent'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
-        
-            Context 'When the system is in the desired state for a database' {
+
+            It 'Should return the state as present when desired database exist' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'AdventureWorks'
                 }
-        
-                $result = Get-TargetResource @testParameters
 
-                It 'Should return the state as present' {
-                    $result.Ensure | Should Be 'Present'
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-        
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                It 'Should return the state as absent when desired database does not exist' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'UnknownDatabase'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the state as present when desired database exist' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'AdventureWorks'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should return the state as present when desired database exist' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'AdventureWorks'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-                
-                It 'Should return the state as absent when desired database does not exist' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'UnknownDatabase'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-        
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Mock -CommandName New-SqlDatabase -MockWith {} -ModuleName $script:DSCResourceName -Verifiable        
-            Mock -CommandName Remove-SqlDatabase -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                It 'Should call the function New-SqlDatabase when desired database should be present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'NewDatabase'
-                        Ensure = 'Present'
-                    }
-
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled New-SqlDatabase -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is not in the desired state' {
-                It 'Should call the function Remove-SqlDatabase when desired database should be absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'AdventureWorks'
-                        Ensure = 'Absent'
-                    }             
-
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Remove-SqlDatabase -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
         }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return the state as present when desired database exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'AdventureWorks'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+            
+            It 'Should return the state as absent when desired database does not exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'UnknownDatabase'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
     }
-    finally
-    {
-        #region FOOTER
+    
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
 
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+        Mock -CommandName New-SqlDatabase -MockWith {} -ModuleName $script:DSCResourceName -Verifiable        
+        Mock -CommandName Remove-SqlDatabase -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
-        #endregion
+        Context 'When the system is not in the desired state' {
+            It 'Should call the function New-SqlDatabase when desired database should be present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'NewDatabase'
+                    Ensure = 'Present'
+                }
+
+                Set-TargetResource @testParameters
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled New-SqlDatabase -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is not in the desired state' {
+            It 'Should call the function Remove-SqlDatabase when desired database should be absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'AdventureWorks'
+                    Ensure = 'Absent'
+                }             
+
+                Set-TargetResource @testParameters
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlDatabase -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
     }
 }
+finally
+{
+    #region FOOTER
 
-$testJob | Receive-Job -Wait
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -1,270 +1,257 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerDatabaseOwner'
 
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerDatabaseOwner'
+#region HEADER
 
-    #region HEADER
-
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
-    }
-
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
-
-    $TestEnvironment = Initialize-TestEnvironment -DSCModuleName $script:DSCModuleName `
-                                                -DSCResourceName $script:DSCResourceName `
-                                                -TestType Unit 
-    #endregion HEADER
-
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
-
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
-        $defaultParameters = @{
-            SQLInstanceName = 'MSSQLSERVER'
-            SQLServer = 'localhost'
-        }
-
-        #endregion Pester Test Initialization
-
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                    Name = 'CONTOSO\SqlServiceAcct'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
-                    return $null
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name as null from the get method' {
-                    $result.Name | Should Be $null
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
-                }
-
-                It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Context 'When the specified database does not exist' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'UnknownDatabase'
-                    Name = 'CONTOSO\SqlServiceAcct'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
-                    return $null
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name as null from the get method' {
-                    $result.Name | Should Be $null
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
-                }
-
-                It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                    Name = 'CONTOSO\SqlServiceAcct'
-                }
-
-                Mock -CommandName Get-SqlDatabaseOwner -MockWith { return 'CONTOSO\SqlServiceAcct' } -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the name of the owner from the get method' {
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Database | Should Be $testParameters.Database
-                }
-
-                It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                It 'Should return the state as false when desired login is not the database owner' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Database = 'AdventureWorks'
-                        Name = 'CONTOSO\SqlServiceAcct'
-                    }       
-
-                    Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
-                        return $null
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should return the state as true when desired login is the database owner' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Database = 'AdventureWorks'
-                        Name = 'CONTOSO\SqlServiceAcct'
-                    } 
-
-                    Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
-                        'CONTOSO\SqlServiceAcct' 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Databases {
-                        return @{
-                            'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                    Name = 'CONTOSO\SqlServiceAcct'
-                }
-
-                It 'Should call the function Set-SqlDatabaseOwner when desired login is not the database owner' {
-                    Mock -CommandName Set-SqlDatabaseOwner -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
-                    
-                    Set-TargetResource @testParameters
-                
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-                
-                $testParameters.Database = 'UnknownDatabase'
-
-                It 'Should throw an error when desired database does not exist' {
-                    Mock -CommandName Set-SqlDatabaseOwner -MockWith {
-                        return Throw
-                    } -ModuleName $script:DSCResourceName -Verifiable
-                    
-                    { Set-TargetResource @testParameters } | Should Throw "Failed to setting the owner of database UnknownDatabase"
-                    
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Database = 'AdventureWorks'
-                    Name = 'CONTOSO\SqlServiceAcct'
-                }
-
-                It 'Should not call the function Set-SqlDatabaseOwner when desired login is the database owner' {
-                    Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
-                        'CONTOSO\SqlServiceAcct' 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-                    
-                    $result = Get-TargetResource @testParameters
-                
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-    }
-    finally
-    {
-        #region FOOTER
-
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
-
-        #endregion
-    }
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-$testJob | Receive-Job -Wait
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment -DSCModuleName $script:DSCModuleName `
+                                            -DSCResourceName $script:DSCResourceName `
+                                            -TestType Unit 
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $defaultParameters = @{
+        SQLInstanceName = 'MSSQLSERVER'
+        SQLServer = 'localhost'
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                return $null
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the name as null from the get method' {
+                $result.Name | Should Be $null
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
+            }
+
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the specified database does not exist' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'UnknownDatabase'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                return $null
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the name as null from the get method' {
+                $result.Name | Should Be $null
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
+            }
+
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            Mock -CommandName Get-SqlDatabaseOwner -MockWith { return 'CONTOSO\SqlServiceAcct' } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the name of the owner from the get method' {
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Database | Should Be $testParameters.Database
+            }
+
+            It 'Should call the mock functions Connect-SQL and Get-SqlDatabaseOwner' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            It 'Should return the state as false when desired login is not the database owner' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                    Name = 'CONTOSO\SqlServiceAcct'
+                }       
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    return $null
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return the state as true when desired login is the database owner' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Database = 'AdventureWorks'
+                    Name = 'CONTOSO\SqlServiceAcct'
+                } 
+
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    'CONTOSO\SqlServiceAcct' 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Databases {
+                    return @{
+                        'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            It 'Should call the function Set-SqlDatabaseOwner when desired login is not the database owner' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+                
+                Set-TargetResource @testParameters
+            
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+            
+            $testParameters.Database = 'UnknownDatabase'
+
+            It 'Should throw an error when desired database does not exist' {
+                Mock -CommandName Set-SqlDatabaseOwner -MockWith {
+                    return Throw
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                { Set-TargetResource @testParameters } | Should Throw "Failed to setting the owner of database UnknownDatabase"
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Database = 'AdventureWorks'
+                Name = 'CONTOSO\SqlServiceAcct'
+            }
+
+            It 'Should not call the function Set-SqlDatabaseOwner when desired login is the database owner' {
+                Mock -CommandName Get-SqlDatabaseOwner -MockWith { 
+                    'CONTOSO\SqlServiceAcct' 
+                } -ModuleName $script:DSCResourceName -Verifiable
+                
+                $result = Get-TargetResource @testParameters
+            
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Get-SqlDatabaseOwner -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Set-SqlDatabaseOwner -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointPermission.Tests.ps1
@@ -1,62 +1,141 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerEndpointPermission'
 
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerEndpointPermission'
+#region HEADER
 
-    #region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $principal = 'COMPANY\SqlServiceAcct'
+    $otherPrincipal = 'COMPANY\OtherAcct'
+    $endpointName = 'DefaultEndpointMirror'
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName 
+        Name = $endpointName
+        Principal = $principal
     }
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    #endregion Pester Test Initialization
 
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
 
-    #endregion HEADER
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
 
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
 
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
 
-        $nodeName = 'localhost'
-        $instanceName = 'DEFAULT'
-        $principal = 'COMPANY\SqlServiceAcct'
-        $otherPrincipal = 'COMPANY\OtherAcct'
-        $endpointName = 'DefaultEndpointMirror'
+            It 'Should not return any permissions' {
+                $result.Permission | Should Be ''
+            }
 
-        $defaultParameters = @{
-            InstanceName = $instanceName
-            NodeName = $nodeName 
-            Name = $endpointName
-            Principal = $principal
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+
+            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                return New-Object Object | 
+                    Add-Member NoteProperty Name $endpointName -PassThru | 
+                    Add-Member ScriptMethod EnumObjectPermissions {
+                        param($permissionSet)
+                        return @(
+                            (New-Object Object |
+                                Add-Member NoteProperty Grantee $principal -PassThru |
+                                Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                            )
+                        )
+                    } -PassThru -Force 
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $testParameters.NodeName
+                $result.InstanceName | Should Be $testParameters.InstanceName
+                $result.Name | Should Be $testParameters.Name
+                $result.Principal | Should Be $testParameters.Principal
+            }
+
+            It 'Should return the permissions passed as parameter' {
+                $result.Permission | Should Be 'CONNECT'
+            }
+
+            It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
         }
 
-        #endregion Pester Test Initialization
+        Assert-VerifiableMocks
+    }
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Present'
+                Permission = 'CONNECT'
+            }
 
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
                 Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
                     return New-Object Object | 
@@ -71,31 +150,49 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                             )
                         } -PassThru -Force 
                 } -ModuleName $script:DSCResourceName -Verifiable
-        
-                $result = Get-TargetResource @testParameters
 
-                It 'Should return the desired state as absent' {
-                    $result.Ensure | Should Be 'Absent'
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $testParameters.NodeName
-                    $result.InstanceName | Should Be $testParameters.InstanceName
-                    $result.Name | Should Be $testParameters.Name
-                    $result.Principal | Should Be $testParameters.Principal
-                }
-
-                It 'Should not return any permissions' {
-                    $result.Permission | Should Be ''
-                }
-
-                It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
-        
-            Context 'When the system is in the desired state' {
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Permission = 'CONNECT'
+            }
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return that desired state is present when wanted desired state is to be Present' {
                 $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
 
                 Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
                     # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
@@ -111,331 +208,221 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                             )
                         } -PassThru -Force 
                 } -ModuleName $script:DSCResourceName -Verifiable
-        
-                $result = Get-TargetResource @testParameters
 
-                It 'Should return the desired state as present' {
-                    $result.Ensure | Should Be 'Present'
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $testParameters.NodeName
-                    $result.InstanceName | Should Be $testParameters.InstanceName
-                    $result.Name | Should Be $testParameters.Name
-                    $result.Principal | Should Be $testParameters.Principal
-                }
-
-                It 'Should return the permissions passed as parameter' {
-                    $result.Permission | Should Be 'CONNECT'
-                }
-
-                It 'Should call the mock function Get-SQLAlwaysOnEndpoint' {
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
 
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    Permission = 'CONNECT'
-                }
-
-                It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Ensure = 'Absent'
                     Permission = 'CONNECT'
                 }
 
-                It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $principal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
                                 )
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
+                            )
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
 
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
 
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
             }
-
-            Context 'When the system is in the desired state' {
-                It 'Should return that desired state is present when wanted desired state is to be Present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $principal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Assert-VerifiableMocks
         }
 
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Context 'When the system is not in the desired state' {
-                It 'Should call the the method Grant when desired state is to be Present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru | 
-                            Add-Member ScriptMethod Grant {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                return
-                            } -PassThru | 
-                            Add-Member ScriptMethod Revoke {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Revoke() when it shouldn''t been called'
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should call the the method Revoke when desired state is to be Absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $principal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru | 
-                            Add-Member ScriptMethod Grant {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Grant() when it shouldn''t been called'
-                            } -PassThru | 
-                            Add-Member ScriptMethod Revoke {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                return
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should not throw error when desired state is already Present' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $principal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru | 
-                            Add-Member ScriptMethod Grant {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Grant() when it shouldn''t been called'
-                            } -PassThru | 
-                            Add-Member ScriptMethod Revoke {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Revoke() when it shouldn''t been called'
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should not throw error when desired state is already Absent' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
-
-                    Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                        # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                        return New-Object Object | 
-                            Add-Member NoteProperty Name $endpointName -PassThru | 
-                            Add-Member ScriptMethod EnumObjectPermissions {
-                                param($permissionSet)
-                                return @(
-                                    (New-Object Object |
-                                        Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
-                                        Add-Member NoteProperty PermissionState 'Grant' -PassThru
-                                    )
-                                )
-                            } -PassThru | 
-                            Add-Member ScriptMethod Grant {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Grant() when it shouldn''t been called'
-                            } -PassThru | 
-                            Add-Member ScriptMethod Revoke {
-                                param(
-                                    $permissionSet, 
-                                    $principal 
-                                )
-                                throw 'Called Revoke() when it shouldn''t been called'
-                            } -PassThru -Force 
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-            Assert-VerifiableMocks
-        }
+        Assert-VerifiableMocks
     }
-    finally
-    {
-        #region FOOTER
 
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            It 'Should call the the method Grant when desired state is to be Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
 
-        #endregion
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should call the the method Revoke when desired state is to be Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            return
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should not throw error when desired state is already Present' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $principal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should not throw error when desired state is already Absent' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                    Permission = 'CONNECT'
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                    return New-Object Object | 
+                        Add-Member NoteProperty Name $endpointName -PassThru | 
+                        Add-Member ScriptMethod EnumObjectPermissions {
+                            param($permissionSet)
+                            return @(
+                                (New-Object Object |
+                                    Add-Member NoteProperty Grantee $otherPrincipal -PassThru |
+                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                )
+                            )
+                        } -PassThru | 
+                        Add-Member ScriptMethod Grant {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Grant() when it shouldn''t been called'
+                        } -PassThru | 
+                        Add-Member ScriptMethod Revoke {
+                            param(
+                                $permissionSet, 
+                                $principal 
+                            )
+                            throw 'Called Revoke() when it shouldn''t been called'
+                        } -PassThru -Force 
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+        Assert-VerifiableMocks
     }
 }
+finally
+{
+    #region FOOTER
 
-$testJob | Receive-Job -Wait
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -2,464 +2,451 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 param()
 
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerLogin'
-
-    #region HEADER
-
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
-    }
-
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
-
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
-
-    #endregion HEADER
-
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
-
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
-        $nodeName = 'localhost'
-        $instanceName = 'MSSQLSERVER'
-
-        $mockSqlLoginUser = "dba" 
-        $mockSqlLoginPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-        $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
-
-        $defaultParameters = @{
-            SQLInstanceName = $instanceName
-            SQLServer = $nodeName
-        }
-
-        #endregion Pester Test Initialization
-
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Logins {
-                        return @{
-                            'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                            'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                            'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\UnknownUser'
-                }
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should not return the state as absent' {
-                    $result.Ensure | Should Be 'Absent'
-                    $result.LoginType | Should Be ''
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-        
-            Context 'When the system is in the desired state for a Windows user' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\Stacy'
-                }
-        
-                $result = Get-TargetResource @testParameters
-
-                It 'Should not return the state as present' {
-                    $result.Ensure | Should Be 'Present'
-                    $result.LoginType | Should Be 'WindowsUser'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Context 'When the system is in the desired state for a Windows group' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\SqlUsers'
-                }
-        
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the state as present' {
-                    $result.Ensure | Should Be 'Present'
-                    $result.LoginType | Should Be 'WindowsGroup'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Context 'When the system is in the desired state for a SQL login' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'John'
-                }
-        
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the state as present' {
-                    $result.Ensure | Should Be 'Present'
-                    $result.LoginType | Should Be 'SqlLogin'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Logins {
-                        return @{
-                            'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                            'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                            'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                It 'Should return the state as absent when desired windows user does not exist' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'COMPANY\UnknownUser'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the state as present when desired login exists and login type is SQL login' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'COMPANY\SqlUsers'
-                        LoginType = 'SqlLogin'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the state as present when desired login exists and login type is Windows' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'John'
-                        LoginType = 'WindowsUser'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should return the state as present when desired windows user exists' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'COMPANY\Stacy'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the state as present when desired windows group exists' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'COMPANY\SqlUsers'
-                        LoginType = 'WindowsGroup'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the state as present when desired sql login exists' {
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'John'
-                        LoginType = 'SqlLogin'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Logins {
-                        return @{
-                            'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                            'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                            'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'UnknownSqlLogin'
-                    LoginType = 'SqlLogin'
-                }
-
-                It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
-                    { Set-TargetResource @testParameters } | Should Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters += @{
-                    LoginCredential = $mockSqlLoginCredential
-                }
-
-                It 'Should not throw an error when desired login type is a SQL login' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'SqlLogin'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\UnknownUser'
-                    LoginType = 'WindowsUser'
-                }
-
-                It 'Should not throw an error when desired login type is a Windows User' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'WindowsUser'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\UnknownGroup'
-                    LoginType = 'WindowsGroup'
-                }
-
-                It 'Should not throw an error when desired login type is a Windows Group' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'WindowsGroup'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Absent'
-                    Name = 'COMPANY\Stacy'
-                }
-
-                It 'Should call the function Remove-SqlLogin when desired state should be absent' {
-                    # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Absent'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Remove-SqlLogin -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'John'
-                    LoginType = 'SqlLogin'
-                }
-
-                It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
-                    { Set-TargetResource @testParameters } | Should Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters += @{
-                    LoginCredential = $mockSqlLoginCredential
-                }
-
-                It 'Should not throw an error when desired login type is a SQL login' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'SqlLogin'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\Stacy'
-                    LoginType = 'WindowsUser'
-                }
-
-                It 'Should not throw an error when desired login type is a Windows User' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'WindowsUser'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\SqlUsers'
-                    LoginType = 'WindowsGroup'
-                }
-
-                It 'Should not throw an error when desired login type is a Windows Group' {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Present'
-                            LoginType = 'WindowsGroup'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Absent'
-                    Name = 'COMPANY\UnknownUser'
-                    LoginType = 'SqlLogin'
-                }
-
-                It 'Should not call the function Remove-SqlLogin when desired state is already absent' {
-                    # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        @{
-                            Ensure = 'Absent'
-                        }
-                    } -ModuleName $script:DSCResourceName -Verifiable
-
-                    Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Remove-SqlLogin -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-    }
-    finally
-    {
-        #region FOOTER
-
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
-
-        #endregion
-    }
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerLogin'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-$testJob | Receive-Job -Wait
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'MSSQLSERVER'
+
+    $mockSqlLoginUser = "dba" 
+    $mockSqlLoginPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+    $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
+
+    $defaultParameters = @{
+        SQLInstanceName = $instanceName
+        SQLServer = $nodeName
+    }
+
+    #endregion Pester Test Initialization
+
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownUser'
+            }
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as absent' {
+                $result.Ensure | Should Be 'Absent'
+                $result.LoginType | Should Be ''
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+    
+        Context 'When the system is in the desired state for a Windows user' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\Stacy'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should not return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsUser'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state for a Windows group' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\SqlUsers'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsGroup'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Context 'When the system is in the desired state for a SQL login' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'John'
+            }
+    
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the state as present' {
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'SqlLogin'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            It 'Should return the state as absent when desired windows user does not exist' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\UnknownUser'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return the state as present when desired login exists and login type is SQL login' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\SqlUsers'
+                    LoginType = 'SqlLogin'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return the state as present when desired login exists and login type is Windows' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'John'
+                    LoginType = 'WindowsUser'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return the state as present when desired windows user exists' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\Stacy'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return the state as present when desired windows group exists' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'COMPANY\SqlUsers'
+                    LoginType = 'WindowsGroup'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should return the state as present when desired sql login exists' {
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'John'
+                    LoginType = 'SqlLogin'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Logins {
+                    return @{
+                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
+                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
+                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'UnknownSqlLogin'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
+                { Set-TargetResource @testParameters } | Should Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters += @{
+                LoginCredential = $mockSqlLoginCredential
+            }
+
+            It 'Should not throw an error when desired login type is a SQL login' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'SqlLogin'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownUser'
+                LoginType = 'WindowsUser'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows User' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsUser'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\UnknownGroup'
+                LoginType = 'WindowsGroup'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows Group' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsGroup'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Name = 'COMPANY\Stacy'
+            }
+
+            It 'Should call the function Remove-SqlLogin when desired state should be absent' {
+                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Absent'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlLogin -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'John'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
+                { Set-TargetResource @testParameters } | Should Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters += @{
+                LoginCredential = $mockSqlLoginCredential
+            }
+
+            It 'Should not throw an error when desired login type is a SQL login' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'SqlLogin'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\Stacy'
+                LoginType = 'WindowsUser'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows User' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsUser'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'COMPANY\SqlUsers'
+                LoginType = 'WindowsGroup'
+            }
+
+            It 'Should not throw an error when desired login type is a Windows Group' {
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Present'
+                        LoginType = 'WindowsGroup'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Ensure = 'Absent'
+                Name = 'COMPANY\UnknownUser'
+                LoginType = 'SqlLogin'
+            }
+
+            It 'Should not call the function Remove-SqlLogin when desired state is already absent' {
+                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
+                Mock -CommandName Get-TargetResource -MockWith {
+                    @{
+                        Ensure = 'Absent'
+                    }
+                } -ModuleName $script:DSCResourceName -Verifiable
+
+                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlLogin -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerPermission.Tests.ps1
@@ -1,58 +1,137 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerPermission'
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerPermission'
 
-    #region HEADER
+#region HEADER
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+    $principal = 'COMPANY\SqlServiceAcct'
+    $permission = @( 'AlterAnyAvailabilityGroup','ViewServerState' )
+
+    #endregion Pester Test Initialization
+
+    $defaultParameters = @{
+        InstanceName = $instanceName
+        NodeName = $nodeName
+        Principal = $principal
+        Permission = $permission
     }
 
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            Mock -CommandName Get-SQLPSInstance -MockWith {
+                [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+                $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                $mockObjectSmoServer.DisplayName = $instanceName
+                $mockObjectSmoServer.InstanceName = $instanceName
+                $mockObjectSmoServer.IsHadrEnabled = $False
+                $mockObjectSmoServer.MockGranteeName = $principal
 
-    #endregion HEADER
+                return $mockObjectSmoServer
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $testParameters = $defaultParameters
 
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
+            $result = Get-TargetResource @testParameters
 
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+            It 'Should return the desired state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
 
-        $nodeName = 'localhost'
-        $instanceName = 'DEFAULT'
-        $principal = 'COMPANY\SqlServiceAcct'
-        $permission = @( 'AlterAnyAvailabilityGroup','ViewServerState' )
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $nodeName
+                $result.InstanceName | Should Be $instanceName
+                $result.Principal | Should Be $principal
+            }
 
-        #endregion Pester Test Initialization
+            It 'Should not return any permissions' {
+                $result.Permission | Should Be $null
+            }
 
-        $defaultParameters = @{
-            InstanceName = $instanceName
-            NodeName = $nodeName
-            Principal = $principal
-            Permission = $permission
+            It 'Should call the mock function Get-SQLPSInstance' {
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
+        }
+    
+        Context 'When the system is in the desired state' {
+            Mock -CommandName Get-SQLPSInstance -MockWith {
+                [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                $mockObjectSmoServer.DisplayName = $instanceName
+                $mockObjectSmoServer.InstanceName = $instanceName
+                $mockObjectSmoServer.IsHadrEnabled = $False
+                $mockObjectSmoServer.MockGranteeName = $principal
+
+                return $mockObjectSmoServer
+            } -ModuleName $script:DSCResourceName -Verifiable
+    
+            $testParameters = $defaultParameters
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the desired state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.NodeName | Should Be $nodeName
+                $result.InstanceName | Should Be $instanceName
+                $result.Principal | Should Be $principal
+            }
+
+            It 'Should return the permissions passed as parameter' {
+                foreach ($currentPermission in $permission) {
+                    if( $result.Permission -ccontains $currentPermission ) {
+                        $permissionState = $true 
+                    } else {
+                        $permissionState = $false
+                        break
+                    }
+                } 
+                
+                $permissionState | Should Be $true
+            }
+
+            It 'Should call the mock function Get-SQLPSInstance' {
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
+            }
         }
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Context 'When the system is not in the desired state' {
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            It 'Should return that desired state is absent when wanted desired state is to be Present' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
@@ -67,29 +146,17 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                 } -ModuleName $script:DSCResourceName -Verifiable
         
                 $testParameters = $defaultParameters
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the desired state as absent' {
-                    $result.Ensure | Should Be 'Absent'
+                $testParameters += @{
+                    Ensure = 'Present'
                 }
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $nodeName
-                    $result.InstanceName | Should Be $instanceName
-                    $result.Principal | Should Be $principal
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should not return any permissions' {
-                    $result.Permission | Should Be $null
-                }
-
-                It 'Should call the mock function Get-SQLPSInstance' {
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
-        
-            Context 'When the system is in the desired state' {
+
+            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
                 Mock -CommandName Get-SQLPSInstance -MockWith {
                     [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
@@ -104,260 +171,181 @@ $testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
                 } -ModuleName $script:DSCResourceName -Verifiable
         
                 $testParameters = $defaultParameters
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the desired state as present' {
-                    $result.Ensure | Should Be 'Present'
+                $testParameters += @{
+                    Ensure = 'Absent'
                 }
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.NodeName | Should Be $nodeName
-                    $result.InstanceName | Should Be $instanceName
-                    $result.Principal | Should Be $principal
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should return the permissions passed as parameter' {
-                    foreach ($currentPermission in $permission) {
-                        if( $result.Permission -ccontains $currentPermission ) {
-                            $permissionState = $true 
-                        } else {
-                            $permissionState = $false
-                            break
-                        }
-                    } 
-                    
-                    $permissionState | Should Be $true
-                }
-
-                It 'Should call the mock function Get-SQLPSInstance' {
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-                }
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
-
-            Assert-VerifiableMocks
         }
 
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Context 'When the system is not in the desired state' {
-                It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+        Context 'When the system is in the desired state' {
+            It 'Should return that desired state is present when wanted desired state is to be Present' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
 
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal
 
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
                 }
 
-                It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
 
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
 
-            Context 'When the system is in the desired state' {
-                It 'Should return that desired state is present when wanted desired state is to be Present' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+            It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal
 
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
                 }
 
-                It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
 
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
-
-            Assert-VerifiableMocks
         }
 
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Context 'When the system is not in the desired state' {
-                It 'Should not throw error when desired state is to be Present' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
-
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal   
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                    }
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should not throw error when desired state is to be Absent' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
-
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = $principal
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should not throw error when desired state is to be Present' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
-
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'   
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Present'
-                    }
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should not throw error when desired state is to be Absent' {
-                    Mock -CommandName Get-SQLPSInstance -MockWith {
-                        [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
-
-                        $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
-                        $mockObjectSmoServer.Name = "$nodeName\$instanceName"
-                        $mockObjectSmoServer.DisplayName = $instanceName
-                        $mockObjectSmoServer.InstanceName = $instanceName
-                        $mockObjectSmoServer.IsHadrEnabled = $False
-                        $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'
-
-                        return $mockObjectSmoServer
-                    } -ModuleName $script:DSCResourceName -Verifiable
-            
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
-
-                    { Set-TargetResource @testParameters } | Should Not Throw
-
-                    Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-            }
-    #>
-            Assert-VerifiableMocks
-        }
+        Assert-VerifiableMocks
     }
-    finally
-    {
-        #region FOOTER
 
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Context 'When the system is not in the desired state' {
+            It 'Should not throw error when desired state is to be Present' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
-        #endregion
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal   
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should not throw error when desired state is to be Absent' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = $principal
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should not throw error when desired state is to be Present' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $true
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'   
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Present'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+
+            It 'Should not throw error when desired state is to be Absent' {
+                Mock -CommandName Get-SQLPSInstance -MockWith {
+                    [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
+
+                    $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server
+                    $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+                    $mockObjectSmoServer.DisplayName = $instanceName
+                    $mockObjectSmoServer.InstanceName = $instanceName
+                    $mockObjectSmoServer.IsHadrEnabled = $False
+                    $mockObjectSmoServer.MockGranteeName = 'Should not call Grant() or Revoke()'
+
+                    return $mockObjectSmoServer
+                } -ModuleName $script:DSCResourceName -Verifiable
+        
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                { Set-TargetResource @testParameters } | Should Not Throw
+
+                Assert-MockCalled Get-SQLPSInstance -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+            }
+        }
+#>
+        Assert-VerifiableMocks
     }
 }
+finally
+{
+    #region FOOTER
 
-$testJob | Receive-Job -Wait
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
@@ -1,275 +1,263 @@
-<#
-    AppVeyor build worker loads the SMO assembly which unable the tests to load the SMO stub classes.
-    Running the tests in a Start-Job script block give us a clean environment. This is a workaround.
-#>
-$testJob = Start-Job -ArgumentList $PSScriptRoot -ScriptBlock {
-    param
-    (
-        [System.String] $PSScriptRoot
-    )
-    $script:DSCModuleName      = 'xSQLServer'
-    $script:DSCResourceName    = 'MSFT_xSQLServerRole'
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerRole'
 
-    #region HEADER
+#region HEADER
 
-    # Unit Test Template Version: 1.1.0
-    [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-        (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
+    $nodeName = 'localhost'
+    $instanceName = 'MSSQLSERVER'
+
+    $defaultParameters = @{
+        SQLInstanceName = $instanceName
+        SQLServer = $nodeName
+        ServerRole = 'dbcreator'
     }
 
-    Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+    #endregion Pester Test Initialization
 
-    $TestEnvironment = Initialize-TestEnvironment `
-        -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceName `
-        -TestType Unit 
+    Describe "$($script:DSCResourceName)\Get-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Roles {
+                    return @{
+                        'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
 
-    #endregion HEADER
+        Context 'When the system is not in the desired state' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'UnknownUser'
+            }
+            
+            Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
 
-    # Begin Testing
-    try
-    {
-        #region Pester Test Initialization
+            $result = Get-TargetResource @testParameters
 
-        # Loading mocked classes
-        Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+            It 'Should return the state as absent' {
+                $result.Ensure | Should Be 'Absent'
+            }
 
-        $nodeName = 'localhost'
-        $instanceName = 'MSSQLSERVER'
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
 
-        $defaultParameters = @{
-            SQLInstanceName = $instanceName
-            SQLServer = $nodeName
-            ServerRole = 'dbcreator'
+            It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
+        }
+    
+        Context 'When the system is in the desired state for a loginName' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'CONTOSO\SQL-Admin'
+                Ensure = 'Present'
+            }
+            
+            Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+
+            $result = Get-TargetResource @testParameters
+
+            It 'Should return the state as present' {
+                $result.Ensure | Should Be 'Present'
+            }
+
+            It 'Should return the same values as passed as parameters' {
+                $result.SQLServer | Should Be $testParameters.SQLServer
+                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                $result.Name | Should Be $testParameters.Name
+            }
+
+            It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            }
         }
 
-        #endregion Pester Test Initialization
+        Assert-VerifiableMocks
+    }
 
-        Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Roles {
-                        return @{
-                            'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
+    Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Roles {
+                    return @{
+                        'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
 
-            Context 'When the system is not in the desired state' {
+        Context 'When the system is not in the desired state' {            
+            It 'Should return the test as false when desired loginName does not exist' {
+
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'UnknownUser'
-                }
-                
-                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Get-TargetResource @testParameters
-
-                It 'Should return the state as absent' {
-                    $result.Ensure | Should Be 'Absent'
+                    Ensure = 'Present'
                 }
 
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
 
-                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
             }
-        
-            Context 'When the system is in the desired state for a loginName' {
+
+            It 'Should return the test as false when non-desired loginName exist' {
+
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'NonDesiredUser'
+                    Ensure = 'Absent'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $false
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Context 'When the system is in the desired state' {
+            It 'Should return the test as true when desired loginName exist' {
+
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
+
                 $testParameters = $defaultParameters
                 $testParameters += @{
                     Name = 'CONTOSO\SQL-Admin'
                     Ensure = 'Present'
                 }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+                        
+            It 'Should return the test as true when non-desired loginName does not exist' {
+
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+
+                $testParameters = $defaultParameters
+                $testParameters += @{
+                    Name = 'CONTOSO\SQL-Admin'
+                    Ensure = 'Absent'
+                }
+
+                $result = Test-TargetResource @testParameters
+                $result | Should Be $true
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith {
+            return New-Object Object | 
+                Add-Member ScriptProperty Roles {
+                    return @{
+                        'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
+                    }
+                } -PassThru -Force 
+        } -ModuleName $script:DSCResourceName -Verifiable
+
+        Context 'When the system is not in the desired state - PRESENT' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'CONTOSO\SQL-Admin'
+                Ensure = 'Present'
+            }
+
+            It 'Should call the mock function Connect-SQL and Add-SqlServerRoleMember' {
+                
+                Mock -CommandName Add-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+                
+                Set-TargetResource @testParameters
+
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Add-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should return the state as present when desired loginName in server role successfully added' {
                 
                 Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
 
                 $result = Get-TargetResource @testParameters
-
-                It 'Should return the state as present' {
-                    $result.Ensure | Should Be 'Present'
-                }
-
-                It 'Should return the same values as passed as parameters' {
-                    $result.SQLServer | Should Be $testParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                    $result.Name | Should Be $testParameters.Name
-                }
-
-                It 'Should call the mock function Connect-SQL and Confirm-SqlServerRoleMember' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Test-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Roles {
-                        return @{
-                            'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state' {            
-                It 'Should return the test as false when desired loginName does not exist' {
-
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'UnknownUser'
-                        Ensure = 'Present'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                }
-
-                It 'Should return the test as false when non-desired loginName exist' {
-
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'NonDesiredUser'
-                        Ensure = 'Absent'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Context 'When the system is in the desired state' {
-                It 'Should return the test as true when desired loginName exist' {
-
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'CONTOSO\SQL-Admin'
-                        Ensure = 'Present'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-                            
-                It 'Should return the test as true when non-desired loginName does not exist' {
-
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $testParameters = $defaultParameters
-                    $testParameters += @{
-                        Name = 'CONTOSO\SQL-Admin'
-                        Ensure = 'Absent'
-                    }
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Confirm-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "$($script:DSCResourceName)\Set-TargetResource" {
-            Mock -CommandName Connect-SQL -MockWith {
-                return New-Object Object | 
-                    Add-Member ScriptProperty Roles {
-                        return @{
-                            'dbcreator' = @( ( New-Object Microsoft.SqlServer.Management.Smo.ServerRole -ArgumentList @( $null, 'CONTOSO\SQL-Admin')) )
-                        }
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            Context 'When the system is not in the desired state - PRESENT' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'CONTOSO\SQL-Admin'
-                    Ensure = 'Present'
-                }
-
-                It 'Should call the mock function Connect-SQL and Add-SqlServerRoleMember' {
-                    
-                    Mock -CommandName Add-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
-                    
-                    Set-TargetResource @testParameters
-
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Add-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should return the state as present when desired loginName in server role successfully added' {
-                    
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $true } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Get-TargetResource @testParameters
-                    $result.Ensure | Should Be 'Present'
-                }
-            }
-
-            Context 'When the system is not in the desired state - ABSENT' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'NonDesiredLogin'
-                    Ensure = 'Absent'
-                }
-
-                It 'Should call the mock function Connect-SQL and Remove-SqlServerRoleMember' {
-
-                    Mock -CommandName Remove-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
-
-                    Set-TargetResource @testParameters
-                    
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                    Assert-MockCalled Remove-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                }
-
-                It 'Should return the state as absent when desired loginName in server role successfully dropped' {
-                    
-                    Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
-
-                    $result = Get-TargetResource @testParameters
-                    $result.Ensure | Should Be 'absent'
-                }
+                $result.Ensure | Should Be 'Present'
             }
         }
-    }
-    finally
-    {
-        #region FOOTER
 
-        Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+        Context 'When the system is not in the desired state - ABSENT' {
+            $testParameters = $defaultParameters
+            $testParameters += @{
+                Name = 'NonDesiredLogin'
+                Ensure = 'Absent'
+            }
 
-        #endregion
+            It 'Should call the mock function Connect-SQL and Remove-SqlServerRoleMember' {
+
+                Mock -CommandName Remove-SqlServerRoleMember -MockWith { } -ModuleName $script:DSCResourceName -Verifiable
+
+                Set-TargetResource @testParameters
+                
+                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+                Assert-MockCalled Remove-SqlServerRoleMember -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
+            }
+
+            It 'Should return the state as absent when desired loginName in server role successfully dropped' {
+                
+                Mock -CommandName Confirm-SqlServerRoleMember -MockWith { return $false } -ModuleName $script:DSCResourceName -Verifiable
+
+                $result = Get-TargetResource @testParameters
+                $result.Ensure | Should Be 'absent'
+            }
+        }
     }
 }
+finally
+{
+    #region FOOTER
 
-$testJob | Receive-Job -Wait
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+
+    #endregion
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,12 @@ build: false
 
 test_script:
     - ps: |
+        Write-Host 'Removing all SQL related PowerShell modules so they can not be used by the common tests.'
+        Write-Host 'This is a workaround because the AppVeyor build worker image contains SQL Server. More information in issue #239.'
+        Write-Host 'Modules that are being removed:'
+        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Host $_.Path; Remove-Item $_.Path -Force; }
+
+        # Start the 
         $testResultsFile = ".\TestsResults.xml"
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))


### PR DESCRIPTION
Improvements how tests are initiated in AppVeyor
- Removed previous workaround (issue #201) from unit tests.
- Changes in appveyor.yml so that SQL modules are removed before common test is run.
- Changes to CONTRIBUTING.md
  - Removed the text about the need to do the workaround in tests (issue #201).
  - Added a short descriptive text how tests works with AppVeyor.
  - Added text explaining that a review only starts when all tests are passing.

This Pull Request (PR) fixes the following issues:
Fixes #239

- [X] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/245)
<!-- Reviewable:end -->
