### PR TITLE
xSQLServerLogin: Removed ShouldProcess; Added Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 - Changes to the unit test for resource
   - xSQLServerSetup
     - Added test coverage for helper function Copy-ItemWithRoboCopy
+- Changes to xSSQLServerLogin
+  - Removed ShouldProcess statements
+  - Added the ability to enforce password policies on SQL logins
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Changes to xSSQLServerLogin
   - Removed ShouldProcess statements
   - Added the ability to enforce password policies on SQL logins
+  - 
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@
 - Changes to xSSQLServerLogin
   - Removed ShouldProcess statements
   - Added the ability to enforce password policies on SQL logins
-  - 
 
 ## 4.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -220,9 +220,9 @@ function Set-TargetResource
                             }
                             catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
                             {
-                                if ( $_.Exception.InnerException.InnerException.InnerException -match '^Password validation failed' )
+                                if ( $_.Exception.InnerException.InnerException.InnerException -match 'Password validation failed' )
                                 {
-                                    throw New-TerminatingError -ErrorType PasswordValidationFailed -FormatArgs $Name -ErrorCategory SecurityError
+                                    throw New-TerminatingError -ErrorType PasswordValidationFailed -FormatArgs $Name,$_.Exception.InnerException.InnerException.InnerException -ErrorCategory SecurityError
                                 }
                                 else
                                 {

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -200,9 +200,9 @@ function Set-TargetResource
                             }
                             catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
                             {
-                                if ( $_.Exception.InnerException.InnerException.InnerException -match '^Password validation failed' )
+                                if ( $_.Exception.InnerException.InnerException.InnerException -match 'Password validation failed' )
                                 {
-                                    throw New-TerminatingError -ErrorType PasswordValidationFailed -FormatArgs $Name -ErrorCategory SecurityError
+                                    throw New-TerminatingError -ErrorType PasswordValidationFailed -FormatArgs $Name,$_.Exception.InnerException.InnerException.InnerException -ErrorCategory SecurityError
                                 }
                                 else
                                 {

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -212,7 +212,7 @@ function Set-TargetResource
                     SqlLogin
                     {
                         # Verify the instance is in Mixed authentication mode
-                        if ( @( 'Mixed', 'Integrated' ) -notcontains $serverObject.LoginMode )
+                        if ( $serverObject.LoginMode -notmatch 'Mixed|Integrated' )
                         {
                             throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $SQLServer,$SQLInstanceName,$serverObject.LoginMode -ErrorCategory NotImplemented
                         }

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -69,7 +69,7 @@ function Set-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $Name,
 
@@ -78,11 +78,11 @@ function Set-TargetResource
         [Microsoft.SqlServer.Management.Smo.LoginType]
         $LoginType = 'WindowsUser',
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $SQLServer,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory$true)]
         [System.String]
         $SQLInstanceName
     )
@@ -246,7 +246,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $Name,
 
@@ -254,11 +254,11 @@ function Test-TargetResource
         [Microsoft.SqlServer.Management.Smo.LoginType]
         $LoginType = 'WindowsUser',
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $SQLServer,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $SQLInstanceName
     )

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -21,10 +21,7 @@ function Get-TargetResource
         $SQLInstanceName = 'MSSQLSERVER'
     )
 
-    $LoginCredential = $paramDictionary.LoginCredential.Value
-    $LoginMustChangePassword = $paramDictionary.LoginMustChangePassword.Value
-    $LoginPasswordExpirationEnabled = $paramDictionary.LoginPasswordExpirationEnabled.Value
-    $LoginPasswordPolicyEnforced = $paramDictionary.LoginPasswordPolicyEnforced.Value
+    Import-SQLPSModule
     
     $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
 
@@ -59,7 +56,7 @@ function Get-TargetResource
         $returnValue.Add('LoginPasswordPolicyEnforced',$login.PasswordPolicyEnforced)
     }
 
-    $returnValue
+    return $returnValue
 }
 
 function Set-TargetResource
@@ -255,9 +252,9 @@ function Test-TargetResource
 
             # Create the LoginPasswordPolicyEnforced parameter
             $loginPasswordPolicyEnforcedAttribute = New-Object System.Management.Automation.ParameterAttribute
-            $ac3 = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
-            $ac3.Add($loginPasswordPolicyEnforcedAttribute)
-            $loginPasswordPolicyEnforcedParam = New-Object System.Management.Automation.RuntimeDefinedParameter('LoginPasswordPolicyEnforced', [bool], $ac3)
+            $ac4 = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+            $ac4.Add($loginPasswordPolicyEnforcedAttribute)
+            $loginPasswordPolicyEnforcedParam = New-Object System.Management.Automation.RuntimeDefinedParameter('LoginPasswordPolicyEnforced', [bool], $ac4)
             $loginPasswordPolicyEnforcedParam.Value = $true
             $paramDictionary.Add('LoginPasswordPolicyEnforced', $loginPasswordPolicyEnforcedParam)
         }

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -229,6 +229,10 @@ function Set-TargetResource
                                     throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
                                 }
                             }
+                            catch
+                            {
+                                throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                            }
                         }
 
                         default

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -130,7 +130,7 @@ function Set-TargetResource
         [System.String]
         $LoginType = 'WindowsUser',
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SQLServer,
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -82,7 +82,7 @@ function Set-TargetResource
         [System.String]
         $SQLServer,
 
-        [Parameter(Mandatory$true)]
+        [Parameter(Mandatory=$true)]
         [System.String]
         $SQLInstanceName
     )

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -196,7 +196,7 @@ function Set-TargetResource
 
                     New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
                     
-                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login($serverObject,$Name)
+                    $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $serverObject,$Name
                     $login.LoginType = $LoginType
 
                     switch ($LoginType)

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -226,6 +226,12 @@ function Set-TargetResource
                     {
                         SqlLogin
                         {
+                            # Verify the instance is in Mixed authentication mode
+                            if ( @( 'Mixed', 'Integrated' ) -notcontains $serverObject.LoginMode )
+                            {
+                                throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $SQLServer,$SQLInstanceName,$serverObject.LoginMode -ErrorCategory NotImplemented
+                            }
+                            
                             $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
                             $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
                             if ( $LoginMustChangePassword )

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -134,7 +134,7 @@ function Set-TargetResource
         [System.String]
         $SQLServer,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SQLInstanceName,
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -411,19 +411,21 @@ function Update-SQLServerLogin
         $Login
     )
 
-    $originalErrorActionPreference = $ErrorActionPreference
-    $ErrorActionPreference = 'Stop'
-
     try
     {
+        $originalErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Stop'
+        
         $Login.Alter()
     }
     catch
     {
         throw New-TerminatingError -ErrorType AlterLoginFailed -FormatArgs $Login.Name -ErrorCategory NotSpecified
     }
-
-    $ErrorActionPreference = 'Continue'
+    finally
+    {
+        $ErrorActionPreference = $originalErrorActionPreference
+    }
 }
 
 <#
@@ -473,6 +475,9 @@ function New-SQLServerLogin
         { 
             try
             {
+                $originalErrorActionPreference = $ErrorActionPreference
+                $ErrorActionPreference = 'Stop'
+                
                 $login.Create($SecureString,$LoginCreateOptions) 
             }
             catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
@@ -483,12 +488,16 @@ function New-SQLServerLogin
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                    throw New-TerminatingError -ErrorType LoginCreationFailedFailedOperation -FormatArgs $Name -ErrorCategory NotSpecified
                 }
             }
             catch
             {
-                throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                throw New-TerminatingError -ErrorType LoginCreationFailedSqlNotSpecified -FormatArgs $Name -ErrorCategory NotSpecified
+            }
+            finally
+            {
+                $ErrorActionPreference = $originalErrorActionPreference
             }
         }
 
@@ -496,11 +505,18 @@ function New-SQLServerLogin
         {
             try
             {
+                $originalErrorActionPreference = $ErrorActionPreference
+                $ErrorActionPreference = 'Stop'
+                
                 $login.Create()
             }
             catch
             {
-                throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                throw New-TerminatingError -ErrorType LoginCreationFailedWindowsNotSpecified -FormatArgs $Name -ErrorCategory NotSpecified
+            }
+            finally
+            {
+                $ErrorActionPreference = $originalErrorActionPreference
             }
         }
     }
@@ -527,11 +543,18 @@ function Remove-SQLServerLogin
 
     try
     {
+        $originalErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Stop'
+        
         $Login.Drop()
     }
     catch
     {
         throw New-TerminatingError -ErrorType DropLoginFailed -FormatArgs $Login.Name -ErrorCategory NotSpecified
+    }
+    finally
+    {
+        $ErrorActionPreference = $originalErrorActionPreference
     }
 }
 
@@ -563,6 +586,9 @@ function Set-SQLServerLoginPassword
 
     try
     {
+        $originalErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Stop'
+        
         $Login.ChangePassword($SecureString)
     }
     catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
@@ -579,6 +605,10 @@ function Set-SQLServerLoginPassword
     catch
     {
         throw New-TerminatingError -ErrorType PasswordChangeFailed -FormatArgs $Name -ErrorCategory NotSpecified
+    }
+    finally
+    {
+        $ErrorActionPreference = $originalErrorActionPreference
     }
 }
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -189,17 +189,17 @@ function Set-TargetResource
                 else
                 {
                     # Some login types need additional work. These will need to be fleshed out more in the future
-                    if ( @('Certificate','AsymmetricKey','ExternalUser','ExternalGroup') -contains $LoginType )
+                    if ( @('Certificate','AsymmetricKey','ExternalUser','ExternalGroup') -contains $lt )
                     {
-                        throw New-TerminatingError -ErrorType LoginTypeNotImplemented -FormatArgs $LoginType -ErrorCategory NotImplemented
+                        throw New-TerminatingError -ErrorType LoginTypeNotImplemented -FormatArgs $lt -ErrorCategory NotImplemented
                     }
 
                     New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
                     
                     $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $serverObject,$Name
-                    $login.LoginType = $LoginType
+                    $login.LoginType = $lt
 
-                    switch ($LoginType)
+                    switch ($lt)
                     {
                         SqlLogin
                         {
@@ -316,7 +316,7 @@ function Test-TargetResource
             'ExternalUser',
             'ExternalGroup'
         )]
-       [System.String]
+        [System.String]
         $LoginType = 'WindowsUser',
 
         [Parameter(Mandatory=$true)]

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -188,22 +188,54 @@ function Set-TargetResource
                 }
                 else
                 {
-                    $createParams = @{
-                        Name = $Name
-                        SQLServer = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
-                        LoginType = $LoginType
-                    }
-
-                    if ( $LoginType -eq 'SqlLogin' )
+                    # Some login types need additional work. These will need to be fleshed out more in the future
+                    if ( @('Certificate','AsymmetricKey','ExternalUser','ExternalGroup') -contains $LoginType )
                     {
-                        $createParams.Add('LoginMustChangePassword',$LoginMustChangePassword)
-                        $createParams.Add('LoginPasswordExpirationEnabled',$LoginPasswordExpirationEnabled)
-                        $createParams.Add('LoginPasswordPolicyEnforced',$LoginPasswordPolicyEnforced)
+                        throw New-TerminatingError -ErrorType LoginTypeNotImplemented -FormatArgs $LoginType -ErrorCategory NotImplemented
                     }
 
                     New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
-                    New-SqlLogin @createParams
+                    
+                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login($serverObject,$Name)
+                    $login.LoginType = $LoginType
+
+                    switch ($LoginType)
+                    {
+                        SqlLogin
+                        {
+                            $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
+                            $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
+                            if ( $LoginMustChangePassword )
+                            {
+                                $LoginCreateOptions = [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::MustChange
+                            }
+                            else
+                            {
+                                $LoginCreateOptions = [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::None
+                            }
+                            
+                            try
+                            {
+                                $login.Create($LoginCredential.Password,$LoginCreateOptions)
+                            }
+                            catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
+                            {
+                                if ( $_.Exception.InnerException.InnerException.InnerException -match '^Password validation failed' )
+                                {
+                                    throw New-TerminatingError -ErrorType PasswordValidationFailed -FormatArgs $Name -ErrorCategory SecurityError
+                                }
+                                else
+                                {
+                                    throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                                }
+                            }
+                        }
+
+                        default
+                        {
+                            $login.Create()
+                        }
+                    }
                 }
             }
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -212,7 +212,7 @@ function Set-TargetResource
                     SqlLogin
                     {
                         # Verify the instance is in Mixed authentication mode
-                        if ( @( 'Mixed', 'Integrated' ) -notcontains $serverObject.LoginMode )
+                        if ( $serverObject.LoginMode -notmatch 'Mixed|Integrated' )
                         {
                             throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $SQLServer,$SQLInstanceName,$serverObject.LoginMode -ErrorCategory NotImplemented
                         }
@@ -333,6 +333,10 @@ function Test-TargetResource
         [Parameter(Mandatory=$true)]
         [System.String]
         $SQLInstanceName,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $LoginCredential,
 
         [Parameter()]
         [bool]

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -209,6 +209,10 @@ function Set-TargetResource
                                     throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
                                 }
                             }
+                            catch
+                            {
+                                throw New-TerminatingError -ErrorType LoginCreationFailed -FormatArgs $Name -ErrorCategory NotSpecified
+                            }
                         }
 
                         default

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -2,6 +2,19 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 
+<#
+    .SYNOPSIS
+    Gets the specified login by name.
+
+    .PARAMETER Name
+    The name of the login to retrieve.
+    
+    .PARAMETER SQLServer
+    Hostname of the SQL Server to retrieve the login from.
+    
+    .PARAMETER SQLInstanceName
+    Name of the SQL instance to retrieve the login from. 
+#>
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -59,6 +72,37 @@ function Get-TargetResource
     return $returnValue
 }
 
+<#
+    .SYNOPSIS
+    Creates a login.
+
+    .PARAMETER Ensure
+    Specifies if the login to exist. Default is 'Present'.
+    
+    .PARAMETER Name
+    The name of the login to retrieve.
+
+    .PARAMETER LoginType
+    The type of login to create. Default is 'WindowsUser'
+    
+    .PARAMETER SQLServer
+    Hostname of the SQL Server to create the login on.
+    
+    .PARAMETER SQLInstanceName
+    Name of the SQL instance to create the login on.
+
+    .PARAMETER LoginCredential
+    The credential containing the password for a SQL Login. Only applies if the login type is SqlLogin.
+
+    .PARAMETER LoginMustChangePassword
+    Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.
+
+    .PARAMETER LoginPasswordExpirationEnabled
+    Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
+
+    .PARAMETER LoginPasswordPolicyEnforced
+    Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -74,7 +118,6 @@ function Set-TargetResource
         $Name,
 
         [Parameter()]
-        #[ValidateSet('SqlLogin', 'WindowsUser', 'WindowsGroup')]
         [Microsoft.SqlServer.Management.Smo.LoginType]
         $LoginType = 'WindowsUser',
 
@@ -235,6 +278,37 @@ function Set-TargetResource
     }
 }
 
+<#
+    .SYNOPSIS
+    Tests to verify the login exists and the properties are correctly set.
+
+    .PARAMETER Ensure
+    Specifies if the login is supposed to exist. Default is 'Present'.
+    
+    .PARAMETER Name
+    The name of the login.
+
+    .PARAMETER LoginType
+    The type of login. Default is 'WindowsUser'
+    
+    .PARAMETER SQLServer
+    Hostname of the SQL Server.
+    
+    .PARAMETER SQLInstanceName
+    Name of the SQL instance.
+
+    .PARAMETER LoginCredential
+    The credential containing the password for a SQL Login. Only applies if the login type is SqlLogin.
+
+    .PARAMETER LoginMustChangePassword
+    Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.
+
+    .PARAMETER LoginPasswordExpirationEnabled
+    Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
+
+    .PARAMETER LoginPasswordPolicyEnforced
+    Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
+#>
 function Test-TargetResource
 {
     [CmdletBinding()]

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -74,8 +74,8 @@ function Set-TargetResource
         $Name,
 
         [Parameter()]
-        [ValidateSet('SqlLogin', 'WindowsUser', 'WindowsGroup')]
-        [System.String]
+        #[ValidateSet('SqlLogin', 'WindowsUser', 'WindowsGroup')]
+        [Microsoft.SqlServer.Management.Smo.LoginType]
         $LoginType = 'WindowsUser',
 
         [Parameter(Mandatory)]
@@ -91,7 +91,7 @@ function Set-TargetResource
     {
         $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
         
-        if ( $LoginType -eq 'SqlLogin' )
+        if ( $LoginType -eq 'SqlLogin' -and $Ensure -eq 'Present' )
         {
             # Create the LoginCredential parameter 
             $loginCredAttribute = New-Object System.Management.Automation.ParameterAttribute
@@ -176,7 +176,7 @@ function Set-TargetResource
 
                     New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
                     
-                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login($serverObject,$Name)
+                    $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $serverObject,$Name
                     $login.LoginType = $LoginType
 
                     switch ($LoginType)
@@ -247,8 +247,7 @@ function Test-TargetResource
         $Name,
 
         [Parameter()]
-        [ValidateSet('SqlLogin', 'WindowsUser', 'WindowsGroup')]
-        [System.String]
+        [Microsoft.SqlServer.Management.Smo.LoginType]
         $LoginType = 'WindowsUser',
 
         [Parameter(Mandatory)]

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -118,7 +118,8 @@ function Set-TargetResource
         $Name,
 
         [Parameter()]
-        [ValidateSet('WindowsUser',
+        [ValidateSet(
+            'WindowsUser',
             'WindowsGroup',
             'SqlLogin',
             'Certificate',
@@ -155,18 +156,6 @@ function Set-TargetResource
     )
 
     Import-SQLPSModule
-
-    try
-    {
-        if ( [Microsoft.SqlServer.Management.Smo.LoginType]$LoginType )
-        {
-            $lt = [Microsoft.SqlServer.Management.Smo.LoginType]$LoginType
-        }
-    }
-    catch
-    {
-        Throw New-TerminatingError -ErrorType InvalidLoginType -FormatArgs $LoginType -ErrorCategory InvalidType
-    }
     
     $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
     
@@ -179,10 +168,10 @@ function Set-TargetResource
                 $login = $serverObject.Logins[$Name]
 
                 if ( $login.LoginType -eq 'SqlLogin' )
-                {
-                    if ( -not $LoginCredential )
+                {                    
+                    if ( ( $LoginType -eq 'SqlLogin' ) -and ( -not $LoginCredential ) )
                     {
-                        New-TerminatingError -ErrorType LoginCredentialNoFound -FormatArgs $Name -ErrorCategory ObjectNotFound
+                        throw New-TerminatingError -ErrorType LoginCredentialNotFound -FormatArgs $Name -ErrorCategory ObjectNotFound
                     }
                     
                     if ( $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled )
@@ -203,17 +192,22 @@ function Set-TargetResource
             else
             {
                 # Some login types need additional work. These will need to be fleshed out more in the future
-                if ( @('Certificate','AsymmetricKey','ExternalUser','ExternalGroup') -contains $lt )
+                if ( @('Certificate','AsymmetricKey','ExternalUser','ExternalGroup') -contains $LoginType )
                 {
-                    throw New-TerminatingError -ErrorType LoginTypeNotImplemented -FormatArgs $lt -ErrorCategory NotImplemented
+                    throw New-TerminatingError -ErrorType LoginTypeNotImplemented -FormatArgs $LoginType -ErrorCategory NotImplemented
                 }
 
+                if ( ( $LoginType -eq 'SqlLogin' ) -and ( -not $LoginCredential ) )
+                {
+                    throw New-TerminatingError -ErrorType LoginCredentialNotFound -FormatArgs $Name -ErrorCategory ObjectNotFound
+                }
+                
                 New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
                 
                 $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $serverObject,$Name
-                $login.LoginType = $lt
+                $login.LoginType = $LoginType
 
-                switch ($lt)
+                switch ($LoginType)
                 {
                     SqlLogin
                     {

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -203,6 +203,12 @@ function Set-TargetResource
                     {
                         SqlLogin
                         {
+                            # Verify the instance is in Mixed authentication mode
+                            if ( @( 'Mixed', 'Integrated' ) -notcontains $serverObject.LoginMode )
+                            {
+                                throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $SQLServer,$SQLInstanceName,$serverObject.LoginMode -ErrorCategory NotImplemented
+                            }
+                            
                             $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
                             $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
                             if ( $LoginMustChangePassword )

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -7,7 +7,7 @@ class MSFT_xSQLServerLogin : OMI_BaseResource
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;
-    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.")] Bool LoginMustChangePassword;
-    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.")] Bool LoginPasswordExpirationEnabled;
-    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.") Bool LoginPasswordPolicyEnforced]
+    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.")] Boolean LoginMustChangePassword;
+    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.")] Boolean LoginPasswordExpirationEnabled;
+    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.")] Boolean LoginPasswordPolicyEnforced;
 };

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -1,13 +1,15 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerLogin")]
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
-    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The specified login is Present or Absent. Default is Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the login.")] String Name;
-    [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name."), Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
+    [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name. Default is WindowsUser. Unsupported login types are Certificate, AsymmetricKey, ExternalUser, and ExternalGroup."),
+        ValueMap{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"},
+        Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;
-    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.")] Boolean LoginMustChangePassword;
-    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.")] Boolean LoginPasswordExpirationEnabled;
-    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.")] Boolean LoginPasswordPolicyEnforced;
+    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.")] Boolean LoginMustChangePassword;
+    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.")] Boolean LoginPasswordExpirationEnabled;
+    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.")] Boolean LoginPasswordPolicyEnforced;
 };

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerLogin")]
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
-    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure; 
     [Key, Description("The name of the login.")] String Name;
     [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name."), Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -1,10 +1,13 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerLogin")]
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
-    [Write, Description("If the values should be present or absent. Valid values are 'Present' or 'Absent'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The name of the SQL login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.")] String Name;
+    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Key, Description("The name of the login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.")] String Name;
+    [Required,Description("The type of login to be created.") ] String LoginType;
+    [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
+    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;
-    [Write, Description("The SQL login type. Valid values are 'SqlLogin', 'WindowsUser' or 'WindowsGroup'."), ValueMap{"SqlLogin","WindowsUser","WindowsGroup"}, Values{"SqlLogin","WindowsUser","WindowsGroup"}] String LoginType;
-    [Key, Description("The SQL Server for the login.")] String SQLServer;
-    [Key, Description("The SQL instance for the login.")] String SQLInstanceName;
+    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.")] Bool LoginMustChangePassword;
+    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.")] Bool LoginPasswordExpirationEnabled;
+    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.") Bool LoginPasswordPolicyEnforced]
 };

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -3,7 +3,7 @@ class MSFT_xSQLServerLogin : OMI_BaseResource
 {
     [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the login.")] String Name;
-    [Write,Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.") ] String LoginType;
+    [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name."), Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerLogin")]
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
-    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure; 
+    [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the login.")] String Name;
     [Write, Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name."), Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -2,8 +2,8 @@
 class MSFT_xSQLServerLogin : OMI_BaseResource
 {
     [Write, Description("The specified login is Present or Absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The name of the login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.")] String Name;
-    [Required,Description("The type of login to be created.") ] String LoginType;
+    [Key, Description("The name of the login.")] String Name;
+    [Write,Description("The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.") ] String LoginType;
     [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.")] String LoginCredential;

--- a/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
@@ -1,0 +1,54 @@
+<#
+.EXAMPLE
+This example shows how to ensure that the Windows user 'CONTOSO\WindowsUser' exists.
+
+.EXAMPLE
+This example shows how to ensure that the Windows group 'CONTOSO\WindowsGroup' exists.
+
+.EXAMPLE
+This example shows how to ensure that the SQL Login 'SqlLogin' exists.
+#>
+
+Configuration Example 
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $SysAdminAccount
+    )
+    
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost {
+        xSQLServerLogin Add_WindowsUser
+        {
+            Ensure = 'Present'
+            Name = 'CONTOSO\WindowsUser'
+            LoginType = 'WindowsUser'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+        }
+
+        xSQLServerLogin Add_WindowsGroup
+        {
+            Ensure = 'Present'
+            Name = 'CONTOSO\WindowsGroup'
+            LoginType = 'WindowsGroup'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+        }
+
+        xSQLServerLogin Add_SqlLogin
+        {
+            Ensure = 'Present'
+            Name = 'SqlLogin'
+            LoginType = 'SqlLogin'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            LoginCredential = $SysAdminAccount
+            LoginMustChangePassword = $false
+            LoginPasswordExpirationEnabled = $true
+            LoginPasswordPolicyEnforced = $true
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
@@ -1,6 +1,6 @@
 <#
 .EXAMPLE
-This example shows how to ensure that the Windows user 'CONTOSO\WindowsUser' exists.
+This example shows how to ensure that the Windows user 'CONTOSO\WindowsUser' exists. 
 
 .EXAMPLE
 This example shows how to ensure that the Windows group 'CONTOSO\WindowsGroup' exists.

--- a/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
@@ -14,7 +14,11 @@ Configuration Example
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
-        $SysAdminAccount
+        $SysAdminAccount,
+
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $LoginCredential
     )
     
     Import-DscResource -ModuleName xSqlServer
@@ -27,6 +31,7 @@ Configuration Example
             LoginType = 'WindowsUser'
             SQLServer = 'SQLServer'
             SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
         }
 
         xSQLServerLogin Add_WindowsGroup
@@ -36,6 +41,7 @@ Configuration Example
             LoginType = 'WindowsGroup'
             SQLServer = 'SQLServer'
             SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
         }
 
         xSQLServerLogin Add_SqlLogin
@@ -45,10 +51,11 @@ Configuration Example
             LoginType = 'SqlLogin'
             SQLServer = 'SQLServer'
             SQLInstanceName = 'DSC'
-            LoginCredential = $SysAdminAccount
+            LoginCredential = $LoginCredential
             LoginMustChangePassword = $false
             LoginPasswordExpirationEnabled = $true
             LoginPasswordPolicyEnforced = $true
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
 }

--- a/Examples/Resources/xSQLServerLogin/2-RemoveLogin.ps1
+++ b/Examples/Resources/xSQLServerLogin/2-RemoveLogin.ps1
@@ -1,0 +1,44 @@
+<#
+.EXAMPLE
+This example shows how to remove the Windows user 'CONTOSO\WindowsUser'.
+
+.EXAMPLE
+This example shows how to remove Windows group 'CONTOSO\WindowsGroup'.
+
+.EXAMPLE
+This example shows how to remove the SQL Login 'SqlLogin'.
+#>
+
+Configuration Example 
+{    
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost {
+        xSQLServerLogin Remove_WindowsUser
+        {
+            Ensure = 'Absent'
+            Name = 'CONTOSO\WindowsUser'
+            LoginType = 'WindowsUser'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+        }
+
+        xSQLServerLogin Remove_WindowsGroup
+        {
+            Ensure = 'Absent'
+            Name = 'CONTOSO\WindowsGroup'
+            LoginType = 'WindowsGroup'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+        }
+
+        xSQLServerLogin Remove_SqlLogin
+        {
+            Ensure = 'Absent'
+            Name = 'SqlLogin'
+            LoginType = 'SqlLogin'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -287,6 +287,44 @@ A full list of changes in each version can be found in the [change log](CHANGELO
 * **LoginPasswordExpirationEnabled**: Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
 * **LoginPasswordPolicyEnforced**: Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
 
+### xSQLServerRole
+
+* **Name**: (Key) Name of the SQL Login to create
+* **Ensure**: If the values should be present or absent. Valid values are 'Present' or 'Absent'.
+* **ServerRole**: Type of SQL role to add.(bulkadmin, dbcreator, diskadmin, processadmin , public, securityadmin, serveradmin , setupadmin, sysadmin)
+* **SQLServer**: SQL Server where login should be created
+* **SQLInstance**: (Key) SQL Instance for the login
+
+### xSQLServerDatabaseRole
+
+* **Ensure**: If 'Present' (the default value) then the login (user) will be added to the role(s). If 'Absent' then the login (user) will be removed from the role(s).
+* **Name**: (Key) The name of the login that will become a member, or removed as a member, of the role(s).
+* **SQLServer**: (Key) The SQL server on which the instance exist.
+* **SQLInstanceName**: (Key) The SQL instance in which the database exist.
+* **Database**: (Key) The database in which the login (user) and role(s) exist.
+* **Role**: One or more roles to which the login (user) will be added or removed.
+
+### xSQLServerDatabasePermissions
+
+* **Database**: (Key) The SQL Database
+* **Name**: (Required) The name of permissions for the SQL database
+* **Permissions**: (Required) The set of Permissions for the SQL database
+* **SQLServer**: The SQL Server for the database
+* **SQLInstanceName**: The SQL instance for the database
+
+### xSQLServerDatabaseOwner
+
+* **Database**: (Key) The SQL Database
+* **Name**: (Required) The name of the SQL login for the owner
+* **SQLServer**: The SQL Server for the database
+* **SQLInstance**: The SQL instance for the database
+
+### xSQLDatabaseRecoveryModel
+
+* **DatabaseName**: (key) The SQL database name
+* **SQLServerInstance**: (Required) The SQL server and instance
+* **RecoveryModel**: (Required) Recovery Model (Full, Simple, BulkLogged)
+
 ### xSQLServerMaxDop
 
 * **Ensure**: An enumerated value that describes if Min and Max memory is configured

--- a/README.md
+++ b/README.md
@@ -277,12 +277,15 @@ A full list of changes in each version can be found in the [change log](CHANGELO
 
 ### xSQLServerLogin
 
-* **Ensure**: If the values should be present or absent. Valid values are 'Present' or 'Absent'.
-* **Name**: (Key) The name of the SQL login. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.
+* **Ensure**: The specified login is Present or Absent.
+* **Name**: (Key) The name of the SQL login.
+* **LoginType**: The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.
+* **SQLServer**: (Key) The hostname of the SQL Server to be configured.
+* **SQLInstanceName**: (Key) Name of the SQL instance to be configured.
 * **LoginCredential**: If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.
-* **LoginType**: The SQL login type. Valid values are 'SqlLogin', 'WindowsUser' or 'WindowsGroup'.
-* **SQLServer**: (Key) The SQL Server for the login.
-* **SQLInstanceName**: (Key) The SQL instance for the login.
+* **LoginMustChangePassword**: Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.
+* **LoginPasswordExpirationEnabled**: Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
+* **LoginPasswordPolicyEnforced**: Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
 
 ### xSQLServerMaxDop
 

--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ A full list of changes in each version can be found in the [change log](CHANGELO
 ### xSQLServerLogin
 
 * **Ensure**: The specified login is Present or Absent.
-* **Name**: (Key) The name of the SQL login.
-* **LoginType**: The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name.
+* **Name**: (Key) The name of the login.
+* **LoginType**: The type of login to be created. If LoginType is 'WindowsUser' or 'WindowsGroup' then provide the name in the format DOMAIN\name. Default is WindowsUser. Unsupported login types are Certificate, AsymmetricKey, ExternalUser, and ExternalGroup.
 * **SQLServer**: (Key) The hostname of the SQL Server to be configured.
 * **SQLInstanceName**: (Key) Name of the SQL instance to be configured.
 * **LoginCredential**: If LoginType is 'SqlLogin' then a PSCredential is needed for the password to the login.
-* **LoginMustChangePassword**: Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.
-* **LoginPasswordExpirationEnabled**: Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
-* **LoginPasswordPolicyEnforced**: Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
+* **LoginMustChangePassword**: Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.
+* **LoginPasswordExpirationEnabled**: Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.
+* **LoginPasswordPolicyEnforced**: Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.
 
 ### xSQLServerRole
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -177,16 +177,6 @@ try
             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
 	}
 
-    $mockNewObjectSmoLogin = {       
-        return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
-            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
-    }
-
-    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
-
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -149,16 +149,6 @@ try
 			} -PassThru -Force
 	}
 
-    $mockNewObjectSmoLogin = {       
-        return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
-            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
-    }
-
-    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
-
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
@@ -396,7 +386,6 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
@@ -470,7 +459,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified Windows Group when it is Absent' {
@@ -481,7 +469,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified SQL Login when it is Absent' {
@@ -515,7 +502,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
@@ -526,7 +512,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 0 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
@@ -537,7 +522,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows Group is Present' {
@@ -548,7 +532,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified SQL Login is Present and all parameters match' {
@@ -560,7 +543,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
@@ -573,7 +555,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
@@ -586,7 +567,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when password validation fails when creating a SQL Login' {
@@ -598,7 +578,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should throw when creating a SQL Login fails' {
@@ -610,7 +589,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
         }
     }

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -177,6 +177,16 @@ try
             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
 	}
 
+    $mockNewObjectSmoLogin = {       
+        return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
+    }
+
+    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
+
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
@@ -197,7 +207,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-            }  
+            }
         }
 
         Context 'When the login is Present' {
@@ -701,7 +711,6 @@ try
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
-
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'PasswordValidationFailed'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -515,6 +515,7 @@ try
             It 'Should add the specified SQL Login when it is Absent' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
 
+<<<<<<< 5dc97f5c092fd1d8fdd3ba52ee913dd858e618cf
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -528,6 +529,8 @@ try
             It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 
+=======
+>>>>>>> Added a check for Login Mode before attempting to create a SQL Login
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -541,6 +544,8 @@ try
             }
 
             It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -564,11 +569,19 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
+<<<<<<< 5dc97f5c092fd1d8fdd3ba52ee913dd858e618cf
             It 'Should throw LoginCredentialNotFound when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 
                 $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
+=======
+            It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
+                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
+>>>>>>> Added a check for Login Mode before attempting to create a SQL Login
 
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
 
@@ -687,7 +700,7 @@ try
                 
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
 
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
 
@@ -709,6 +722,8 @@ try
             }
             
             It 'Should throw when creating a SQL Login fails' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentExisting.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -720,6 +735,8 @@ try
             }
 
             It 'Should throw when creating a SQL Login fails with an unhandled exception' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentUnknown.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -1,6 +1,5 @@
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-param()
 
 $script:DSCModuleName      = 'xSQLServer'
 $script:DSCResourceName    = 'MSFT_xSQLServerLogin'
@@ -58,6 +57,8 @@ try
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
 
+        Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
+
         Context 'When the system is not in the desired state' {
             $testParameters = $defaultParameters
             $testParameters += @{
@@ -68,7 +69,7 @@ try
 
             It 'Should not return the state as absent' {
                 $result.Ensure | Should Be 'Absent'
-                $result.LoginType | Should Be ''
+                $result.LoginType | Should Be $null
             }
 
             It 'Should return the same values as passed as parameters' {
@@ -158,6 +159,10 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
+        
+        # Loading stub cmdlets
+        Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
+        
         Mock -CommandName Connect-SQL -MockWith {
             return New-Object Object | 
                 Add-Member ScriptProperty Logins {
@@ -168,6 +173,8 @@ try
                     }
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
 
         Context 'When the system is not in the desired state' {
             It 'Should return the state as absent when desired windows user does not exist' {
@@ -253,6 +260,10 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
+
+        # Loading stub cmdlets
+        Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
+
         Mock -CommandName Connect-SQL -MockWith {
             return New-Object Object | 
                 Add-Member ScriptProperty Logins {
@@ -263,6 +274,8 @@ try
                     }
                 } -PassThru -Force 
         } -ModuleName $script:DSCResourceName -Verifiable
+
+        Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
 
         Context 'When the system is not in the desired state' {
             $testParameters = $defaultParameters

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -43,7 +43,7 @@ try
         SQLInstanceName = 'MSSQLSERVER'
         SQLServer = 'Server1'
     }
-      
+
     $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
     $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
 
@@ -694,7 +694,23 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
+
+            It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
         }
+    }
+
+    Describe "$($script:DSCResourceName)\Set-TargetResource" {
+        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
+        Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
     }
 }
 finally

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -169,16 +169,6 @@ try
             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
 	}
 
-    $mockNewObjectSmoLogin = {       
-        return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
-            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
-    }
-
-    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
-
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
@@ -415,7 +405,6 @@ try
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
@@ -542,6 +531,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+
             }
 
             It 'Should throw when adding an unsupported login type' {

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -515,7 +515,6 @@ try
             It 'Should add the specified SQL Login when it is Absent' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
 
-<<<<<<< 5dc97f5c092fd1d8fdd3ba52ee913dd858e618cf
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -529,8 +528,6 @@ try
             It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 
-=======
->>>>>>> Added a check for Login Mode before attempting to create a SQL Login
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -569,19 +566,11 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
-<<<<<<< 5dc97f5c092fd1d8fdd3ba52ee913dd858e618cf
             It 'Should throw LoginCredentialNotFound when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 
                 $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
-=======
-            It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-                
-                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
->>>>>>> Added a check for Login Mode before attempting to create a SQL Login
 
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -106,6 +106,7 @@ try
     $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
     $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
     $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
+
     
     $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
     $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
@@ -147,6 +148,16 @@ try
 				}
 			} -PassThru -Force
 	}
+
+    $mockNewObjectSmoLogin = {       
+        return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
+    }
+
+    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
 
     #endregion Pester Test Initialization
 
@@ -385,6 +396,7 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
@@ -458,6 +470,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified Windows Group when it is Absent' {
@@ -468,6 +481,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified SQL Login when it is Absent' {
@@ -501,6 +515,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
@@ -511,6 +526,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 0 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
@@ -521,6 +537,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows Group is Present' {
@@ -531,6 +548,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified SQL Login is Present and all parameters match' {
@@ -542,6 +560,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
@@ -554,6 +573,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
@@ -566,6 +586,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when password validation fails when creating a SQL Login' {
@@ -577,10 +598,11 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should throw when creating a SQL Login fails' {
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentExisting.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
 
@@ -588,17 +610,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should throw when creating a SQL Login fails with an unhandled exception' {
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentUnknown.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-
-                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'LoginCreationFailed'
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
         }
     }

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -197,9 +197,7 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-            }
-
-            
+            }  
         }
 
         Context 'When the login is Present' {

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -787,7 +787,7 @@ try
                     $login.LoginType = 'WindowsUser'
                     $login.MockLoginType = 'SqlLogin'
 
-                    { New-SQLServerLogin -Login $login } | Should Throw 'LoginCreationFailed'
+                    { New-SQLServerLogin -Login $login } | Should Throw 'LoginCreationFailedWindowsNotSpecified'
                 }
 
                 It 'Should throw the correct error when password validation fails when creating a SQL Login' {
@@ -813,7 +813,7 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
+                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailedFailedOperation'
                 }
 
                 It 'Should throw the correct error when creating a SQL Login fails with an unhandled exception' {
@@ -826,7 +826,7 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
+                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailedSqlNotSpecified'
                 }
             }
         }

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -106,7 +106,6 @@ try
     $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
     $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
     $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
-
     
     $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
     $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
@@ -581,7 +580,18 @@ try
             }
 
             It 'Should throw when creating a SQL Login fails' {
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentExisting.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'LoginCreationFailed'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should throw when creating a SQL Login fails with an unhandled exception' {
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentUnknown.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -28,431 +28,323 @@ try
 {
     #region Pester Test Initialization
 
-    # Loading mocked classes
-    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+    Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
 
-    $nodeName = 'localhost'
-    $instanceName = 'MSSQLSERVER'
-
+    # Create PSCredential object for SQL Logins
     $mockSqlLoginUser = "dba" 
     $mockSqlLoginPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
     $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
 
-    $defaultParameters = @{
-        SQLInstanceName = $instanceName
-        SQLServer = $nodeName
+    $instanceParameters = @{
+        SQLInstanceName = 'MSSQLSERVER'
+        SQLServer = 'Server1'
     }
+    
+    $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
+    $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
+
+    $getTargetResource_UnknownWindows = $instanceParameters.Clone()
+    $getTargetResource_UnknownWindows.Add( 'Name','Windows\UserOrGroup' )
+
+    $getTargetResource_KnownSqlLogin = $instanceParameters.Clone()
+    $getTargetResource_KnownSqlLogin.Add( 'Name','SqlLogin1' )
+
+    $getTargetResource_KnownWindowsUser = $instanceParameters.Clone()
+    $getTargetResource_KnownWindowsUser.Add( 'Name','Windows\User1' )
+
+    $getTargetResource_KnownWindowsGroup = $instanceParameters.Clone()
+    $getTargetResource_KnownWindowsGroup.Add( 'Name','Windows\Group1' )
+
+    $testTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+    $testTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+    $testTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+    $testTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+    $testTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+    $testTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+    $testTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+    $testTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+    $testTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+
+    $testTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+    $testTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+    $testTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
+    $testTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
+    $testTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
+    $testTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+
+    $testTargetResource_SqlLoginPresentWithDefaultValues = $instanceParameters.Clone()
+    $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
+    $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
+
+    #$testTargetResource_SqlLoginPresent.Add( 'LoginMustChangePassword',$true )
+    #$testTargetResource_SqlLoginPresent.Add( 'LoginPasswordExpirationEnabled',$true )
+    #$testTargetResource_SqlLoginPresent.Add( 'LoginPasswordPolicyEnforced',$true )
+
+    $mockConnectSQL = {
+		return New-Object Object | 
+			Add-Member ScriptProperty Logins {
+				return @{
+					'Windows\User1' = @( ( New-Object Object | 
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
+						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru -Force
+                    ) )
+					'SqlLogin1' = @( ( New-Object Object | 
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
+						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru | 
+						Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+						Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+						Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru -Force
+                    ) )
+					'Windows\Group1' = @( ( New-Object Object | 
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
+						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru -Force
+                    ) )
+				}
+			} -PassThru -Force
+	}
 
     #endregion Pester Test Initialization
 
     Describe "$($script:DSCResourceName)\Get-TargetResource" {
-        Mock -CommandName Connect-SQL -MockWith {
-            return New-Object Object | 
-                Add-Member ScriptProperty Logins {
-                    return @{
-                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                    }
-                } -PassThru -Force 
-        } -ModuleName $script:DSCResourceName -Verifiable
-
+        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable -Scope Describe
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
 
-        Context 'When the system is not in the desired state' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\UnknownUser'
+        Context 'When the login is Absent' {
+
+            It 'Should be Absent when an unknown SQL Login is provided' {
+                ( Get-TargetResource @getTargetResource_UnknownSqlLogin ).Ensure | Should Be 'Absent'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            $result = Get-TargetResource @testParameters
+            It 'Should be Absent when an unknown Windows User or Group is provided' {
+                ( Get-TargetResource @getTargetResource_UnknownWindows ).Ensure | Should Be 'Absent'
 
-            It 'Should not return the state as absent' {
-                $result.Ensure | Should Be 'Absent'
-                $result.LoginType | Should Be $null
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.SQLServer | Should Be $testParameters.SQLServer
-                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                $result.Name | Should Be $testParameters.Name
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should call the mock function Connect-SQL' {
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-            }
-        }
-    
-        Context 'When the system is in the desired state for a Windows user' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\Stacy'
-            }
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should not return the state as present' {
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'WindowsUser'
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.SQLServer | Should Be $testParameters.SQLServer
-                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Connect-SQL' {
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-            }
+            
         }
 
-        Context 'When the system is in the desired state for a Windows group' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\SqlUsers'
-            }
-    
-            $result = Get-TargetResource @testParameters
+        Context 'When the login is Present' {
+            It 'Should be Present when a known SQL Login is provided' {
+                $result = Get-TargetResource @getTargetResource_KnownSqlLogin
 
-            It 'Should return the state as present' {
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'WindowsGroup'
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.SQLServer | Should Be $testParameters.SQLServer
-                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Connect-SQL' {
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-            }
-        }
-
-        Context 'When the system is in the desired state for a SQL login' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'John'
-            }
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the state as present' {
                 $result.Ensure | Should Be 'Present'
                 $result.LoginType | Should Be 'SqlLogin'
+                $result.LoginMustChangePassword | Should Not Be $null
+                $result.LoginPasswordExpirationEnabled | Should Not Be $null
+                $result.LoginPasswordPolicyEnforced | Should Not Be $null
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should return the same values as passed as parameters' {
-                $result.SQLServer | Should Be $testParameters.SQLServer
-                $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
-                $result.Name | Should Be $testParameters.Name
+            It 'Should be Present when a known Windows User is provided' {
+                $result = Get-TargetResource @getTargetResource_KnownWindowsUser
+
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsUser'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should call the mock function Connect-SQL' {
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
+            It 'Should be Present when a known Windows User is provided' {
+                $result = Get-TargetResource @getTargetResource_KnownWindowsGroup
+
+                $result.Ensure | Should Be 'Present'
+                $result.LoginType | Should Be 'WindowsGroup'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
         }
-
-        Assert-VerifiableMocks
     }
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        
-        # Loading stub cmdlets
-        Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
-        
-        Mock -CommandName Connect-SQL -MockWith {
-            return New-Object Object | 
-                Add-Member ScriptProperty Logins {
-                    return @{
-                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                    }
-                } -PassThru -Force 
-        } -ModuleName $script:DSCResourceName -Verifiable
-
+        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
 
-        Context 'When the system is not in the desired state' {
-            It 'Should return the state as absent when desired windows user does not exist' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\UnknownUser'
-                }
+        Context 'When the desired state is Absent' {
+            It 'Should return $true when the specified Windows user is Absent' {
+                $testTargetResource_WindowsUserAbsent_EnsureAbsent = $testTargetResource_WindowsUserAbsent.Clone()
+                $testTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
+                ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsureAbsent ) | Should Be $true
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should return the state as present when desired login exists and login type is SQL login' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\SqlUsers'
-                    LoginType = 'SqlLogin'
-                }
+            It 'Should return $true when the specified Windows group is Absent' {
+                $testTargetResource_WindowsGroupAbsent_EnsureAbsent = $testTargetResource_WindowsGroupAbsent.Clone()
+                $testTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsureAbsent ) | Should Be $true
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should return the state as present when desired login exists and login type is Windows' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'John'
-                    LoginType = 'WindowsUser'
-                }
+            It 'Should return $true when the specified SQL Login is Absent' {
+                $testTargetResource_SqlLoginAbsent_EnsureAbsent = $testTargetResource_SqlLoginAbsent.Clone()
+                $testTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsureAbsent ) | Should Be $true 
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-        }
-
-        Context 'When the system is in the desired state' {
-            It 'Should return the state as present when desired windows user exists' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\Stacy'
-                }
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should return the state as present when desired windows group exists' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'COMPANY\SqlUsers'
-                    LoginType = 'WindowsGroup'
-                }
+            It 'Should return $false when the specified Windows user is Present' {
+                $testTargetResource_WindowsUserPresent_EnsureAbsent = $testTargetResource_WindowsUserPresent.Clone()
+                $testTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsureAbsent ) | Should Be $false 
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
 
-            It 'Should return the state as present when desired sql login exists' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Name = 'John'
-                    LoginType = 'SqlLogin'
-                }
+            It 'Should return $false when the specified Windows group is Present' {
+                $testTargetResource_WindowsGroupPresent_EnsureAbsent = $testTargetResource_WindowsGroupPresent.Clone()
+                $testTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsureAbsent ) | Should Be $false 
 
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $false when the specified SQL Login is Present' {
+                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent ) | Should Be $false 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
             }
         }
+        
+        Context 'When the desired state is Present' {
+            It 'Should return $false when the specified Windows user is Absent' {
+                $testTargetResource_WindowsUserAbsent_EnsurePresent = $testTargetResource_WindowsUserAbsent.Clone()
+                $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
 
-        Assert-VerifiableMocks
+                ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should Be $false
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $false when the specified Windows group is Absent' {
+                $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
+                $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should Be $false
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $false when the specified SQL Login is Absent' {
+                $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
+                $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should Be $false 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $true when the specified Windows user is Present' {
+                $testTargetResource_WindowsUserPresent_EnsurePresent = $testTargetResource_WindowsUserPresent.Clone()
+                $testTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsurePresent ) | Should Be $true
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $true when the specified Windows group is Present' {
+                $testTargetResource_WindowsGroupPresent_EnsurePresent = $testTargetResource_WindowsGroupPresent.Clone()
+                $testTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsurePresent ) | Should Be $true
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $true when the specified SQL Login is Present using default parameter values' {
+                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent.Add( 'Ensure','Present' )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent ) | Should Be $true 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $true when the specified SQL Login is Present and PasswordExpirationEnabled is $true' {
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'Ensure','Present' )
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$true )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent ) | Should Be $true 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $false when the specified SQL Login is Present and PasswordExpirationEnabled is $false' {
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'Ensure','Present' )
+                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$false )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent ) | Should Be $false 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $true when the specified SQL Login is Present and PasswordPolicyEnforced is $true' {
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'Ensure','Present' )
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$true )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent ) | Should Be $true 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+
+            It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
+                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
+
+                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false 
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+            }
+        }
     }
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
-
-        # Loading stub cmdlets
-        Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
-
-        Mock -CommandName Connect-SQL -MockWith {
-            return New-Object Object | 
-                Add-Member ScriptProperty Logins {
-                    return @{
-                        'COMPANY\Stacy' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\Stacy') -Property @{ LoginType = 'WindowsUser'} ) )
-                        'John' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'John') -Property @{ LoginType = 'SqlLogin'} ) )
-                        'COMPANY\SqlUsers' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'COMPANY\SqlUsers') -Property @{ LoginType = 'WindowsGroup'} ) )
-                    }
-                } -PassThru -Force 
-        } -ModuleName $script:DSCResourceName -Verifiable
-
+        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
 
-        Context 'When the system is not in the desired state' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'UnknownSqlLogin'
-                LoginType = 'SqlLogin'
-            }
 
-            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
-                { Set-TargetResource @testParameters } | Should Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters += @{
-                LoginCredential = $mockSqlLoginCredential
-            }
-
-            It 'Should not throw an error when desired login type is a SQL login' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'SqlLogin'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\UnknownUser'
-                LoginType = 'WindowsUser'
-            }
-
-            It 'Should not throw an error when desired login type is a Windows User' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'WindowsUser'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\UnknownGroup'
-                LoginType = 'WindowsGroup'
-            }
-
-            It 'Should not throw an error when desired login type is a Windows Group' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'WindowsGroup'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Ensure = 'Absent'
-                Name = 'COMPANY\Stacy'
-            }
-
-            It 'Should call the function Remove-SqlLogin when desired state should be absent' {
-                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Absent'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                Set-TargetResource @testParameters
-
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Remove-SqlLogin -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-        }
-
-        Context 'When the system is in the desired state' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'John'
-                LoginType = 'SqlLogin'
-            }
-
-            It 'Should throw an error when desired login type is a SQL login and LoginCredential parameter is not passed' {
-                { Set-TargetResource @testParameters } | Should Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters += @{
-                LoginCredential = $mockSqlLoginCredential
-            }
-
-            It 'Should not throw an error when desired login type is a SQL login' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'SqlLogin'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\Stacy'
-                LoginType = 'WindowsUser'
-            }
-
-            It 'Should not throw an error when desired login type is a Windows User' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'WindowsUser'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Name = 'COMPANY\SqlUsers'
-                LoginType = 'WindowsGroup'
-            }
-
-            It 'Should not throw an error when desired login type is a Windows Group' {
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Present'
-                        LoginType = 'WindowsGroup'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                { Set-TargetResource @testParameters } | Should Not Throw
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                Ensure = 'Absent'
-                Name = 'COMPANY\UnknownUser'
-                LoginType = 'SqlLogin'
-            }
-
-            It 'Should not call the function Remove-SqlLogin when desired state is already absent' {
-                # Mock the return value from the Get-method, because Test-method is ran at the end of the Set-method to validate that the removal (in this case) was successful.
-                Mock -CommandName Get-TargetResource -MockWith {
-                    @{
-                        Ensure = 'Absent'
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                Mock -CommandName Remove-SqlLogin -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                Set-TargetResource @testParameters
-
-                Assert-MockCalled Connect-SQL -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Remove-SqlLogin -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-        }
-
-        Assert-VerifiableMocks
     }
 }
 finally

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -79,32 +79,72 @@ try
     $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
     $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
 
-    #$testTargetResource_SqlLoginPresent.Add( 'LoginMustChangePassword',$true )
-    #$testTargetResource_SqlLoginPresent.Add( 'LoginPasswordExpirationEnabled',$true )
-    #$testTargetResource_SqlLoginPresent.Add( 'LoginPasswordPolicyEnforced',$true )
+    $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
+    $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
+    $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+    
+    $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+    $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+    $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+    $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+    $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+    $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+    $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+    $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+    $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+    
+    $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+    $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+    $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
+    $setTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
+    $setTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
+    $setTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+
+    $setTargetResource_SqlLoginPresent = $instanceParameters.Clone()
+    $setTargetResource_SqlLoginPresent.Add( 'Name','SqlLogin1' )
+    $setTargetResource_SqlLoginPresent.Add( 'LoginType','SqlLogin' )
 
     $mockConnectSQL = {
 		return New-Object Object | 
 			Add-Member ScriptProperty Logins {
 				return @{
-					'Windows\User1' = @( ( New-Object Object | 
+					'Windows\User1' = ( New-Object Object | 
 						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
-						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru -Force
-                    ) )
-					'SqlLogin1' = @( ( New-Object Object | 
+						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                    )
+					'SqlLogin1' = ( New-Object Object | 
 						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
 						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru | 
 						Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
 						Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-						Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru -Force
-                    ) )
-					'Windows\Group1' = @( ( New-Object Object | 
+						Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                    )
+					'Windows\Group1' = ( New-Object Object | 
 						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
-						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru -Force
-                    ) )
+						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                    )
 				}
 			} -PassThru -Force
 	}
+
+    $mockNewObjectSmoLogin = {       
+        return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
+    }
+
+    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
 
     #endregion Pester Test Initialization
 
@@ -118,14 +158,14 @@ try
                 ( Get-TargetResource @getTargetResource_UnknownSqlLogin ).Ensure | Should Be 'Absent'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should be Absent when an unknown Windows User or Group is provided' {
                 ( Get-TargetResource @getTargetResource_UnknownWindows ).Ensure | Should Be 'Absent'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             
@@ -142,7 +182,7 @@ try
                 $result.LoginPasswordPolicyEnforced | Should Not Be $null
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should be Present when a known Windows User is provided' {
@@ -152,7 +192,7 @@ try
                 $result.LoginType | Should Be 'WindowsUser'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should be Present when a known Windows User is provided' {
@@ -162,7 +202,7 @@ try
                 $result.LoginType | Should Be 'WindowsGroup'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
         }
     }
@@ -179,7 +219,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsureAbsent ) | Should Be $true
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified Windows group is Absent' {
@@ -189,7 +229,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsureAbsent ) | Should Be $true
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified SQL Login is Absent' {
@@ -199,7 +239,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsureAbsent ) | Should Be $true 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified Windows user is Present' {
@@ -209,7 +249,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsureAbsent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified Windows group is Present' {
@@ -219,7 +259,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsureAbsent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified SQL Login is Present' {
@@ -229,7 +269,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
         }
         
@@ -241,7 +281,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should Be $false
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified Windows group is Absent' {
@@ -251,7 +291,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should Be $false
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified SQL Login is Absent' {
@@ -261,7 +301,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified Windows user is Present' {
@@ -271,7 +311,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsurePresent ) | Should Be $true
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified Windows group is Present' {
@@ -281,7 +321,7 @@ try
                 ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsurePresent ) | Should Be $true
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified SQL Login is Present using default parameter values' {
@@ -291,7 +331,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent ) | Should Be $true 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified SQL Login is Present and PasswordExpirationEnabled is $true' {
@@ -302,7 +342,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent ) | Should Be $true 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified SQL Login is Present and PasswordExpirationEnabled is $false' {
@@ -313,7 +353,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $true when the specified SQL Login is Present and PasswordPolicyEnforced is $true' {
@@ -324,7 +364,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent ) | Should Be $true 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
@@ -335,7 +375,7 @@ try
                 ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false 
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
         }
     }
@@ -343,8 +383,212 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
+        Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
+        Context 'When the desired state is Absent' {
+            It 'Should drop the specified Windows User when it is Present' {
+                $setTargetResource_WindowsUserPresent_EnsureAbsent = $setTargetResource_WindowsUserPresent.Clone()
+                $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
+                Set-TargetResource @setTargetResource_WindowsUserPresent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should drop the specified Windows Group when it is Present' {
+                $setTargetResource_WindowsGroupPresent_EnsureAbsent = $setTargetResource_WindowsGroupPresent.Clone()
+                $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should drop the specified SQL Login when it is Present' {
+                $setTargetResource_SqlLoginPresent_EnsureAbsent = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should do nothing when the specified Windows User is Absent' {
+                $setTargetResource_WindwsUserAbsent_EnsureAbsent = $setTargetResource_WindowsUserAbsent.Clone()
+                $setTargetResource_WindwsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                Set-TargetResource @setTargetResource_WindwsUserAbsent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should do nothing when the specified Windows Group is Absent' {
+                $setTargetResource_WindwsGroupAbsent_EnsureAbsent = $setTargetResource_WindowsGroupAbsent.Clone()
+                $setTargetResource_WindwsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                Set-TargetResource @setTargetResource_WindwsGroupAbsent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should do nothing when the specified SQL Login is Absent' {
+                $setTargetResource_SqlLoginAbsent_EnsureAbsent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsureAbsent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+        }
+
+        Context 'When the desired state is Present' {
+            It 'Should add the specified Windows User when it is Absent' {
+                $setTargetResource_WindowsUserAbsent_EnsurePresent = $setTargetResource_WindowsUserAbsent.Clone()
+                $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should add the specified Windows Group when it is Absent' {
+                $setTargetResource_WindowsGroupAbsent_EnsurePresent = $setTargetResource_WindowsGroupAbsent.Clone()
+                $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should add the specified SQL Login when it is Absent' {
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should throw when adding an unsupported login type' {
+                $setTargetResource_CertificateAbsent_EnsurePresent = $setTargetResource_CertificateAbsent.Clone()
+                $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                { Set-TargetResource @setTargetResource_CertificateAbsent_EnsurePresent } | Should Throw 'LoginTypeNotImplemented'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
+                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                { Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresen0t } | Should Throw
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should do nothing if the specified Windows User is Present' {
+                $setTargetResource_WindowsUserPresent_EnsurePresent = $setTargetResource_WindowsUserPresent.Clone()
+                $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                Set-TargetResource @setTargetResource_WindowsUserPresent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should do nothing if the specified Windows Group is Present' {
+                $setTargetResource_WindowsGroupPresent_EnsurePresent = $setTargetResource_WindowsGroupPresent.Clone()
+                $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should do nothing if the specified SQL Login is Present and all parameters match' {
+                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential',$mockSqlLoginCredential )
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginPasswordExpirationEnabled',$false )
+
+                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential',$mockSqlLoginCredential )
+                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginPasswordPolicyEnforced',$false )
+
+                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
+            }
+
+            It 'Should throw when password validation fails when creating a SQL Login' {
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'PasswordValidationFailed'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
+            }
+
+            It 'Should throw when creating a SQL Login fails' {
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'LoginCreationFailed'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
+            }
+        }
     }
 }
 finally

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -857,30 +857,6 @@ try
                     { SetPassword @setPwParams } | Should Throw 'PasswordChangeFailed'
                 }
             }
-
-            It 'Should throw when creating a SQL Login fails with an unhandled exception' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-                
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentUnknown.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-
-                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'LoginCreationFailed'
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false 
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Time 1 -Exactly
-            }
         }
     }
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -148,34 +148,34 @@ try
     $setTargetResource_SqlLoginPresent.Add( 'LoginType','SqlLogin' )
 
     $mockConnectSQL = {
-		return New-Object Object | 
-			Add-Member ScriptProperty Logins {
-				return @{
-					'Windows\User1' = ( New-Object Object | 
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
-						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
+  return New-Object Object | 
+   Add-Member ScriptProperty Logins {
+    return @{
+     'Windows\User1' = ( New-Object Object | 
+      Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
+      Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                     )
-					'SqlLogin1' = ( New-Object Object | 
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
-						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru | 
-						Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
-						Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-						Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+     'SqlLogin1' = ( New-Object Object | 
+      Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
+      Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru | 
+      Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+      Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+      Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                     )
-					'Windows\Group1' = ( New-Object Object | 
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
-						Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
+     'Windows\Group1' = ( New-Object Object | 
+      Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
+      Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                     )
-				}
-			} -PassThru |
+    }
+   } -PassThru |
             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
-	}
+ }
 
     #endregion Pester Test Initialization
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -415,10 +415,10 @@ try
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
-        Mock -CommandName AlterLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName CreateLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName DropLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName SetPassword -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName Update-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName New-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName Remove-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName Set-SQLServerLoginPassword -MockWith {} -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
             It 'Should drop the specified Windows User when it is Present' {
@@ -430,10 +430,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsUserPresent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should drop the specified Windows Group when it is Present' {
@@ -445,10 +445,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should drop the specified SQL Login when it is Present' {
@@ -460,10 +460,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginPresent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing when the specified Windows User is Absent' {
@@ -475,10 +475,10 @@ try
                 Set-TargetResource @setTargetResource_WindwsUserAbsent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing when the specified Windows Group is Absent' {
@@ -490,10 +490,10 @@ try
                 Set-TargetResource @setTargetResource_WindwsGroupAbsent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing when the specified SQL Login is Absent' {
@@ -505,10 +505,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsureAbsent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
         }
 
@@ -522,10 +522,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should add the specified Windows Group when it is Absent' {
@@ -537,10 +537,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should add the specified SQL Login when it is Absent' {
@@ -553,10 +553,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
@@ -570,10 +570,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw the correct error when adding an unsupported login type' {
@@ -585,10 +585,10 @@ try
                 { Set-TargetResource @setTargetResource_CertificateAbsent_EnsurePresent } | Should Throw 'LoginTypeNotImplemented'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw the correct error when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
@@ -600,10 +600,10 @@ try
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
@@ -615,10 +615,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsUserPresent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows Group is Present' {
@@ -630,10 +630,10 @@ try
                 Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
 
             It 'Should update the password of the specified SQL Login if it is Present and all parameters match' {
@@ -646,10 +646,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
             }
 
             It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
@@ -663,10 +663,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
             }
 
             It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
@@ -680,10 +680,10 @@ try
                 Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
             }
 
             It 'Should throw the correct error when creating a SQL Login if the LoginMode is not Mixed' {
@@ -726,16 +726,16 @@ try
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName AlterLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName CreateLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName DropLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName SetPassword -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
             }
         }
     }
 
     InModuleScope -ModuleName $script:DSCResourceName {
-        Describe "$($script:DSCResourceName)\AlterLogin" {
+        Describe "$($script:DSCResourceName)\Update-SQLServerLogin" {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the Login is altered' {
@@ -743,25 +743,35 @@ try
                     $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
                     $login.LoginType = 'WindowsUser'
 
-                    AlterLogin -Login $login
+                    { Update-SQLServerLogin -Login $login } | Should Not Throw
+                }
+
+                It 'Should throw the correct error when altering the login fails' {
+                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
+                    $login.LoginType = 'WindowsUser'
+                    $login.MockLoginType = 'SqlLogin'
+
+                    { Update-SQLServerLogin -Login $login } | Should Throw 'AlterLoginFailed'
                 }
             }
         }
 
-        Describe "$($script:DSCResourceName)\CreateLogin" {
+        Describe "$($script:DSCResourceName)\New-SQLServerLogin" {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
             
             Context 'When the Login is created' {
                 It 'Should silently create a Windows login' {
                     $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
                     $login.LoginType = 'WindowsUser'
+                    $login.MockLoginType = 'WindowsUser'
 
-                    CreateLogin -Login $login
+                    { New-SQLServerLogin -Login $login } | Should Not Throw
                 }
 
                 It 'Should silently create a SQL login' {
                     $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'dba' )
                     $login.LoginType = 'SqlLogin'
+                    $login.MockLoginType = 'SqlLogin'
                     
                     $createLoginParams = @{
                         Login = $login
@@ -769,7 +779,15 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    CreateLogin @createLoginParams
+                    { New-SQLServerLogin @createLoginParams } | Should Not Throw
+                }
+
+                It 'Should throw the correct error when login creation fails' {
+                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
+                    $login.LoginType = 'WindowsUser'
+                    $login.MockLoginType = 'SqlLogin'
+
+                    { New-SQLServerLogin -Login $login } | Should Throw 'LoginCreationFailed'
                 }
 
                 It 'Should throw the correct error when password validation fails when creating a SQL Login' {
@@ -782,7 +800,7 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    { CreateLogin @createLoginParams } | Should Throw 'PasswordValidationFailed'
+                    { New-SQLServerLogin @createLoginParams } | Should Throw 'PasswordValidationFailed'
                 }
 
                 It 'Should throw the correct error when creating a SQL Login fails' {
@@ -795,7 +813,7 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    { CreateLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
+                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
                 }
 
                 It 'Should throw the correct error when creating a SQL Login fails with an unhandled exception' {
@@ -808,12 +826,12 @@ try
                         LoginCreateOptions = 'None'
                     }
 
-                    { CreateLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
+                    { New-SQLServerLogin @createLoginParams } | Should Throw 'LoginCreationFailed'
                 }
             }
         }
 
-        Describe "$($script:DSCResourceName)\DropLogin" {
+        Describe "$($script:DSCResourceName)\Remove-SQLServerLogin" {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
             
             Context 'When the Login is dropped' {
@@ -821,22 +839,39 @@ try
                     $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
                     $login.LoginType = 'WindowsUser'
 
-                    DropLogin -Login $login
+                    { Remove-SQLServerLogin -Login $login } | Should Not Throw
+                }
+
+                It 'Should throw the correct error when dropping the login fails' {
+                    $login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Domain\User' )
+                    $login.LoginType = 'WindowsUser'
+                    $login.MockLoginType = 'SqlLogin'
+
+                    { Remove-SQLServerLogin -Login $login } | Should Throw 'DropLoginFailed'
                 }
             }
         }
 
-        Describe "$($script:DSCResourceName)\SetPassword" {
+        Describe "$($script:DSCResourceName)\Set-SQLServerLoginPassword" {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the password is set on an existing login' {
+                It 'Should silently set the password' {
+                    $setPwParams = @{
+                        Login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'dba' )
+                        SecureString = ConvertTo-SecureString -String 'P@ssw0rd-12P@ssw0rd-12' -AsPlainText -Force
+                    }
+                    
+                    { Set-SQLServerLoginPassword @setPwParams } | Should Not Throw
+                }
+
                 It 'Should throw the correct error when password validation fails' {
                     $setPwParams = @{
                         Login = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'dba' )
                         SecureString = ConvertTo-SecureString -String 'pw' -AsPlainText -Force
                     }
                     
-                    { SetPassword @setPwParams } | Should Throw 'PasswordValidationFailed'
+                    { Set-SQLServerLoginPassword @setPwParams } | Should Throw 'PasswordValidationFailed'
                 }
 
                 It 'Should throw the correct error when changing the password fails' {
@@ -845,7 +880,7 @@ try
                         SecureString = ConvertTo-SecureString -String 'reused' -AsPlainText -Force
                     }
                     
-                    { SetPassword @setPwParams } | Should Throw 'PasswordChangeFailed'
+                    { Set-SQLServerLoginPassword @setPwParams } | Should Throw 'PasswordChangeFailed'
                 }
 
                 It 'Should throw the correct error when changing the password fails' {
@@ -854,15 +889,10 @@ try
                         SecureString = ConvertTo-SecureString -String 'other' -AsPlainText -Force
                     }
                     
-                    { SetPassword @setPwParams } | Should Throw 'PasswordChangeFailed'
+                    { Set-SQLServerLoginPassword @setPwParams } | Should Throw 'PasswordChangeFailed'
                 }
             }
         }
-    }
-
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
-        Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
     }
 }
 finally

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -111,6 +111,26 @@ try
     $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
     $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
 
+    $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
+    $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
+    $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+    
+    $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+    $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+    $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+    $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+    $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+    $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+    $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+    $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+    $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+    
+    $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+    $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+    $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
     $setTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
     $setTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
     $setTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
@@ -148,6 +168,16 @@ try
 			} -PassThru |
             Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
 	}
+
+    $mockNewObjectSmoLogin = {       
+        return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
+    }
+
+    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
 
     #endregion Pester Test Initialization
 
@@ -385,6 +415,7 @@ try
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
+        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -145,7 +145,8 @@ try
                         Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
                     )
 				}
-			} -PassThru -Force
+			} -PassThru |
+            Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Mixed' -PassThru -Force
 	}
 
     #endregion Pester Test Initialization
@@ -383,12 +384,13 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
             It 'Should drop the specified Windows User when it is Present' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsUserPresent_EnsureAbsent = $setTargetResource_WindowsUserPresent.Clone()
                 $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -399,6 +401,8 @@ try
             }
 
             It 'Should drop the specified Windows Group when it is Present' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsGroupPresent_EnsureAbsent = $setTargetResource_WindowsGroupPresent.Clone()
                 $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -409,6 +413,8 @@ try
             }
 
             It 'Should drop the specified SQL Login when it is Present' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginPresent_EnsureAbsent = $setTargetResource_SqlLoginPresent.Clone()
                 $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -419,6 +425,8 @@ try
             }
 
             It 'Should do nothing when the specified Windows User is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindwsUserAbsent_EnsureAbsent = $setTargetResource_WindowsUserAbsent.Clone()
                 $setTargetResource_WindwsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -429,6 +437,8 @@ try
             }
 
             It 'Should do nothing when the specified Windows Group is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindwsGroupAbsent_EnsureAbsent = $setTargetResource_WindowsGroupAbsent.Clone()
                 $setTargetResource_WindwsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -439,6 +449,8 @@ try
             }
 
             It 'Should do nothing when the specified SQL Login is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsureAbsent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
 
@@ -451,6 +463,8 @@ try
 
         Context 'When the desired state is Present' {
             It 'Should add the specified Windows User when it is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsUserAbsent_EnsurePresent = $setTargetResource_WindowsUserAbsent.Clone()
                 $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -461,6 +475,8 @@ try
             }
 
             It 'Should add the specified Windows Group when it is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsGroupAbsent_EnsurePresent = $setTargetResource_WindowsGroupAbsent.Clone()
                 $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -471,6 +487,8 @@ try
             }
 
             It 'Should add the specified SQL Login when it is Absent' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -482,6 +500,8 @@ try
             }
 
             It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -494,6 +514,8 @@ try
             }
 
             It 'Should throw when adding an unsupported login type' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_CertificateAbsent_EnsurePresent = $setTargetResource_CertificateAbsent.Clone()
                 $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -504,6 +526,8 @@ try
             }
 
             It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
                 $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -514,6 +538,8 @@ try
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsUserPresent_EnsurePresent = $setTargetResource_WindowsUserPresent.Clone()
                 $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -524,6 +550,8 @@ try
             }
 
             It 'Should do nothing if the specified Windows Group is Present' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_WindowsGroupPresent_EnsurePresent = $setTargetResource_WindowsGroupPresent.Clone()
                 $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
 
@@ -534,6 +562,8 @@ try
             }
 
             It 'Should do nothing if the specified SQL Login is Present and all parameters match' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
                 $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -545,6 +575,8 @@ try
             }
 
             It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled = $setTargetResource_SqlLoginPresent.Clone()
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -557,6 +589,8 @@ try
             }
 
             It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced = $setTargetResource_SqlLoginPresent.Clone()
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -568,7 +602,52 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
+            It 'Should throw when creating a SQL Login if the LoginMode is not Mixed' {
+                $mockConnectSQL_LoginModeNormal = {
+                    return New-Object Object | 
+                        Add-Member ScriptProperty Logins {
+                            return @{
+                                'Windows\User1' = ( New-Object Object | 
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                )
+                                'SqlLogin1' = ( New-Object Object | 
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru | 
+                                    Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
+                                    Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
+                                    Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                )
+                                'Windows\Group1' = ( New-Object Object | 
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                )
+                            }
+                        } -PassThru |
+                        Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Normal' -PassThru -Force
+                }
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL_LoginModeNormal -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
+                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+            
             It 'Should throw when password validation fails when creating a SQL Login' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
@@ -580,6 +659,8 @@ try
             }
 
             It 'Should throw when creating a SQL Login fails' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentExisting.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
@@ -591,6 +672,8 @@ try
             }
 
             It 'Should throw when creating a SQL Login fails with an unhandled exception' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsentUnknown.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -29,6 +29,7 @@ try
     #region Pester Test Initialization
 
     Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
+    Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
     # Create PSCredential object for SQL Logins
     $mockSqlLoginUser = "dba" 
@@ -135,16 +136,6 @@ try
 				}
 			} -PassThru -Force
 	}
-
-    $mockNewObjectSmoLogin = {       
-        return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru | 
-            Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
-            Add-Member -MemberType ScriptMethod -Name Create -Value {} -PassThru -Force
-    }
-
-    $mockNewObjectSmoLoginParamFilter = { 'TypeName' -eq 'Microsoft.SqlServer.Management.Smo.Login' }
 
     #endregion Pester Test Initialization
 
@@ -383,7 +374,6 @@ try
     Describe "$($script:DSCResourceName)\Set-TargetResource" {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName New-Object -MockWith $mockNewObjectSmoLogin -ModuleName $script:DSCResourceName -ParameterFilter $mockNewObjectSmoLoginParamFilter -Verifiable
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Context 'When the desired state is Absent' {
@@ -457,7 +447,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified Windows Group when it is Absent' {
@@ -468,7 +457,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should add the specified SQL Login when it is Absent' {
@@ -480,7 +468,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should throw when adding an unsupported login type' {
@@ -491,7 +478,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
@@ -502,7 +488,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 0 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
@@ -513,7 +498,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified Windows Group is Present' {
@@ -524,7 +508,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should do nothing if the specified SQL Login is Present and all parameters match' {
@@ -536,7 +519,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
@@ -549,7 +531,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
@@ -562,7 +543,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 0 -Exactly
             }
 
             It 'Should throw when password validation fails when creating a SQL Login' {
@@ -574,7 +554,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
 
             It 'Should throw when creating a SQL Login fails' {
@@ -586,7 +565,6 @@ try
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-Object -ParameterFilter $mockNewObjectSmoLoginParamFilter -Scope It -Times 1 -Exactly
             }
         }
     }

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -36,6 +36,9 @@ try
     $mockSqlLoginPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
     $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
 
+    $mockSqlLoginBadPassword = "pw" | ConvertTo-SecureString -asPlainText -Force
+    $mockSqlLoginCredentialBadpassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginBadPassword )
+
     $instanceParameters = @{
         SQLInstanceName = 'MSSQLSERVER'
         SQLServer = 'Server1'
@@ -548,7 +551,7 @@ try
             It 'Should throw when password validation fails when creating a SQL Login' {
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
 
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'PasswordValidationFailed'
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -669,7 +669,7 @@ try
                 
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
 
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -43,7 +43,7 @@ try
         SQLInstanceName = 'MSSQLSERVER'
         SQLServer = 'Server1'
     }
-    
+      
     $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
     $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
 
@@ -82,7 +82,7 @@ try
     $testTargetResource_SqlLoginPresentWithDefaultValues = $instanceParameters.Clone()
     $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
     $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
-
+    
     $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
     $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
     $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
@@ -525,16 +525,27 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
-            It 'Should throw when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
+            It 'Should throw LoginCredentialNotFound when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 
-                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
+                $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
+                $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
 
-                { Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresen0t } | Should Throw
+                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+            }
+            It 'Should throw LoginCredentialNotFound when modifying the specified SQL Login when it is Present and is missing the LoginCredential parameter' {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                
+                $setTargetResource_SqlLoginPresent_EnsurePresent_NoCred = $setTargetResource_SqlLoginPresent.Clone()
+                $setTargetResource_SqlLoginPresent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
+
+                { Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
+
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
 
             It 'Should do nothing if the specified Windows User is Present' {
@@ -657,7 +668,7 @@ try
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
             }
-
+            
             It 'Should throw when creating a SQL Login fails' {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
                 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -701,6 +701,7 @@ try
                 $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
                 $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadpassword )
+
                 { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'PasswordValidationFailed'
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -607,7 +607,7 @@ finally
 {
     #region FOOTER
 
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
 
     #endregion
 }

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -202,6 +202,9 @@ namespace Microsoft.SqlServer.Management.Smo
         public bool PasswordPolicyEnforced = false;
         public bool PasswordExpirationEnabled = false;
 
+        public string MockName;
+        public LoginType MockLoginType;
+
         public Login( Server server, string name )
         {
             this.Name = name;
@@ -212,14 +215,31 @@ namespace Microsoft.SqlServer.Management.Smo
             this.Name = name;
         }
         
-        public void Alter () {}
+        public void Alter()
+        {
+            if( !( String.IsNullOrEmpty(this.MockName) ) )
+            {
+                if(this.MockName != this.Name)
+                {
+                    throw new Exception();
+                }
+            }
+
+            if( !( String.IsNullOrEmpty(this.MockLoginType.ToString()) ) )
+            {
+                if( this.MockLoginType != this.LoginType )
+                {
+                    throw new Exception(this.MockLoginType.ToString());
+                }
+            }
+        }
         
-        public void ChangePassword ( SecureString secureString )
+        public void ChangePassword( SecureString secureString )
         {
             IntPtr valuePtr = IntPtr.Zero;
             try
             {
-                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);            
                 if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
                 {                    
                     throw new FailedOperationException (
@@ -258,6 +278,22 @@ namespace Microsoft.SqlServer.Management.Smo
 
             if( this.LoginType == LoginType.SqlLogin && _mockPasswordPassed != true ) {
                 throw new System.Exception( "Called Create() method for the LoginType 'SqlLogin' but called with the wrong overloaded method. Did not pass the password with the Create() method." );
+            }
+
+            if( !( String.IsNullOrEmpty(this.MockName) ) )
+            {
+                if(this.MockName != this.Name)
+                {
+                    throw new Exception();
+                }
+            }
+
+            if( !( String.IsNullOrEmpty(this.MockLoginType.ToString()) ) )
+            {
+                if( this.MockLoginType != this.LoginType )
+                {
+                    throw new Exception(this.MockLoginType.ToString());
+                }
             }
         }
 
@@ -312,6 +348,21 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Drop()
         {
+            if( !( String.IsNullOrEmpty(this.MockName) ) )
+            {
+                if(this.MockName != this.Name)
+                {
+                    throw new Exception();
+                }
+            }
+
+            if( !( String.IsNullOrEmpty(this.MockLoginType.ToString()) ) )
+            {
+                if( this.MockLoginType != this.LoginType )
+                {
+                    throw new Exception(this.MockLoginType.ToString());
+                }
+            }
         }
     }
 	

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -2,11 +2,23 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.SqlServer.Management.Smo
 {
     #region Public Enums
 
+    // TypeName: Microsoft.SqlServer.Management.Smo.LoginCreateOptions
+    // Used by:
+    //  MSFT_xSQLServerLogin.Tests.ps1
+    public enum LoginCreateOptions
+    {
+        None = 0,
+        IsHashed = 1,
+        MustChange = 2
+    }
+    
     // TypeName: Microsoft.SqlServer.Management.Smo.LoginType
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
     // Used by: 
@@ -194,6 +206,8 @@ namespace Microsoft.SqlServer.Management.Smo
             
         public string Name;
         public LoginType LoginType = LoginType.Unknown;
+        public bool PasswordPolicyEnforced = true;
+        public bool PasswordExpirationEnabled = true;
 
         public void Create()
         {
@@ -267,11 +281,13 @@ namespace Microsoft.SqlServer.Management.Smo
     //  xSQLServerDatabaseRole.Tests.ps1
     public class User 
     {
-       public User( Server server, string name ) {
+        public User( Server server, string name )
+        {
             this.Name = name;
         } 
 
-        public User( Object server, string name ) {
+        public User( Object server, string name )
+        {
             this.Name = name;
         } 
             
@@ -282,8 +298,69 @@ namespace Microsoft.SqlServer.Management.Smo
         {
         }
 
+        public void Create( SecureString password, LoginCreateOptions options  )
+        {
+            IntPtr valuePtr = IntPtr.Zero;
+            try {
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(password);
+                if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
+                {
+                    throw new FailedOperationException( "FailedOperationException", new Exception( "InnerException1", new Exception( "InnerException2", new Exception( "Password validation failed" ) ) ) );
+                }
+
+            } finally {
+                Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+            }
+        }
+
         public void Drop()
         {
+        }
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.SqlServerManagementException
+    // BaseType: System.Exception 
+    // Used by:
+    //  xSqlServerLogin.Tests.ps1
+    public class SqlServerManagementException : Exception
+    {
+        public SqlServerManagementException ()
+        {
+
+        }
+
+        public SqlServerManagementException ( string message, Exception innerException )
+        {
+            
+        }
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.SmoException
+    // BaseType: Microsoft.SqlServer.Management.Smo.SqlServerManagementException  
+    // Used by:
+    //  xSqlServerLogin.Tests.ps1
+    public class SmoException : SqlServerManagementException
+    {
+        public SmoException ()
+        {
+
+        }
+        
+        public SmoException ( string message, Exception innerException )
+        {
+
+        }
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.FailedOperationException
+    // BaseType: Microsoft.SqlServer.Management.Smo.SmoException
+    // Used by:
+    //  xSqlServerLogin.Tests.ps1
+    public class FailedOperationException : SmoException
+    {
+        public FailedOperationException ( string message, Exception innerException )
+        {
+
         }
     }
 

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -381,9 +381,6 @@ namespace Microsoft.SqlServer.Management.Smo
         {
         }
 
-        public string Name;
-        public string Login;
-
         public void Drop()
         {
         }

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -340,8 +340,20 @@ namespace Microsoft.SqlServer.Management.Smo
         {
         }
 
-        public string Name;
-        public string Login;
+        public void Create( SecureString password, LoginCreateOptions options  )
+        {
+            IntPtr valuePtr = IntPtr.Zero;
+            try {
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(password);
+                if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
+                {
+                    throw new FailedOperationException( "FailedOperationException", new Exception( "InnerException1", new Exception( "InnerException2", new Exception( "Password validation failed" ) ) ) );
+                }
+
+            } finally {
+                Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+            }
+        }
 
         public void Drop()
         {

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -336,6 +336,25 @@ namespace Microsoft.SqlServer.Management.Smo
         public string Name;
         public string Login;
 
+        public void Create()
+        {
+        }
+
+        public void Create( SecureString password, LoginCreateOptions options  )
+        {
+            IntPtr valuePtr = IntPtr.Zero;
+            try {
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(password);
+                if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
+                {
+                    throw new FailedOperationException( "FailedOperationException", new Exception( "InnerException1", new Exception( "InnerException2", new Exception( "Password validation failed" ) ) ) );
+                }
+
+            } finally {
+                Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+            }
+        }
+
         public void Drop()
         {
         }

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -340,20 +340,8 @@ namespace Microsoft.SqlServer.Management.Smo
         {
         }
 
-        public void Create( SecureString password, LoginCreateOptions options  )
-        {
-            IntPtr valuePtr = IntPtr.Zero;
-            try {
-                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(password);
-                if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
-                {
-                    throw new FailedOperationException( "FailedOperationException", new Exception( "InnerException1", new Exception( "InnerException2", new Exception( "Password validation failed" ) ) ) );
-                }
-
-            } finally {
-                Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
-            }
-        }
+        public string Name;
+        public string Login;
 
         public void Drop()
         {

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -44,4 +44,5 @@ AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '
 PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}
 LoginCreationFailed = Creation of the login '{0}' failed.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
+IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed'.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -41,7 +41,7 @@ ConfigurationRestartRequired = Configuration option '{0}' has been updated, but 
 AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '{1}'.
 
 # Login
-PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}
+PasswordValidationFailed = Creation of the login '{0}' failed because the password validation failed.
 LoginCreationFailed = Creation of the login '{0}' failed.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -41,7 +41,7 @@ ConfigurationRestartRequired = Configuration option '{0}' has been updated, but 
 AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '{1}'.
 
 # Login
-PasswordValidationFailed = Creation of the login '{0}' failed because the password validation failed.
+PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}
 LoginCreationFailed = Creation of the login '{0}' failed.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -45,4 +45,6 @@ PasswordValidationFailed = Creation of the login '{0}' failed due to the followi
 LoginCreationFailed = Creation of the login '{0}' failed.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
 IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed'.
+InvalidLoginType = The value '{0}' is not a valid login type.
+LoginCredentialNoFound = The credential for the SQL Login '{0}' was not found.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -45,6 +45,5 @@ PasswordValidationFailed = Creation of the login '{0}' failed due to the followi
 LoginCreationFailed = Creation of the login '{0}' failed.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
 IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed'.
-InvalidLoginType = The value '{0}' is not a valid login type.
-LoginCredentialNoFound = The credential for the SQL Login '{0}' was not found.
+LoginCredentialNotFound = The credential for the SQL Login '{0}' was not found.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -42,7 +42,9 @@ AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '
 
 # Login
 PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}
-LoginCreationFailed = Creation of the login '{0}' failed.
+LoginCreationFailedFailedOperation = Creation of the login '{0}' failed due to a failed operation.
+LoginCreationFailedSqlNotSpecified = Creation of the SQL login '{0}' failed due to an unspecified error.
+LoginCreationFailedWindowsNotSpecified = Creation of the Windows login '{0}' failed due to an unspecified error.
 LoginTypeNotImplemented = The login type '{0}' is not implemented in this resource.
 IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed' authentication mode.
 LoginCredentialNotFound = The credential for the SQL Login '{0}' was not found.

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -39,4 +39,9 @@ ConfigurationRestartRequired = Configuration option '{0}' has been updated, but 
 
 # AlwaysOnService
 AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '{1}'.
+
+# Login
+PasswordValidationFailed = Creation of the login '{0}' failed because the password validation failed.
+LoginCreationFailed = Creation of the login '{0}' failed.
+LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -47,4 +47,7 @@ LoginTypeNotImplemented = The login type '{0}' is not implemented in this resour
 IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed' authentication mode.
 LoginCredentialNotFound = The credential for the SQL Login '{0}' was not found.
 PasswordChangeFailed = Setting the password failed for the SQL Login '{0}'.
+AlterLoginFailed = Altering the login '{0}' failed.
+CreateLoginFailed = Creating the login '{0}' failed.
+DropLoginFailed = Dropping the login '{0}' failed.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -43,7 +43,8 @@ AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '
 # Login
 PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}
 LoginCreationFailed = Creation of the login '{0}' failed.
-LoginTypeNotImplemented = The login type '{0}' is not implemented in this module.
-IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed'.
+LoginTypeNotImplemented = The login type '{0}' is not implemented in this resource.
+IncorrectLoginMode = The instance '{0}\{1}' is currently in '{2}' authentication mode. To create a SQL Login, it must be set to 'Mixed' authentication mode.
 LoginCredentialNotFound = The credential for the SQL Login '{0}' was not found.
+PasswordChangeFailed = Setting the password failed for the SQL Login '{0}'.
 '@


### PR DESCRIPTION
Updated the xSQLServerLogin resource to remove all references to the ShouldProcess cmdlet. Added the following parameters for the SqlLogin type:

- LoginMustChangePassword
- LoginPasswordExpirationEnabled
- LoginPasswordPolicyEnforced

Updated the examples and unit tests.

This Pull Request (PR) fixes the following issues:
Remove ShouldProcess: Fixes #240 
Add SqlLogin Password Requirements: Fixes #251 

- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [X] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/249)
<!-- Reviewable:end -->
