### PR TITLE
xSQLServerSetup: Changes to the helper function Copy-ItemWithRoboCopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   - Now it uses CIM cmdlets to get information from WMI classes.
   - Resolved all of the PSScriptAnalyzer warnings that was triggered in the common tests.
   - Improvement for service accounts to enable support for Managed Service Accounts as well as other nt authority accounts
-  - Changes to helper function Copy-ItemWithRoboCopy
+  - Changes to the helper function Copy-ItemWithRoboCopy
     - Robocopy is now started using Start-Process and the error handling has been improved.
     - Robocopy now removes files at the destination path if they no longer exists at the source.
     - Robocopy copies using unbuffered I/O when available (recommended for large files).
@@ -29,7 +29,7 @@
   - Added to the description text for the parameter `Credential` describing how to authenticate using Windows Authentication.
   - Added examples to show how to authenticate using either SQL or Windows authentication.
   - A recent issue showed that there is a known problem running this resource using PowerShell 4.0. For more information, see [issue #273](https://github.com/PowerShell/xSQLServer/issues/273)
-- Changes to unit tests for resource
+- Changes to the unit test for resource
   - xSQLServerSetup
     - Added test coverage for helper function Copy-ItemWithRoboCopy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     - Robocopy is now started using Start-Process and the error handling has been improved.
     - Robocopy now removes files at the destination path if they no longer exists at the source.
     - Robocopy copies using unbuffered I/O when available (recommended for large files).
+  - Added a more descriptive text for the parameter `SourceCredential` to further explain how the parameter work.
 - Changes to xSQLServerScript
   - All credential parameters now also has the type [System.Management.Automation.Credential()] to better work with PowerShell 4.0.
   - It is now possible to configure two instances on the same node, with the same script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,19 @@
   - Now it uses CIM cmdlets to get information from WMI classes.
   - Resolved all of the PSScriptAnalyzer warnings that was triggered in the common tests.
   - Improvement for service accounts to enable support for Managed Service Accounts as well as other nt authority accounts
+  - Changes to helper function Copy-ItemWithRoboCopy
+    - Robocopy is now started using Start-Process and the error handling has been improved.
+    - Robocopy now removes files at the destination path if they no longer exists at the source.
+    - Robocopy copies using unbuffered I/O when available (recommended for large files).
 - Changes to xSQLServerScript
   - All credential parameters now also has the type [System.Management.Automation.Credential()] to better work with PowerShell 4.0.
   - It is now possible to configure two instances on the same node, with the same script.
   - Added to the description text for the parameter `Credential` describing how to authenticate using Windows Authentication.
   - Added examples to show how to authenticate using either SQL or Windows authentication.
   - A recent issue showed that there is a known problem running this resource using PowerShell 4.0. For more information, see [issue #273](https://github.com/PowerShell/xSQLServer/issues/273)
+- Changes to unit tests for resource
+  - xSQLServerSetup
+    - Added test coverage for helper function Copy-ItemWithRoboCopy
 
 ## 4.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -16,7 +16,8 @@ Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $script
         Credential to be used to perform the installation.
 
     .PARAMETER SourceCredential
-        Credential to be used to access SourcePath.
+        Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. The parameter `SourceCredential` is used
+        to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter `SourcePath` and `SourceFolder`.
 
     .PARAMETER InstanceName
         Name of the SQL instance to be installed.
@@ -322,7 +323,10 @@ function Get-TargetResource
         Credential to be used to perform the installation.
 
     .PARAMETER SourceCredential
-        Credential to be used to access SourcePath.
+        Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. Using this parameter will trigger a copy
+        of the installation media to a temp folder on the target node. Setup will then be started from the temp folder on the target node.
+        For any subsequent calls to the resource, the parameter `SourceCredential` is used to evaluate what major version the file 'setup.exe'
+        has in the path set, again, by the parameter `SourcePath` and `SourceFolder`.
 
     .PARAMETER SuppressReboot
         Suppressed reboot.
@@ -881,7 +885,8 @@ function Set-TargetResource
         Credential to be used to perform the installation.
 
     .PARAMETER SourceCredential
-        Credential to be used to access SourcePath.
+        Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. The parameter `SourceCredential` is used
+        to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter `SourcePath` and `SourceFolder`.
 
     .PARAMETER SuppressReboot
         Suppresses reboot.
@@ -1251,18 +1256,18 @@ function Copy-ItemWithRoboCopy
         Write-Verbose 'Unbuffered I/O cannot be used due to incompatible version of Robocopy.'
     }
 
-    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $Path, 
+    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $Path,
                                                          $DestinationPath,
                                                          $robocopyArgumentCopySubDirectoriesIncludingEmpty,
                                                          $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                                                          $robocopyArgumentUseUnbufferedIO,
                                                          $robocopyArgumentSilent
-    
+
     $robocopyStartProcessParameters = @{
         FilePath = $robocopyExecutable.Name
         ArgumentList = $robocopyArgumentList
     }
-    
+
     Write-Verbose ('Robocopy is started with the following arguments: {0}' -f $robocopyArgumentList )
     $robocopyProcess = Start-Process @robocopyStartProcessParameters -Wait -NoNewWindow -PassThru
 
@@ -1272,28 +1277,28 @@ function Copy-ItemWithRoboCopy
         {
             throw "Robocopy reported errors when copying files. Error code: $_."
         }
-        
+
         {$_ -gt 7 }
         {
             throw "Robocopy reported that failures occured when copying files. Error code: $_."
         }
-        
+
         1
         {
             Write-Verbose 'Robocopy copied files sucessfully'
         }
 
-        2 
+        2
         {
             Write-Verbose 'Robocopy found files at the destination path that is not present at the source path, these extra files was remove at the destination path.'
         }
 
-        3 
+        3
         {
             Write-Verbose 'Robocopy copied files to destination sucessfully. Robocopy also found files at the destination path that is not present at the source path, these extra files was remove at the destination path.'
         }
-        
-        {$_ -eq 0 -or $null -eq $_ } 
+
+        {$_ -eq 0 -or $null -eq $_ }
         {
             Write-Verbose 'Robocopy reported that all files already present.'
         }

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -4,7 +4,7 @@ class MSFT_xSQLServerSetup : OMI_BaseResource
     [Write, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource.")] String SourcePath;
     [Write, Description("Folder within the source path containing the source files for installation. Default value is 'Source'.")] String SourceFolder;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to perform the installation.")] String SetupCredential;
-    [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to access SourcePath.")] String SourceCredential;
+    [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to access the path set in the parameter 'SourcePath' and 'SourceFolder'. Using this parameter will trigger a copy of the installation media to a temp folder on the target node. Setup will then be started from the temp folder on the target node. For any subsequent calls to the resource, the parameter 'SourceCredential' is used to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter 'SourcePath' and 'SourceFolder'.")] String SourceCredential;
     [Write, Description("Suppresses reboot.")] Boolean SuppressReboot;
     [Write, Description("Forces reboot.")] Boolean ForceReboot;
     [Write, Description("SQL features to be installed.")] String Features;

--- a/README.md
+++ b/README.md
@@ -369,7 +369,13 @@ _Note: There is a known problem running this resource using PowerShell 4.0. See 
 * **SourcePath**: (Required) The path to the root of the source files for installation. I.e and UNC path to a shared resource.
 * **SourceFolder**: Folder within the source path containing the source files for installation. Default value is 'Source'.
 * **SetupCredential**: (Required) Credential to be used to perform the installation.
-* **SourceCredential**: Credential used to access SourcePath.
+* **SourceCredential**: Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. Using this parameter will trigger a copy of the installation media to a temp folder on the target node. Setup will then be started from the temp folder on the target node. For any subsequent calls to the resource, the parameter `SourceCredential` is used to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter `SourcePath` and `SourceFolder`.
+  * Temp folder is evaluated like this according to online documentation for [System.IO.Path.GetTempPath()](https://msdn.microsoft.com/en-us/library/system.io.path.gettemppath(v=vs.110).aspx)
+  * > - Checks for the existence of environment variables in the following order and uses the first path found:
+  * >  - The path specified by the TMP environment variable.
+  * >  - The path specified by the TEMP environment variable.
+  * >  - The path specified by the USERPROFILE environment variable.
+  * >  - The Windows directory.
 * **SuppressReboot**: Suppresses reboot.
 * **ForceReboot**: Forces reboot.
 * **Features**: (Key) SQL features to be installed.

--- a/README.md
+++ b/README.md
@@ -369,13 +369,7 @@ _Note: There is a known problem running this resource using PowerShell 4.0. See 
 * **SourcePath**: (Required) The path to the root of the source files for installation. I.e and UNC path to a shared resource.
 * **SourceFolder**: Folder within the source path containing the source files for installation. Default value is 'Source'.
 * **SetupCredential**: (Required) Credential to be used to perform the installation.
-* **SourceCredential**: Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. Using this parameter will trigger a copy of the installation media to a temp folder on the target node. Setup will then be started from the temp folder on the target node. For any subsequent calls to the resource, the parameter `SourceCredential` is used to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter `SourcePath` and `SourceFolder`.
-  * Temp folder is evaluated like this according to online documentation for [System.IO.Path.GetTempPath()](https://msdn.microsoft.com/en-us/library/system.io.path.gettemppath(v=vs.110).aspx)
-  * > - Checks for the existence of environment variables in the following order and uses the first path found:
-  * >  - The path specified by the TMP environment variable.
-  * >  - The path specified by the TEMP environment variable.
-  * >  - The path specified by the USERPROFILE environment variable.
-  * >  - The Windows directory.
+* **SourceCredential**: Credentials used to access the path set in the parameter `SourcePath` and `SourceFolder`. Using this parameter will trigger a copy of the installation media to a temp folder on the target node. Setup will then be started from the temp folder on the target node. For any subsequent calls to the resource, the parameter `SourceCredential` is used to evaluate what major version the file 'setup.exe' has in the path set, again, by the parameter `SourcePath` and `SourceFolder`. To know how the temp folder is evaluated please read the online documentation for [System.IO.Path.GetTempPath()](https://msdn.microsoft.com/en-us/library/system.io.path.gettemppath(v=vs.110).aspx).
 * **SuppressReboot**: Suppresses reboot.
 * **ForceReboot**: Forces reboot.
 * **Features**: (Key) SQL features to be installed.

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -461,17 +461,60 @@ try
             )
         }
 
+        $mockRobocopyExecutableName = 'Robocopy.exe'
+        $mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
+        $mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
+        $mockRobocopyExectuableVersion = ''     # Set dynamically during runtime
+        $mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
+        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
+        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
+        $mockRobocopyArgumentUseUnbufferedIO = '/J'
+        $mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
+        $mockRobocopyArgumentDestinationPath = 'D:\Temp'
+
+        $mockGetCommand = {
+            return @(
+                (
+                    New-Object Object |
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
+                        Add-Member ScriptProperty FileVersionInfo {
+                            return @( ( New-Object Object |
+                                    Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
+                                ) )
+                        } -PassThru -Force
+                )
+            )
+        }
+
+        $mockStartProcessExpectedArgument = ''  # Set dynamically during runtime
+        $mockStartProcessExitCode = 0  # Set dynamically during runtime
+
+        $mockStartProcess = {
+            if ( $ArgumentList -ne $mockStartProcessExpectedArgument )
+            {
+                throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
+            }
+
+            return New-Object Object |
+                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
+        }
+
+        $mockStartProcess_WithExitCode = {
+            return New-Object Object |
+                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
+        }
+
         $mockGetTemporaryFolder = {
             return $mockSourcePathUNC
         }
 
         <#
         Needed a way to see into the Set-method for the arguments the Set-method is building and sending to 'setup.exe', and fail
-        the test if the arguments is diffentent from the expected arguments.
+        the test if the arguments is different from the expected arguments.
         Solved this by dynamically set the expected arguments before each It-block. If the arguments differs the mock of
         StartWin32Process throws an error message, similiar to what Pester would have reported (expected -> but was).
         #>
-        $mockStartWin32ProcessExpectedArgument = ''
+        $mockStartWin32ProcessExpectedArgument = '' # Set dynamically during runtime
         $mockStartWin32Process = {
             if ( $Arguments -ne $mockStartWin32ProcessExpectedArgument )
             {
@@ -2005,7 +2048,7 @@ try
                         }
 
                         Mock -CommandName NetUse -Verifiable
-                        Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
+                        Mock -CommandName Start-Process -Verifiable
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
 
@@ -2036,7 +2079,7 @@ try
 
                         Assert-MockCalled -CommandName NetUse -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Copy-ItemWithRoboCopy -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -2158,7 +2201,7 @@ try
                         }
 
                         Mock -CommandName NetUse -Verifiable
-                        Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
+                        Mock -CommandName Start-Process -Verifiable
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
 
@@ -2188,7 +2231,7 @@ try
 
                         Assert-MockCalled -CommandName NetUse -Exactly -Times 4 -Scope It
                         Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Copy-ItemWithRoboCopy -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -2505,7 +2548,164 @@ try
                 }
             }
         }
-    }
+
+        # Tests only the parts of the code that does not already get tested thru the other tests.
+        Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
+            Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
+                BeforeEach {
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
+                }
+
+
+                It 'Should use Unbuffered IO when copying' {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+
+                    $mockStartProcessExpectedArgument =
+                        $mockRobocopyArgumentSourcePath,
+                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                        $mockRobocopyArgumentUseUnbufferedIO,
+                        $mockRobocopyArgumentSilent -join ' '
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should not use Unbuffered IO when copying' {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
+
+                    $mockStartProcessExpectedArgument =
+                        $mockRobocopyArgumentSourcePath,
+                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                        '',
+                        $mockRobocopyArgumentSilent -join ' '
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
+                BeforeEach {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+                }
+
+                It 'Should throw the correct error message when error code is 8' {
+                    $mockStartProcessExitCode = 8
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should throw the correct error message when error code is 16' {
+                    $mockStartProcessExitCode = 16
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
+                    $mockStartProcessExitCode = 9
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
+                BeforeEach {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+                }
+
+                It 'Should finish succesfully with exit code 1' {
+                    $mockStartProcessExitCode = 1
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should finish succesfully with exit code 2' {
+                    $mockStartProcessExitCode = 2
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should finish succesfully with exit code 3' {
+                    $mockStartProcessExitCode = 3
+
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+   }
 }
 finally
 {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -490,7 +490,7 @@ try
         $mockStartProcessExitCode = 0  # Set dynamically during runtime
 
         $mockStartProcess = {
-            if ( $ArgumentList -ne $mockStartProcessExpectedArgument )
+            if ( $ArgumentList -cne $mockStartProcessExpectedArgument )
             {
                 throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
             }


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - Changes to the helper function Copy-ItemWithRoboCopy
    - Robocopy is now started using Start-Process and the error handling has been improved.
    - Robocopy now removes files at the destination path if they no longer exists at the source.
    - Robocopy copies using unbuffered I/O when available (recommended for large files).
- Changes to unit tests for resource
  - xSQLServerSetup
    - Added test coverage for helper function Copy-ItemWithRoboCopy

This Pull Request (PR) fixes the following issues:
Fixes #185
Fixes #278
Fixes #286 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/282)
<!-- Reviewable:end -->
