### PR TITLE
xSQLServerSetup: Some code cleanup, and misplaced entry in the CHANGELOG.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@
   - Added to the description text for the parameter `Credential` describing how to authenticate using Windows Authentication.
   - Added examples to show how to authenticate using either SQL or Windows authentication.
   - A recent issue showed that there is a known problem running this resource using PowerShell 4.0. For more information, see [issue #273](https://github.com/PowerShell/xSQLServer/issues/273)
-  - The examples 'AddServerRole' and 'RemoveServerRole' can now compile correctly.
 - Changes to the unit test for resource
   - xSQLServerSetup
     - Added test coverage for helper function Copy-ItemWithRoboCopy

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -62,11 +62,11 @@ function Get-TargetResource
         $null = New-SmbMapping @newSmbMappingParameters
     }
 
-    $path = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
+    $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    New-VerboseMessage -Message "Using path: $path"
+    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
 
-    $sqlVersion = Get-SqlMajorVersion -Path $path
+    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
     if ($SourceCredential)
     {
@@ -614,11 +614,11 @@ function Set-TargetResource
         $SourcePath = $mediaDestinationPath
     }
 
-    $path = ResolvePath (Join-Path -Path $SourcePath -ChildPath 'setup.exe')
+    $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    New-VerboseMessage -Message "Using path: $path"
+    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
 
-    $sqlVersion = Get-SqlMajorVersion -Path $path
+    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
     # Determine features to install
     $featuresToInstall = ""

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -861,9 +861,9 @@ function Set-TargetResource
 
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
-    $process = StartWin32Process -Path $path -Arguments $arguments
+    $process = StartWin32Process -Path $pathToSetupExecutable -Arguments $arguments
     New-VerboseMessage -Message $process
-    WaitForWin32ProcessEnd -Path $path -Arguments $arguments
+    WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments
 
     if ($ForceReboot -or ($null -ne (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name 'PendingFileRenameOperations' -ErrorAction SilentlyContinue)))
     {


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - Code cleanup. A function was used, that wasn't needed. And change a variable name to align more against HQRM.
- Changes to CHANGELOG.md
  - A duplicated and out of order row was removed.

This Pull Request (PR) fixes the following issues:
n/a

- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/312)
<!-- Reviewable:end -->
