### PR TITLE
Changes to tests in xSQLServer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-﻿DSCResource.Tests 
+﻿DSCResource.Tests
 .vs
 .vscode
+node_modules

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD029": {
+        "style": "ordered"
+    },
+    "MD034": false,
+    "MD024": false,
+    "MD013": false,
+    "no-hard-tabs": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,25 @@
   - Added to the description text for the parameter `Credential` describing how to authenticate using Windows Authentication.
   - Added examples to show how to authenticate using either SQL or Windows authentication.
   - A recent issue showed that there is a known problem running this resource using PowerShell 4.0. For more information, see [issue #273](https://github.com/PowerShell/xSQLServer/issues/273)
+  - The examples 'AddServerRole' and 'RemoveServerRole' can now compile correctly.
 - Changes to the unit test for resource
   - xSQLServerSetup
     - Added test coverage for helper function Copy-ItemWithRoboCopy
 - Changes to xSQLServerLogin
   - Removed ShouldProcess statements
   - Added the ability to enforce password policies on SQL logins
+- Added common test (xSQLServerCommon.Tests) for xSQLServer module
+  - Now all markdown files will be style checked when tests are running in AppVeyor after sending in a pull request.
+  - Now all [Examples](/Examples/Resources) will be tested by compiling to a .mof file after sending in a pull request.
+- Changes to xSQLServerDatabaseOwner
+  - The example 'SetDatabaseOwner' can now compile, it wrongly had a `DependsOn` in the example.
+- Changes to SQLServerRole
+  - The examples 'AddServerRole' and 'RemoveServerRole' can now compile, it wrongly had a `DependsOn` in the example.
+- Changes to CONTRIBUTING.md
+  - Added section 'Tests for examples files'
+  - Added section 'Tests for style check of Markdown files'
+  - Added section 'Documentation with Markdown'
+  - Added texts to section 'Tests'
 
 ## 4.0.0.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,28 @@ one resource, then the functions can also be placed in the common [xSQLServerHel
 
 For a review of a Pull Request (PR) to start, all tests must pass without error. If you need help to figure why some test don't pass, just write a comment in the Pull Request (PR), or submit an issue, and somebody will come along and assist.
 
+To run all tests manually run the following.
+
+```powershell
+Install-Module Pester
+cd '<path to cloned repository>\Tests'
+Invoke-Pester
+```
+
+#### Tests for style check of Markdown files
+
+When sending in a Pull Request (PR) style check will be performed on all Markdown files, and if the tests find any error the build will fail.
+See the section [Documentation with Markdown](#documentation-with-markdown) how these errors kan be found before sending in the PR.
+
+The Markdown tests can be run locally if the packet manager 'npm' is available. To have npm available you need to install [node.js](https://nodejs.org/en/download/).
+If 'npm' is not available, a warning text will print and the rest of the tests will continue run.
+
+#### Tests for examples files
+
+When sending in a Pull Request (PR) all example files will be tested so they can be compiled to a .mof file. If the tests find any error the build will fail.
+Before the test runs in AppVeyor the module will be copied to the first path of `$env:PSModulePath`.
+To run this test locally, make sure you have the xSQLServer module deployed to a path where it can be used. See `$env:PSModulePath` to view the existing paths.
+
 #### Using SMO stub classes
 
 There are [stub classes](https://github.com/PowerShell/xSQLServer/blob/dev/Tests/Unit/Stubs/SMO.cs) for the SMO classes which can be used and improved on when creating tests where SMO classes are used in the code being tested.
@@ -83,3 +105,8 @@ There are [stub classes](https://github.com/PowerShell/xSQLServer/blob/dev/Tests
 
 AppVeyor is the platform where the tests is run when sending in a Pull Request (PR). All tests are run on a clean AppVeyor build worker for each push to the Pull Request (PR).
 The tests that are run on the build worker are common tests, unit tests and integration tests (with some limitations).
+
+### Documentation with Markdown
+
+If using Visual Studio Code to edit Markdown files it can be a good idea to install the markdownlint extension. It will help to do style checking.
+The file [.markdownlint.json](/.markdownlint.json) is prepared with a default set of rules which will automatically be used by the extension.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Invoke-Pester
 
 #### Tests for style check of Markdown files
 
-When sending in a Pull Request (PR) style check will be performed on all Markdown files, and if the tests find any error the build will fail.
+When sending in a Pull Request (PR) a style check will be performed on all Markdown files, and if the tests find any error the build will fail.
 See the section [Documentation with Markdown](#documentation-with-markdown) how these errors kan be found before sending in the PR.
 
 The Markdown tests can be run locally if the packet manager 'npm' is available. To have npm available you need to install [node.js](https://nodejs.org/en/download/).
@@ -93,7 +93,7 @@ If 'npm' is not available, a warning text will print and the rest of the tests w
 
 #### Tests for examples files
 
-When sending in a Pull Request (PR) all example files will be tested so they can be compiled to a .mof file. If the tests find any error the build will fail.
+When sending in a Pull Request (PR) all example files will be tested so they can be compiled to a .mof file. If the tests find any errors the build will fail.
 Before the test runs in AppVeyor the module will be copied to the first path of `$env:PSModulePath`.
 To run this test locally, make sure you have the xSQLServer module deployed to a path where it can be used. See `$env:PSModulePath` to view the existing paths.
 

--- a/Examples/Resources/xSQLServerAlias/1-AddSQLServerAlias.ps1
+++ b/Examples/Resources/xSQLServerAlias/1-AddSQLServerAlias.ps1
@@ -1,17 +1,17 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the SQL Alias
-    SQLDSC* exists with Named Pipes or TCP. 
+    SQLDSC* exists with Named Pipes or TCP.
 #>
 
-Configuration Example 
+Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
         [PSCredential]
         $SysAdminAccount
     )
-    
+
     Import-DscResource -ModuleName xSqlServer
 
     node localhost {

--- a/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
+++ b/Examples/Resources/xSQLServerDatabaseOwner/1-SetDatabaseOwner.ps1
@@ -1,42 +1,39 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the user account CONTOSO\SQLAdmin
-    is "Owner" of SQL database "AdventureWorks". 
+    is "Owner" of SQL database "AdventureWorks".
 #>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
 
-    Configuration Example 
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost
     {
-        param
-        (
-            [Parameter(Mandatory = $true)]
-            [System.Management.Automation.PSCredential]
-            [System.Management.Automation.Credential()]
-            $SysAdminAccount
-        )
-
-        Import-DscResource -ModuleName xSqlServer
-
-        node localhost 
+        xSQLServerLogin Add_SqlServerLogin_SQLAdmin
         {
-            xSQLServerLogin Add_SqlServerLogin_SQLAdmin
-            {
-                DependsOn = '[xSqlServerSetup]SETUP_SqlMSSQLSERVER'
-                Ensure = 'Present'
-                Name = 'CONTOSO\SQLAdmin'
-                LoginType = 'WindowsUser'        
-                SQLServer = 'SQLServer'
-                SQLInstanceName = 'DSC'
-                PsDscRunAsCredential = $SysAdminAccount
-            }
+            Ensure = 'Present'
+            Name = 'CONTOSO\SQLAdmin'
+            LoginType = 'WindowsUser'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
+        }
 
-            xSQLServerDatabaseOwner Set_SqlDatabaseOwner_SQLAdmin
-            {
-                DependsOn = '[xSQLServerLogin]Add_SqlServerLogin_SQLAdmin'
-                Name = 'CONTOSO\SQLAdmin'
-                Database = 'AdventureWorks'
-                SQLServer = 'SQLServer'
-                SQLInstanceName = 'DSC'
-                PsDscRunAsCredential = $SysAdminAccount
-            }
+        xSQLServerDatabaseOwner Set_SqlDatabaseOwner_SQLAdmin
+        {
+            Name = 'CONTOSO\SQLAdmin'
+            Database = 'AdventureWorks'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
+}

--- a/Examples/Resources/xSQLServerRole/1-AddServerRole.ps1
+++ b/Examples/Resources/xSQLServerRole/1-AddServerRole.ps1
@@ -1,29 +1,39 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the user account CONTOSO\SQLAdmin
-    has "dbcreator" and "securityadmin" SQL server roles. 
+    has "dbcreator" and "securityadmin" SQL server roles.
 #>
 
-    Configuration Example 
-    {
-        param(
-            [Parameter(Mandatory = $true)]
-            [PSCredential]
-            $SysAdminAccount
-        )
-        
-        Import-DscResource -ModuleName xSqlServer
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $SysAdminAccount
+    )
 
-        node localhost {
-            xSQLServerRole Add_SqlServerRole_SQLAdmin
-            {
-                DependsOn = '[xSQLServerLogin]Add_SqlServerLogin_SQLAdmin'
-                Ensure = 'Present'
-                Name = 'CONTOSO\SQLAdmin'
-                ServerRole = "dbcreator","securityadmin"
-                SQLServer = 'SQLServer'
-                SQLInstanceName = 'DSC'
-                PsDscRunAsCredential = $SysAdminAccount
-            }
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost {
+        xSQLServerLogin Add_LoginForSQLAdmin
+        {
+            Ensure = 'Present'
+            Name = 'CONTOSO\SQLAdmin'
+            LoginType = 'WindowsUser'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        xSQLServerRole Add_ServerRoleToLogin
+        {
+            DependsOn = '[xSQLServerLogin]Add_LoginForSQLAdmin'
+            Ensure = 'Present'
+            Name = 'CONTOSO\SQLAdmin'
+            ServerRole = "dbcreator","securityadmin"
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
+}

--- a/Examples/Resources/xSQLServerRole/2-RemoveServerRole.ps1
+++ b/Examples/Resources/xSQLServerRole/2-RemoveServerRole.ps1
@@ -1,29 +1,28 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the user account CONTOSO\SQLUser
-    does not have "setupadmin" SQL server role. 
+    does not have "setupadmin" SQL server role.
 #>
 
-    Configuration Example 
-    {
-        param(
-            [Parameter(Mandatory = $true)]
-            [PSCredential]
-            $SysAdminAccount
-        )
-        
-        Import-DscResource -ModuleName xSqlServer
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $SysAdminAccount
+    )
 
-        node localhost {
-            xSQLServerRole Add_SqlServerRole_SQLAdmin
-            {
-                DependsOn = '[xSQLServerLogin]Add_SqlServerLogin_SQLAdmin'
-                Ensure = 'Absent'
-                Name = 'CONTOSO\SQLUser'
-                ServerRole = "setupadmin"
-                SQLServer = 'SQLServer'
-                SQLInstanceName = 'DSC'
-                PsDscRunAsCredential = $SysAdminAccount
-            }
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost {
+        xSQLServerRole Remove_ServerRoleFromLogin
+        {
+            Ensure = 'Absent'
+            Name = 'CONTOSO\SQLUser'
+            ServerRole = "setupadmin"
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
         }
     }
+}

--- a/Examples/Resources/xSQLServerScript/1-RunScriptUsingSQLAuthentication.ps1
+++ b/Examples/Resources/xSQLServerScript/1-RunScriptUsingSQLAuthentication.ps1
@@ -3,7 +3,7 @@
     This example shows how to run SQL script using SQL Authentication.
 #>
 
-Configuration Example 
+Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
@@ -27,15 +27,3 @@ Configuration Example
         }
     }
 }
-
-$configurationData = @{ 
-    AllNodes = @(
-        @{
-            NodeName = 'localhost'
-        }
-    )
-}
-
-Example -SqlCredential (Get-Credential) -ConfigurationData $configurationData -OutputPath 'C:\DSCTemp\Configuration'
-
-Start-DscConfiguration -Path 'C:\DSCTemp\Configuration' -Wait -Verbose -Force

--- a/Examples/Resources/xSQLServerScript/2-RunScriptUsingWindowsAuthentication.ps1
+++ b/Examples/Resources/xSQLServerScript/2-RunScriptUsingWindowsAuthentication.ps1
@@ -4,7 +4,7 @@
     First example shows how the resource is run as account SYSTEM. And the second example shows how the resource is run with a user account.
 #>
 
-Configuration Example 
+Configuration Example
 {
     param(
         [Parameter(Mandatory = $true)]
@@ -39,15 +39,3 @@ Configuration Example
         }
     }
 }
-
-$configurationData = @{
-    AllNodes = @(
-        @{
-            NodeName = 'localhost'
-        }
-    )
-}
-
-Example -SqlCredential (Get-Credential) -ConfigurationData $configurationData -OutputPath 'C:\DSCTemp\Configuration'
-
-Start-DscConfiguration -Path 'C:\DSCTemp\Configuration' -Wait -Verbose -Force

--- a/Tests/xSQLServerCommon.Tests.ps1
+++ b/Tests/xSQLServerCommon.Tests.ps1
@@ -1,0 +1,165 @@
+[CmdletBinding()]
+# Suppressing this because we need to generate a mocked credential to pass examples that need in in the tests
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param()
+
+$script:moduleRoot = Split-Path $PSScriptRoot -Parent
+
+Describe 'xSQLServer module common tests' {
+    Context -Name 'When there are example file for resource' {
+            <#
+                For Appveyor builds copy the module to the system modules directory so it falls
+                in to a PSModulePath folder and is picked up correctly.
+            #>
+            if ($env:APPVEYOR)
+            {
+                $powershellModulePath = Join-Path -Path (($env:PSModulePath -split ';')[0]) -ChildPath 'xSQLServer'
+                Copy-item -Path $env:APPVEYOR_BUILD_FOLDER -Destination $powershellModulePath -Recurse -Force
+            }
+
+            $mockPassword = ConvertTo-SecureString '&iPm%M5q3K$Hhq=wcEK' -AsPlainText -Force
+            $mockCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @('username', $mockPassword)
+            $mockConfigData = @{
+                AllNodes = @(
+                    @{
+                        NodeName = "localhost"
+                        PSDscAllowPlainTextPassword = $true
+                    }
+                )
+            }
+
+            $exampleFile = Get-ChildItem -Path "$script:moduleRoot\Examples\Resources" -Filter "*.ps1" -Recurse
+
+            foreach ($exampleToValidate in $exampleFile)
+            {
+                $exampleDescriptiveName = Join-Path -Path (Split-Path $exampleToValidate.Directory -Leaf) -ChildPath (Split-Path $exampleToValidate -Leaf)
+
+                It "Should compile MOFs for example '$exampleDescriptiveName' correctly" {
+                    {
+                        #Start-Job -ScriptBlock {
+                        . $exampleToValidate.FullName
+
+                        $exampleCommand = Get-Command Example -ErrorAction SilentlyContinue
+                        if ($exampleCommand)
+                        {
+                            try
+                            {
+                                $params = @{}
+                                $exampleCommand.Parameters.Keys | Where-Object { $_ -like '*Account' -or ($_ -like '*Credential' -and $_ -ne 'PsDscRunAsCredential')  } | ForEach-Object -Process {
+                                    $params.Add($_, $mockCredential)
+                                }
+
+                                Example @params -ConfigurationData $mockConfigData -OutputPath 'TestDrive:\' -ErrorAction Continue -WarningAction SilentlyContinue | Out-Null
+                            }
+                            finally
+                            {
+                                # Remove the function we dot-sourced so next example doesn't use the previous.
+                                Remove-Item function:Example
+                            }
+                        }
+                        else
+                        {
+                            throw "The example '$exampleDescriptiveName' does not contain a function 'Example'."
+                        }
+                    } | Should Not Throw
+                }
+        }
+
+        if ($env:APPVEYOR -eq $true)
+        {
+            Remove-item -Path $powershellModulePath -Recurse -Force -Confirm:$false
+
+            # Restore the module in 'memory' to ensure other tests after this test have access to it
+            Import-Module -Name "$script:moduleRoot\xSQLServer.psd1" -Global -Force
+        }
+    }
+
+    Context -Name 'Validate Markdown files' {
+        if (Get-Command npm)
+        {
+            It 'Should not throw an error when installing dependencies' {
+                {
+                    <#
+                        gulp; gulp is a toolkit that helps you automate painful or time-consuming tasks in your development workflow.
+                        gulp must be installed globally to be able to be called through Start-Process
+                    #>
+                    Start-Process -FilePath "npm" -ArgumentList "install -g gulp" -WorkingDirectory $script:moduleRoot -Wait -WindowStyle Hidden
+
+                    # gulp must also be installed locally to be able to be referenced in the javascript file.
+                    Start-Process -FilePath "npm" -ArgumentList "install gulp" -WorkingDirectory $script:moduleRoot -Wait -WindowStyle Hidden
+
+                    # Used in gulpfile.js; A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise
+                    Start-Process -FilePath "npm" -ArgumentList "install through2" -WorkingDirectory $script:moduleRoot -Wait -WindowStyle Hidden
+
+                    # Used in gulpfile.js; A Node.js style checker and lint tool for Markdown/CommonMark files.
+                    Start-Process -FilePath "npm" -ArgumentList "install markdownlint" -WorkingDirectory $script:moduleRoot -Wait -WindowStyle Hidden
+
+                    # gulp-concat is installed as devDependencies. Used in gulpfile.js; Concatenates files
+                    Start-Process -FilePath "npm" -ArgumentList "install gulp-concat -D" -WorkingDirectory $script:moduleRoot -Wait -WindowStyle Hidden
+                } | Should Not Throw
+            }
+
+            It 'Should not have an error in any Markdown files' {
+                $markdownError = 0
+
+                try
+                {
+                    # This executes the gulpfile.js in the root folder of the module.
+                    Start-Process -FilePath "gulp" -ArgumentList "test-mdsyntax --silent" -WorkingDirectory $script:moduleRoot -Wait -NoNewWindow
+
+                    # Wait 3 second so the locks on file 'markdownerror.txt' has been released.
+                    Start-Sleep -Seconds 3
+
+                    $markdownFoundErrorPath = Join-Path -Path $script:moduleRoot -ChildPath "markdownerror.txt"
+
+                    if ((Test-Path -Path $markdownFoundErrorPath))
+                    {
+                        Get-Content -Path $markdownFoundErrorPath | ForEach-Object -Process {
+                            if (-not [string]::IsNullOrEmpty($_))
+                            {
+                                Write-Warning -Message $_
+
+                                $markdownError++
+                            }
+                        }
+                    }
+
+                    <#
+                        When running in AppVeyor. Wait 5 second so the output have time to be sent to AppVeyor Console.
+                        If there are many errors, the AppVeyor Console doesn't have time to print all warning messages
+                        and messages comes out of order.
+                    #>
+                    if( $env:APPVEYOR )
+                    {
+                        Start-Sleep -Seconds 5
+                    }
+                }
+                catch [System.Exception]
+                {
+                    Write-Warning -Message "Unable to run gulp to test Markdown files. Please be sure that you have installed node.js. Error: $_"
+                }
+
+                # Removes the 'markdownerror.txt' file from the module root so it is not shipped.
+                Remove-Item -Path $markdownFoundErrorPath -Force -ErrorAction SilentlyContinue
+
+                # The actual test that will fail the build if it is not zero.
+                $markdownError | Should Be 0
+            }
+
+            It 'Should not throw an error when uninstalling dependencies' {
+                {
+                    # Uninstalled npm packages in reverse order
+                    Start-Process -FilePath "npm" -ArgumentList "uninstall gulp-concat -D" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+                    Start-Process -FilePath "npm" -ArgumentList "uninstall markdownlint" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+                    Start-Process -FilePath "npm" -ArgumentList "uninstall through2" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+                    Start-Process -FilePath "npm" -ArgumentList "uninstall gulp" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+                    Start-Process -FilePath "npm" -ArgumentList "uninstall -g gulp" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+                } | Should Not Throw
+            }
+        }
+        else
+        {
+            Write-Warning -Message 'Cannot find npm to install dependencies needed to test markdown files. Skipping this test!'
+        }
+    }
+}

--- a/Tests/xSQLServerCommon.Tests.ps1
+++ b/Tests/xSQLServerCommon.Tests.ps1
@@ -1,5 +1,5 @@
 [CmdletBinding()]
-# Suppressing this because we need to generate a mocked credential to pass examples that need in in the tests
+# Suppressing this because we need to generate a mocked credentials that will be passed along to the examples that are needed in the tests.
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param()
 
@@ -52,7 +52,7 @@ Describe 'xSQLServer module common tests' {
                             }
                             finally
                             {
-                                # Remove the function we dot-sourced so next example doesn't use the previous.
+                                # Remove the function we dot-sourced so next example file doesn't use the previous Example-function.
                                 Remove-Item function:Example
                             }
                         }
@@ -106,7 +106,7 @@ Describe 'xSQLServer module common tests' {
                     # This executes the gulpfile.js in the root folder of the module.
                     Start-Process -FilePath "gulp" -ArgumentList "test-mdsyntax --silent" -WorkingDirectory $script:moduleRoot -Wait -NoNewWindow
 
-                    # Wait 3 second so the locks on file 'markdownerror.txt' has been released.
+                    # Wait 3 seconds so the locks on file 'markdownerror.txt' has been released.
                     Start-Sleep -Seconds 3
 
                     $markdownFoundErrorPath = Join-Path -Path $script:moduleRoot -ChildPath "markdownerror.txt"
@@ -124,7 +124,7 @@ Describe 'xSQLServer module common tests' {
                     }
 
                     <#
-                        When running in AppVeyor. Wait 5 second so the output have time to be sent to AppVeyor Console.
+                        When running in AppVeyor. Wait 5 seconds so the output have time to be sent to AppVeyor Console.
                         If there are many errors, the AppVeyor Console doesn't have time to print all warning messages
                         and messages comes out of order.
                     #>

--- a/Tests/xSQLServerCommon.Tests.ps1
+++ b/Tests/xSQLServerCommon.Tests.ps1
@@ -156,7 +156,11 @@ Describe 'xSQLServer module common tests' {
                     Start-Process -FilePath "npm" -ArgumentList "uninstall -g gulp" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
 
                     # Remove folder node_modules that npm created.
-                    Remove-Item -Path (Join-Path -Path $script:moduleRoot -ChildPath 'node_modules') -Recurse -Force
+                    $npmNpdeModulesPath = (Join-Path -Path $script:moduleRoot -ChildPath 'node_modules')
+                    if( Test-Path -Path $npmNpdeModulesPath)
+                    {
+                        Remove-Item -Path $npmNpdeModulesPath -Recurse -Force
+                    }
                 } | Should Not Throw
             }
         }

--- a/Tests/xSQLServerCommon.Tests.ps1
+++ b/Tests/xSQLServerCommon.Tests.ps1
@@ -154,6 +154,9 @@ Describe 'xSQLServer module common tests' {
                     Start-Process -FilePath "npm" -ArgumentList "uninstall through2" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
                     Start-Process -FilePath "npm" -ArgumentList "uninstall gulp" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
                     Start-Process -FilePath "npm" -ArgumentList "uninstall -g gulp" -WorkingDirectory $script:moduleRoot -Wait -PassThru  -WindowStyle Hidden
+
+                    # Remove folder node_modules that npm created.
+                    Remove-Item -Path (Join-Path -Path $script:moduleRoot -ChildPath 'node_modules') -Recurse -Force
                 } | Should Not Throw
             }
         }

--- a/Tests/xSQLServerCommon.Tests.ps1
+++ b/Tests/xSQLServerCommon.Tests.ps1
@@ -36,7 +36,6 @@ Describe 'xSQLServer module common tests' {
 
                 It "Should compile MOFs for example '$exampleDescriptiveName' correctly" {
                     {
-                        #Start-Job -ScriptBlock {
                         . $exampleToValidate.FullName
 
                         $exampleCommand = Get-Command Example -ErrorAction SilentlyContinue
@@ -74,7 +73,7 @@ Describe 'xSQLServer module common tests' {
         }
     }
 
-    Context -Name 'Validate Markdown files' {
+    Context -Name 'When there are Markdown files in the module' {
         if (Get-Command npm)
         {
             It 'Should not throw an error when installing dependencies' {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,23 @@
-#---------------------------------# 
-#      environment configuration  # 
-#---------------------------------# 
+#---------------------------------#
+#      environment configuration  #
+#---------------------------------#
 version: 4.0.{build}.0
-install: 
+install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: |
         Import-Module -Name .\DscResource.Tests\TestHelper.psm1 -Force
         Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
         Install-Module -Name Pester -Repository PSGallery -Force
 
-#---------------------------------# 
-#      build configuration        # 
-#---------------------------------# 
+#---------------------------------#
+#      build configuration        #
+#---------------------------------#
 
 build: false
 
-#---------------------------------# 
-#      test configuration         # 
-#---------------------------------# 
+#---------------------------------#
+#      test configuration         #
+#---------------------------------#
 
 test_script:
     - ps: |
@@ -26,20 +26,20 @@ test_script:
         Write-Host 'Modules that are being removed:'
         Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Host $_.Path; Remove-Item $_.Path -Force; }
 
-        # Start the 
+        # Start the tests
         $testResultsFile = ".\TestsResults.xml"
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        if ($res.FailedCount -gt 0) { 
+        if ($res.FailedCount -gt 0) {
             throw "$($res.FailedCount) tests failed."
         }
-    
-#---------------------------------# 
-#      deployment configuration   # 
-#---------------------------------# 
 
-# scripts to run before deployment 
-deploy_script: 
+#---------------------------------#
+#      deployment configuration   #
+#---------------------------------#
+
+# scripts to run before deployment
+deploy_script:
   - ps: |
       # Creating project artifact
       $stagingDirectory = (Resolve-Path ..).Path
@@ -48,23 +48,23 @@ deploy_script:
       $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
       Add-Type -assemblyname System.IO.Compression.FileSystem
       [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
-      
+
       # Creating NuGet package artifact
       New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version $env:APPVEYOR_BUILD_VERSION -author "Microsoft" -owners "Microsoft" -licenseUrl "https://github.com/PowerShell/DscResources/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "DesiredStateConfiguration DSC DSCResourceKit" -destinationPath .
       nuget pack ".\$($env:APPVEYOR_PROJECT_NAME).nuspec" -outputdirectory .
       $nuGetPackageName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + ".nupkg"
       $nuGetPackagePath = (Get-ChildItem $nuGetPackageName).FullName
-      
+
       @(
           # You can add other artifacts here
           $zipFilePath,
           $nuGetPackagePath
-      ) | % { 
+      ) | % {
           Write-Host "Pushing package $_ as Appveyor artifact"
           Push-AppveyorArtifact $_
         }
-        
-        
+
+
 
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,24 @@
+var gulp = require("gulp");
+var concat = require("gulp-concat");
+var through2 = require("through2");
+var markdownlint = require("markdownlint");
+
+gulp.task("test-mdsyntax", function task() {
+  return gulp.src(["./DSCResources/**/*.md","./*.md"], { "read": false })
+    .pipe(through2.obj(function obj(file, enc, next) {
+      markdownlint(
+        {
+          "files": [ file.path ],
+          "config": require("./.markdownlint.json")
+        },
+        function callback(err, result) {
+          var resultString = (result || "").toString();
+          if (resultString) {
+            file.contents = new Buffer(resultString);
+          }
+          next(err, file);
+        });
+    }))
+    .pipe(concat("markdownerror.txt", { newLine: "\r\n" }))
+    .pipe(gulp.dest("."));
+});


### PR DESCRIPTION
Changes to tests in xSQLServer module

- Added common test xSQLServerCommon.Tests for xSQLServer module
  - Now all markdown files will be style checked when tests are running in AppVeyor after sending in a pull request.
  - Now all [Examples](/Examples/Resources) will be tested by compiling to a .mof file after sending in a pull request.
- Changes to xSQLServerDatabaseOwner
  - The example 'SetDatabaseOwner' can now compile, it wrongly had a `DependsOn` in the example.
- Changes to SQLServerRole
  - The examples 'AddServerRole' and 'RemoveServerRole' can now compile, it wrongly had a `DependsOn` in the example.
- Changes to xSQLServerScript
  - The examples 'AddServerRole' and 'RemoveServerRole' can now compile correctly.
- Changes to CONTRIBUTING.md
  - Added section 'Tests for examples files'
  - Added section 'Tests for style check of Markdown files'
  - Added section 'Documentation with Markdown'
  - Added texts to section 'Tests'
- Added default rules to .markdownlint.json

This Pull Request (PR) fixes the following issues:
n/a

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/300)
<!-- Reviewable:end -->
