### PR TITLE
xSQLServerSetup: Add support for clustered installations (Fixes #227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@
 - Changes to xSQLServerDatabasePermission
   - BREAKING CHANGE: Renamed xSQLServerDatabasePermissions to xSQLServerDatabasePermission to align wíth naming convention.
   - BREAKING CHANGE: The mandatory parameters now include PermissionState, SQLServer, and SQLInstanceName.
+- Added support for clustered installations to xSQLServerSetup
+  - Migrated relevant code from xSQLServerFailoverClusterSetup
+  - Removed Get-WmiObject usage
+  - Clustered storage mapping now supports asymmetric cluster storage
+  - Added support for multi-subnet clusters
+  - Added localized error messages for cluster object mapping
+  - Updated README.md to reflect new parameters
 
 ## 4.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
   - Added support for multi-subnet clusters
   - Added localized error messages for cluster object mapping
   - Updated README.md to reflect new parameters
+- Updated description for xSQLServerFailoverClusterSetup to indicate it is deprecated.
 
 ## 4.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -884,10 +884,10 @@ function Set-TargetResource
         Action = $Action
     }
 
-    # Create install arguments
-    $arguments = @{
-        Quient = 'True'
-        IAcceptSQLServerLicenseTerms = 'True'
+    # Add standard install arguments
+    $setupArgs += @{
+        Quiet = $true
+        IAcceptSQLServerLicenseTerms = $true
         Action = $Action
     }
 
@@ -925,67 +925,14 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('SQLSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'SQLSVCACCOUNT' -PasswordArgumentName 'SQLSVCPASSWORD' -User $SQLSvcAccount
-
-            if ($SQLSvcAccount.UserName -eq "SYSTEM")
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('SQLSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                $setupArgs.Add('SQLSVCACCOUNT', $SQLSvcAccount.UserName)
-                $setupArgs.Add('SQLSVCPASSWORD', $SQLSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /SQLSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
-                $arguments.Add('SQLSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                #$arguments += " /SQLSVCACCOUNT=`"" + $SQLSvcAccount.UserName + "`""
-                #$arguments += " /SQLSVCPASSWORD=`"" + $SQLSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('SQLSVCACCOUNT', $SQLSvcAccount.UserName)
-                $arguments.Add('SQLSVCPASSWORD', $SQLSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $SQLSvcAccount -AccountType 'SQL')
         }
 
         if($PSBoundParameters.ContainsKey('AgtSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'AGTSVCACCOUNT' -PasswordArgumentName 'AGTSVCPASSWORD' -User $AgtSvcAccount
-
-            if($AgtSvcAccount.UserName -eq 'SYSTEM')
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('AGTSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                $setupArgs.Add('AGTSVCACCOUNT', $AgtSvcAccount.UserName)
-                $setupArgs.Add('AGTSVCPASSWORD', $AgtSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /AGTSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
-                $arguments.Add('AGTSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                #$arguments += " /AGTSVCACCOUNT=`"" + $AgtSvcAccount.UserName + "`""
-                #$arguments += " /AGTSVCPASSWORD=`"" + $AgtSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('AGTSVCACCOUNT', $AgtSvcAccount.UserName)
-                $arguments.Add('AGTSVCPASSWORD', $AgtSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $AgtSvcAccount -AccountType 'AGT')
         }
 
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
         $setupArgs.Add('SQLSysAdminAccounts', $($SetupCredential.UserName))
         if ($PSBoundParameters -icontains 'SQLSysAdminAccounts')
         {
@@ -998,42 +945,12 @@ function Set-TargetResource
         }
 
         $setupArgs.Add('AGTSVCSTARTUPTYPE','Automatic')
-=======
-        #$arguments += ' /AGTSVCSTARTUPTYPE=Automatic'
-        $arguments.Add('AGTSVCSTARTUPTYPE','Automatic')
->>>>>>> Converted argument array to hashtable
     }
 
     if ($Features.Contains('FULLTEXT'))
     {
         if ($PSBoundParameters.ContainsKey('FTSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'FTSVCACCOUNT' -PasswordArgumentName 'FTSVCPASSWORD' -User $FTSvcAccount
-
-            if ($FTSvcAccount.UserName -eq 'SYSTEM')
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('FTSVCACCOUNT','NT AUTHORITY\LOCAL SERVICE')
-            }
-            else
-            {
-                $setupArgs.Add('FTSVCACCOUNT', $FTSvcAccount.UserName)
-                $setupArgs.Add('FTSVCPASSWORD', $FTSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /FTSVCACCOUNT=`"NT AUTHORITY\LOCAL SERVICE`""
-                $arguments.Add('FTSVCACCOUNT','NT AUTHORITY\LOCAL SERVICE')
-            }
-            else
-            {
-                #$arguments += " /FTSVCACCOUNT=`"" + $FTSvcAccount.UserName + "`""
-                #$arguments += " /FTSVCPASSWORD=`"" + $FTSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('FTSVCACCOUNT', $FTSvcAccount.UserName)
-                $arguments.Add('FTSVCPASSWORD', $FTSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $FTSvcAccount -AccountType 'FT')
         }
     }
@@ -1042,32 +959,6 @@ function Set-TargetResource
     {
         if ($PSBoundParameters.ContainsKey('RSSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'RSSVCACCOUNT' -PasswordArgumentName 'RSSVCPASSWORD' -User $RSSvcAccount
-
-            if ($RSSvcAccount.UserName -eq "SYSTEM")
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('RSSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                $setupArgs.Add('RSSVCACCOUNT', $RSSvcAccount.UserName)
-                $setupArgs.Add('RSSVCPASSWORD', $RSSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /RSSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
-                $arguments.Add('RSSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                #$arguments += " /RSSVCACCOUNT=`"" + $RSSvcAccount.UserName + "`""
-                #$arguments += " /RSSVCPASSWORD=`"" + $RSSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('RSSVCACCOUNT', $RSSvcAccount.UserName)
-                $arguments.Add('RSSVCPASSWORD', $RSSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $RSSvcAccount -AccountType 'RS')
         }
     }
@@ -1085,33 +976,14 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('ASSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'ASSVCACCOUNT' -PasswordArgumentName 'ASSVCPASSWORD' -User $ASSvcAccount
-
-            if($ASSvcAccount.UserName -eq 'SYSTEM')
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('ASSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                $setupArgs.Add('ASSVCACCOUNT', $ASSvcAccount.UserName)
-                $setupArgs.Add('ASSVCPASSWORD', $ASSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /ASSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
-                $arguments.Add('ASSVCACCOUNT','NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                #$arguments += " /ASSVCACCOUNT=`"" + $ASSvcAccount.UserName + "`""
-                #$arguments += " /ASSVCPASSWORD=`"" + $ASSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('ASSVCACCOUNT', $ASSvcAccount.UserName)
-                $arguments.Add('ASSVCPASSWORD', $ASSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $ASSvcAccount -AccountType 'AS')
+        }
+
+        $setupArgs.Add('ASSysAdminAccounts', @($SetupCredential.UserName))
+
+        if($PSBoundParameters.ContainsKey("ASSysAdminAccounts"))
+        {
+            $setupArgs['ASSysAdminAccounts'] += $ASSysAdminAccounts
         }
 
         $setupArgs.Add('ASSysAdminAccounts', @($SetupCredential.UserName))
@@ -1126,32 +998,6 @@ function Set-TargetResource
     {
         if ($PSBoundParameters.ContainsKey('ISSvcAccount'))
         {
-            <#
-            $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'ISSVCACCOUNT' -PasswordArgumentName 'ISSVCPASSWORD' -User $ISSvcAccount
-
-            if ($ISSvcAccount.UserName -eq 'SYSTEM')
-            {
-<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
-                $setupArgs.Add('ISSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                $setupArgs.Add('ISSVCACCOUNT', $ISSvcAccount.UserName)
-                $setupArgs.Add('ISSVCPASSWORD', $ISSvcAccount.GetNetworkCredential().Password)
-=======
-                #$arguments += " /ISSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
-                $arguments.Add('ISSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
-            }
-            else
-            {
-                #$arguments += " /ISSVCACCOUNT=`"" + $ISSvcAccount.UserName + "`""
-                #$arguments += " /ISSVCPASSWORD=`"" + $ISSvcAccount.GetNetworkCredential().Password + "`""
-                $arguments.Add('ISSVCACCOUNT', $ISSvcAccount.UserName)
-                $arguments.Add('ISSVCPASSWORD', $ISSvcAccount.GetNetworkCredential().Password)
->>>>>>> Converted argument array to hashtable
-            }
-            #>
-
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $ISSvcAccount -AccountType 'IS')
         }
     }
@@ -1195,6 +1041,7 @@ function Set-TargetResource
 
             $arguments += "/$($setupArg.Key.ToUpper())=$($setupArgValue) "
         }
+
     }
 
     # Replace sensitive values for verbose output
@@ -1221,7 +1068,6 @@ function Set-TargetResource
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
     $process = StartWin32Process -Path $path -Arguments $arguments.Trim()
-
     New-VerboseMessage -Message $process
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments.Trim()
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1657,7 +1657,6 @@ function Test-IPAddress
     return (($IPAddressDecimal -band $SubnetDecimal) -eq ($NetworkDecimal -band $SubnetDecimal))
 }
 
-<<<<<<< 5fc129f536806a599d9c949fadae68c8909ede33
 <#
     .SYNOPSIS
         Builds service account parameters for setup

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -510,7 +510,6 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
         $Action = 'Install',
@@ -799,7 +798,7 @@ function Set-TargetResource
         $clusterIPAddresses = @()
 
         ## Get a required lising of drives based on user parameters
-        $requiredDrives = Get-Variable -Name '*SQL*Dir' | ForEach-Object { [System.IO.Path]::GetPathRoot($_.Value).TrimEnd('\') } | Select -Unique
+        $requiredDrives = Get-Variable -Name '*SQL*Dir' | ForEach-Object { [System.IO.Path]::GetPathRoot($_.Value).TrimEnd('\') } | Select-Object -Unique
 
         ## Get the disk resources that are available (not assigned to a cluster role)
         $availableStorage = Get-CimInstance -Namespace root/MSCluster -ClassName MSCluster_ResourceGroup -Filter "Name = 'Available Storage'" |
@@ -808,11 +807,11 @@ function Set-TargetResource
         foreach ($diskResource in $availableStorage)
         {
             ## Determine whether the current node is a possible owner of the disk resource
-            $possibleOwners = $diskResource | Get-CimAssociatedInstance -Association 'MSCluster_ResourceToPossibleOwner' -KeyOnly | Select -ExpandProperty Name
+            $possibleOwners = $diskResource | Get-CimAssociatedInstance -Association 'MSCluster_ResourceToPossibleOwner' -KeyOnly | Select-Object -ExpandProperty Name
             if ($possibleOwners -icontains $env:COMPUTERNAME)
             {
                 ## Determine whether this disk contains one of our required partitions
-                if ($requiredDrives -icontains ($diskResource | Get-CimAssociatedInstance -ResultClassName 'MSCluster_DiskPartition' | Select -ExpandProperty Path))
+                if ($requiredDrives -icontains ($diskResource | Get-CimAssociatedInstance -ResultClassName 'MSCluster_DiskPartition' | Select-Object -ExpandProperty Path))
                 {
                     $failoverClusterDisks += $diskResource.Name
                 }
@@ -820,11 +819,11 @@ function Set-TargetResource
         }
 
         ## Ensure we have a unique listing of disks
-        $failoverClusterDisks = $failoverClusterDisks | Select -Unique
+        $failoverClusterDisks = $failoverClusterDisks | Select-Object -Unique
 
         ## Ensure we mapped all required drives
-        $requiredDriveCount = $requiredDrives | Measure-Object | Select -ExpandProperty Count
-        $mappedDriveCount = $failoverClusterDisks | Measure-Object | Select -ExpandProperty Count
+        $requiredDriveCount = $requiredDrives | Measure-Object | Select-Object -ExpandProperty Count
+        $mappedDriveCount = $failoverClusterDisks | Measure-Object | Select-Object -ExpandProperty Count
 
         if ($mappedDriveCount -ne $requiredDriveCount)
         {
@@ -859,8 +858,8 @@ function Set-TargetResource
         }
 
         ## Ensure we mapped all required networks
-        $suppliedNetworkCount = $FailoverClusterIPAddress | Measure-Object | Select -ExpandProperty Count
-        $mappedNetworkCount = $clusterIPAddresses | Measure-Object | Select -ExpandProperty Count
+        $suppliedNetworkCount = $FailoverClusterIPAddress | Measure-Object | Select-Object -ExpandProperty Count
+        $mappedNetworkCount = $clusterIPAddresses | Measure-Object | Select-Object -ExpandProperty Count
         
         if ($suppliedNetworkCount -ne $mappedNetworkCount)
         {
@@ -1068,9 +1067,8 @@ function Set-TargetResource
 
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
-    Write-Host $arguments
-    <#
     $process = StartWin32Process -Path $path -Arguments $arguments.Trim()
+
     New-VerboseMessage -Message $process
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments.Trim()
 
@@ -1090,7 +1088,6 @@ function Set-TargetResource
     {
         throw New-TerminatingError -ErrorType TestFailedAfterSet -ErrorCategory InvalidResult
     }
-    #>
 }
 
 <#
@@ -1242,7 +1239,6 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
         $Action = 'Install', 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1455,6 +1455,9 @@ function Test-TargetResource
         SetupCredential = $SetupCredential
         SourceCredential = $SourceCredential
         InstanceName = $InstanceName
+        FailoverClusterGroup = $FailoverClusterGroup
+        FailoverClusterIPAddress = $FailoverClusterIPAddress
+        FailoverClusterNetworkName = $FailoverClusterNetworkName
     }
 
     $getTargetResourceResult = Get-TargetResource @parameters
@@ -1475,6 +1478,37 @@ function Test-TargetResource
                 New-VerboseMessage -Message "Unable to find feature '$feature' among the installed features: '$($getTargetResourceResult.Features)'"
                 $result = $false
             }
+        }
+    }
+    
+    if ($PSCmdlet.ParameterSetName -eq 'ClusterInstall')
+    {
+        New-VerboseMessage -Message "Clustered install, checking parameters."
+
+        if ($sqlData.FailoverClusterGroup -ne $FailoverClusterGroup)
+        {
+            if ($sqlData.FailoverClusterNetworkName -eq $FailoverClusterNetworkName)
+            {
+                if ($sqlData.FailoverClusterIPAddress -eq $FailoverClusterIPAddress)
+                {
+                    $result = $true
+                }
+                else
+                {
+                    New-VerboseMessage -Message "IP Address '$FailoverClusterIPAddress' not valid for cluster host name '$FailoverClusterNetworkName'"
+                    $result = $false
+                }
+            }
+            else
+            {
+                New-VerboseMessage -Message "Hostname '$FailoverClusterNetworkName' not valid for cluster group '$FailoverClusterGroup'."
+                $result = $false
+            }
+        }
+        else
+        {
+            New-VerboseMessage -Message "Unable to find cluster group '$FailoverClusterGroup'"
+            $result = $false
         }
     }
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -510,6 +510,7 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
         $Action = 'Install',
@@ -1067,6 +1068,8 @@ function Set-TargetResource
 
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
+    Write-Host $arguments
+    <#
     $process = StartWin32Process -Path $path -Arguments $arguments.Trim()
     New-VerboseMessage -Message $process
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments.Trim()
@@ -1087,6 +1090,7 @@ function Set-TargetResource
     {
         throw New-TerminatingError -ErrorType TestFailedAfterSet -ErrorCategory InvalidResult
     }
+    #>
 }
 
 <#
@@ -1238,6 +1242,7 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
         $Action = 'Install', 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1416,30 +1416,15 @@ function Test-TargetResource
     {
         New-VerboseMessage -Message "Clustered install, checking parameters."
 
-        if ($sqlData.FailoverClusterGroup -eq $FailoverClusterGroup)
-        {
-            if ($sqlData.FailoverClusterNetworkName -eq $FailoverClusterNetworkName)
-            {
-                if ($sqlData.FailoverClusterIPAddress -eq $FailoverClusterIPAddress)
-                {
-                    $result = $true
-                }
-                else
-                {
-                    New-VerboseMessage -Message "IP Address '$FailoverClusterIPAddress' not valid for cluster host name '$FailoverClusterNetworkName'"
-                    $result = $false
-                }
-            }
-            else
-            {
-                New-VerboseMessage -Message "Hostname '$FailoverClusterNetworkName' not valid for cluster group '$FailoverClusterGroup'."
+        $result = $true
+
+        Get-Variable -Name FailoverCluster* | ForEach-Object {
+            $variableName = $_.Name
+
+            if ($sqlData.$variableName -ne $_.Value) {
+                New-VerboseMessage -Message "$variableName '$($_.Value)' is not valid for this cluster."
                 $result = $false
             }
-        }
-        else
-        {
-            New-VerboseMessage -Message "Unable to find cluster group '$FailoverClusterGroup'"
-            $result = $false
         }
     }
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -823,7 +823,12 @@ function Set-TargetResource
     }
 
     # Create install arguments
-    $arguments = "/Quiet=`"True`" /IAcceptSQLServerLicenseTerms=`"True`" /Action=`"Install`""
+    $arguments = @{
+        Quient = 'True'
+        IAcceptSQLServerLicenseTerms = 'True'
+        Action = $Action
+    }
+
     $argumentVars = @(
         'InstanceName',
         'InstanceID',
@@ -858,22 +863,74 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('SQLSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'SQLSVCACCOUNT' -PasswordArgumentName 'SQLSVCPASSWORD' -User $SQLSvcAccount
+
+            if ($SQLSvcAccount.UserName -eq "SYSTEM")
+            {
+                #$arguments += " /SQLSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('SQLSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /SQLSVCACCOUNT=`"" + $SQLSvcAccount.UserName + "`""
+                #$arguments += " /SQLSVCPASSWORD=`"" + $SQLSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('SQLSVCACCOUNT', $SQLSvcAccount.UserName)
+                $arguments.Add('SQLSVCPASSWORD', $SQLSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $SQLSvcAccount -AccountType 'SQL')
         }
 
         if($PSBoundParameters.ContainsKey('AgtSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'AGTSVCACCOUNT' -PasswordArgumentName 'AGTSVCPASSWORD' -User $AgtSvcAccount
+
+            if($AgtSvcAccount.UserName -eq 'SYSTEM')
+            {
+                #$arguments += " /AGTSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('AGTSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /AGTSVCACCOUNT=`"" + $AgtSvcAccount.UserName + "`""
+                #$arguments += " /AGTSVCPASSWORD=`"" + $AgtSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('AGTSVCACCOUNT', $AgtSvcAccount.UserName)
+                $arguments.Add('AGTSVCPASSWORD', $AgtSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $AgtSvcAccount -AccountType 'AGT')
         }
 
-        $arguments += ' /AGTSVCSTARTUPTYPE=Automatic'
+        #$arguments += ' /AGTSVCSTARTUPTYPE=Automatic'
+        $arguments.Add('AGTSVCSTARTUPTYPE','Automatic')
     }
 
     if ($Features.Contains('FULLTEXT'))
     {
         if ($PSBoundParameters.ContainsKey('FTSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'FTSVCACCOUNT' -PasswordArgumentName 'FTSVCPASSWORD' -User $FTSvcAccount
+
+            if ($FTSvcAccount.UserName -eq 'SYSTEM')
+            {
+                #$arguments += " /FTSVCACCOUNT=`"NT AUTHORITY\LOCAL SERVICE`""
+                $arguments.Add('FTSVCACCOUNT','NT AUTHORITY\LOCAL SERVICE')
+            }
+            else
+            {
+                #$arguments += " /FTSVCACCOUNT=`"" + $FTSvcAccount.UserName + "`""
+                #$arguments += " /FTSVCPASSWORD=`"" + $FTSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('FTSVCACCOUNT', $FTSvcAccount.UserName)
+                $arguments.Add('FTSVCPASSWORD', $FTSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $FTSvcAccount -AccountType 'FT')
         }
     }
 
@@ -881,7 +938,24 @@ function Set-TargetResource
     {
         if ($PSBoundParameters.ContainsKey('RSSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'RSSVCACCOUNT' -PasswordArgumentName 'RSSVCPASSWORD' -User $RSSvcAccount
+
+            if ($RSSvcAccount.UserName -eq "SYSTEM")
+            {
+                #$arguments += " /RSSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('RSSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /RSSVCACCOUNT=`"" + $RSSvcAccount.UserName + "`""
+                #$arguments += " /RSSVCPASSWORD=`"" + $RSSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('RSSVCACCOUNT', $RSSvcAccount.UserName)
+                $arguments.Add('RSSVCPASSWORD', $RSSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $RSSvcAccount -AccountType 'RS')
         }
     }
 
@@ -898,7 +972,24 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('ASSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'ASSVCACCOUNT' -PasswordArgumentName 'ASSVCPASSWORD' -User $ASSvcAccount
+
+            if($ASSvcAccount.UserName -eq 'SYSTEM')
+            {
+                #$arguments += " /ASSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('ASSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /ASSVCACCOUNT=`"" + $ASSvcAccount.UserName + "`""
+                #$arguments += " /ASSVCPASSWORD=`"" + $ASSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('ASSVCACCOUNT', $ASSvcAccount.UserName)
+                $arguments.Add('ASSVCPASSWORD', $ASSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $ASSvcAccount -AccountType 'AS')
         }
     }
 
@@ -906,7 +997,24 @@ function Set-TargetResource
     {
         if ($PSBoundParameters.ContainsKey('ISSvcAccount'))
         {
+            <#
             $arguments = $arguments | Join-ServiceAccountInfo -UsernameArgumentName 'ISSVCACCOUNT' -PasswordArgumentName 'ISSVCPASSWORD' -User $ISSvcAccount
+
+            if ($ISSvcAccount.UserName -eq 'SYSTEM')
+            {
+                #$arguments += " /ISSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('ISSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /ISSVCACCOUNT=`"" + $ISSvcAccount.UserName + "`""
+                #$arguments += " /ISSVCPASSWORD=`"" + $ISSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('ISSVCACCOUNT', $ISSvcAccount.UserName)
+                $arguments.Add('ISSVCPASSWORD', $ISSvcAccount.GetNetworkCredential().Password)
+            }
+            #>
+
+            $arguments += (Get-ServiceAccountParameters -ServiceAccount $ISSvcAccount -AccountType 'IS')
         }
     }
 
@@ -1531,6 +1639,64 @@ fucntion Test-IPAddress
     ## Determine whether the IP Address is valid for this network / subnet
     return (($IPAddressDecimal -band $SubnetDecimal) -eq ($NetworkDecimal -band $SubnetDecimal))
 }
+
+<#
+    .SYNOPSIS
+        Builds service account parameters for setup
+
+    .PARAMETER ServiceAccount
+        Credential for the service account
+
+    .PARAMETER AccountType
+        Type of service account 
+#>
+function Get-ServiceAccountParameters {
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param
+    (
+        [PSCredential]
+        $ServiceAccount,
+
+        [ValidateSet('SQL','AGT','IS','RS','AS','FT')]
+        [String]
+        $AccountType
+    )
+
+    switch -Regex ($ServiceAccount.UserName.ToUpper())
+    {
+        '^(?:NT ?AUTHORITY\\)?(SYSTEM|LOCALSERVICE|LOCAL SERVICE|NETWORKSERVICE|NETWORK SERVICE)$'
+        {
+            $user = "NT AUTHORITY\$($Matches[1])"
+            $passwd = ''
+        }
+
+        '^(?:NT SERVICE\\)(.*)$'
+        {
+            $user = "NT SERVICE\$($Matches[1])"
+            $passwd = ''
+        }
+
+        '.*\$'
+        {
+            $user = $ServiceAccount.UserName
+            $passwd = '' 
+        }
+
+        default
+        {
+            $user = $ServiceAccount.UserName
+            $passwd = $ServiceAccount.GetNetworkCredential().Password
+        }
+    }
+
+    return @{
+        "$($AccountType)SVCACCOUNT" = $user
+        "$($AccountType)SVCPASSWORD" = $passwd
+    }
+
+}
+
 <#
     .SYNOPSIS
         Returns the argument string appeneded with the account information as is given in UserAlias and User parameters

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -638,7 +638,7 @@ function Set-TargetResource
         $FailoverClusterGroup = "SQL Server ($InstanceName)",
 
         [Parameter(ParameterSetName = 'ClusterInstall')]
-        [System.Net.IPAddress[]]
+        [System.String[]]
         $FailoverClusterIPAddress,
 
         [Parameter(ParameterSetName = 'ClusterInstall')]
@@ -1361,7 +1361,7 @@ function Test-TargetResource
         $FailoverClusterGroup = "SQL Server ($InstanceName)",
 
         [Parameter(ParameterSetName = 'ClusterInstall')]
-        [System.Net.IPAddress[]]
+        [System.String[]]
         $FailoverClusterIPAddress,
 
         [Parameter(ParameterSetName = 'ClusterInstall')]

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1657,41 +1657,44 @@ function Get-ServiceAccountParameters {
 
         [ValidateSet('SQL','AGT','IS','RS','AS','FT')]
         [String]
-        $AccountType
+        $ServiceType
     )
+
+    $parameters = @{}
 
     switch -Regex ($ServiceAccount.UserName.ToUpper())
     {
         '^(?:NT ?AUTHORITY\\)?(SYSTEM|LOCALSERVICE|LOCAL SERVICE|NETWORKSERVICE|NETWORK SERVICE)$'
         {
-            $user = "NT AUTHORITY\$($Matches[1])"
-            $passwd = ''
+            $parameters = @{
+                "$($ServiceType)SVCACCOUNT" = "NT AUTHORITY\$($Matches[1])"
+            }
         }
 
         '^(?:NT SERVICE\\)(.*)$'
         {
-            $user = "NT SERVICE\$($Matches[1])"
-            $passwd = ''
+            $parameters = @{
+                "$($ServiceType)SVCACCOUNT" = "NT SERVICE\$($Matches[1])"
+            }
         }
 
         '.*\$'
         {
-            $user = $ServiceAccount.UserName
-            $passwd = '' 
+            $parameters = @{
+                "$($ServiceType)SVCACCOUNT" = $ServiceAccount.UserName
+            }
         }
 
         default
         {
-            $user = $ServiceAccount.UserName
-            $passwd = $ServiceAccount.GetNetworkCredential().Password
+            $parameters = @{
+                "$($ServiceType)SVCACCOUNT" = $ServiceAccount.UserName
+                "$($ServiceType)SVCPASSWORD" = $ServiceAccount.GetNetworkCredential().Password
+            }
         }
     }
 
-    return @{
-        "$($AccountType)SVCACCOUNT" = $user
-        "$($AccountType)SVCPASSWORD" = $passwd
-    }
-
+    return $parameters
 }
 
 <#

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -510,10 +510,9 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
-        $Action = 'Install', 
+        $Action = 'Install',
 
         [System.String]
         $SourcePath,
@@ -1309,7 +1308,6 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory = $true)]
         [ValidateSet('Install','InstallFailoverCluster','AddNode','PrepareFailoverCluster','CompleteFailoverCluster')]
         [System.String]
         $Action = 'Install', 
@@ -1735,6 +1733,7 @@ function Test-IPAddress
     return (($IPAddressDecimal -band $SubnetDecimal) -eq ($NetworkDecimal -band $SubnetDecimal))
 }
 
+<<<<<<< 5fc129f536806a599d9c949fadae68c8909ede33
 <#
     .SYNOPSIS
         Builds service account parameters for setup

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -884,6 +884,13 @@ function Set-TargetResource
         Action = $Action
     }
 
+    # Create install arguments
+    $arguments = @{
+        Quient = 'True'
+        IAcceptSQLServerLicenseTerms = 'True'
+        Action = $Action
+    }
+
     $argumentVars = @(
         'InstanceName',
         'InstanceID',
@@ -923,12 +930,24 @@ function Set-TargetResource
 
             if ($SQLSvcAccount.UserName -eq "SYSTEM")
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('SQLSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
             }
             else
             {
                 $setupArgs.Add('SQLSVCACCOUNT', $SQLSvcAccount.UserName)
                 $setupArgs.Add('SQLSVCPASSWORD', $SQLSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /SQLSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('SQLSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /SQLSVCACCOUNT=`"" + $SQLSvcAccount.UserName + "`""
+                #$arguments += " /SQLSVCPASSWORD=`"" + $SQLSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('SQLSVCACCOUNT', $SQLSvcAccount.UserName)
+                $arguments.Add('SQLSVCPASSWORD', $SQLSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 
@@ -942,18 +961,31 @@ function Set-TargetResource
 
             if($AgtSvcAccount.UserName -eq 'SYSTEM')
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('AGTSVCACCOUNT','NT AUTHORITY\SYSTEM')
             }
             else
             {
                 $setupArgs.Add('AGTSVCACCOUNT', $AgtSvcAccount.UserName)
                 $setupArgs.Add('AGTSVCPASSWORD', $AgtSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /AGTSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('AGTSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /AGTSVCACCOUNT=`"" + $AgtSvcAccount.UserName + "`""
+                #$arguments += " /AGTSVCPASSWORD=`"" + $AgtSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('AGTSVCACCOUNT', $AgtSvcAccount.UserName)
+                $arguments.Add('AGTSVCPASSWORD', $AgtSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 
             $arguments += (Get-ServiceAccountParameters -ServiceAccount $AgtSvcAccount -AccountType 'AGT')
         }
 
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
         $setupArgs.Add('SQLSysAdminAccounts', $($SetupCredential.UserName))
         if ($PSBoundParameters -icontains 'SQLSysAdminAccounts')
         {
@@ -966,6 +998,10 @@ function Set-TargetResource
         }
 
         $setupArgs.Add('AGTSVCSTARTUPTYPE','Automatic')
+=======
+        #$arguments += ' /AGTSVCSTARTUPTYPE=Automatic'
+        $arguments.Add('AGTSVCSTARTUPTYPE','Automatic')
+>>>>>>> Converted argument array to hashtable
     }
 
     if ($Features.Contains('FULLTEXT'))
@@ -977,12 +1013,24 @@ function Set-TargetResource
 
             if ($FTSvcAccount.UserName -eq 'SYSTEM')
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('FTSVCACCOUNT','NT AUTHORITY\LOCAL SERVICE')
             }
             else
             {
                 $setupArgs.Add('FTSVCACCOUNT', $FTSvcAccount.UserName)
                 $setupArgs.Add('FTSVCPASSWORD', $FTSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /FTSVCACCOUNT=`"NT AUTHORITY\LOCAL SERVICE`""
+                $arguments.Add('FTSVCACCOUNT','NT AUTHORITY\LOCAL SERVICE')
+            }
+            else
+            {
+                #$arguments += " /FTSVCACCOUNT=`"" + $FTSvcAccount.UserName + "`""
+                #$arguments += " /FTSVCPASSWORD=`"" + $FTSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('FTSVCACCOUNT', $FTSvcAccount.UserName)
+                $arguments.Add('FTSVCPASSWORD', $FTSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 
@@ -999,12 +1047,24 @@ function Set-TargetResource
 
             if ($RSSvcAccount.UserName -eq "SYSTEM")
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('RSSVCACCOUNT','NT AUTHORITY\SYSTEM')
             }
             else
             {
                 $setupArgs.Add('RSSVCACCOUNT', $RSSvcAccount.UserName)
                 $setupArgs.Add('RSSVCPASSWORD', $RSSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /RSSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('RSSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /RSSVCACCOUNT=`"" + $RSSvcAccount.UserName + "`""
+                #$arguments += " /RSSVCPASSWORD=`"" + $RSSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('RSSVCACCOUNT', $RSSvcAccount.UserName)
+                $arguments.Add('RSSVCPASSWORD', $RSSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 
@@ -1030,12 +1090,24 @@ function Set-TargetResource
 
             if($ASSvcAccount.UserName -eq 'SYSTEM')
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('ASSVCACCOUNT','NT AUTHORITY\SYSTEM')
             }
             else
             {
                 $setupArgs.Add('ASSVCACCOUNT', $ASSvcAccount.UserName)
                 $setupArgs.Add('ASSVCPASSWORD', $ASSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /ASSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('ASSVCACCOUNT','NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /ASSVCACCOUNT=`"" + $ASSvcAccount.UserName + "`""
+                #$arguments += " /ASSVCPASSWORD=`"" + $ASSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('ASSVCACCOUNT', $ASSvcAccount.UserName)
+                $arguments.Add('ASSVCPASSWORD', $ASSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 
@@ -1059,12 +1131,24 @@ function Set-TargetResource
 
             if ($ISSvcAccount.UserName -eq 'SYSTEM')
             {
+<<<<<<< ad77977c9cee7ac25d5808542513b205849f8675
                 $setupArgs.Add('ISSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
             }
             else
             {
                 $setupArgs.Add('ISSVCACCOUNT', $ISSvcAccount.UserName)
                 $setupArgs.Add('ISSVCPASSWORD', $ISSvcAccount.GetNetworkCredential().Password)
+=======
+                #$arguments += " /ISSVCACCOUNT=`"NT AUTHORITY\SYSTEM`""
+                $arguments.Add('ISSVCACCOUNT', 'NT AUTHORITY\SYSTEM')
+            }
+            else
+            {
+                #$arguments += " /ISSVCACCOUNT=`"" + $ISSvcAccount.UserName + "`""
+                #$arguments += " /ISSVCPASSWORD=`"" + $ISSvcAccount.GetNetworkCredential().Password + "`""
+                $arguments.Add('ISSVCACCOUNT', $ISSvcAccount.UserName)
+                $arguments.Add('ISSVCPASSWORD', $ISSvcAccount.GetNetworkCredential().Password)
+>>>>>>> Converted argument array to hashtable
             }
             #>
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerSetup")]
 class MSFT_xSQLServerSetup : OMI_BaseResource
 {
-    [Write, Description("The action to be performed. Default value is 'Install'."), ValueMap{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}]  String Action;
+    [Write, Description("The action to be performed. Default value is 'Install'."), ValueMap{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}] String Action;
     [Write, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.")] String SourcePath;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to perform the installation.")] String SetupCredential;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to access the path set in the parameter 'SourcePath'.")] String SourceCredential;
@@ -48,7 +48,7 @@ class MSFT_xSQLServerSetup : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Service account for Integration Services service.")] String ISSvcAccount;
     [Read, Description("Output username for the Integration Services service.")] String ISSvcAccountUsername;
     [Write, Description("Specifies the startup mode for SQL Server Browser service."), ValueMap{"Automatic", "Disabled", "Manual"}, Values{"Automatic", "Disabled", "Manual"}] String BrowserSvcStartupType;
-    [Write, Description("The name of the resource group to create for the clustered SQL Server instance")] String FailoverClusterGroup;
-    [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance")] String FailoverClusterIPAddress[];
+    [Write, Description("The name of the resource group to create for the clustered SQL Server instance.")] String FailoverClusterGroup;
+    [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance.")] String FailoverClusterIPAddress[];
     [Write, Description("Host name to be assigend to the clustered SQL Server instance.")] String FailoverClusterNetworkName;
 };

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -1,9 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerSetup")]
 class MSFT_xSQLServerSetup : OMI_BaseResource
 {
-    [Write, Description("The action to be performed. Default value is 'Install'."), ValueMap{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}] String Action;
+    [Write, Description("The action to be performed. Default value is 'Install'."), ValueMap{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}]  String Action;
     [Write, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.")] String SourcePath;
-    [Write, Description("Folder within the source path containing the source files for installation. Default value is 'Source'.")] String SourceFolder;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to perform the installation.")] String SetupCredential;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to access the path set in the parameter 'SourcePath'.")] String SourceCredential;
     [Write, Description("Suppresses reboot.")] Boolean SuppressReboot;
@@ -50,6 +49,6 @@ class MSFT_xSQLServerSetup : OMI_BaseResource
     [Read, Description("Output username for the Integration Services service.")] String ISSvcAccountUsername;
     [Write, Description("Specifies the startup mode for SQL Server Browser service."), ValueMap{"Automatic", "Disabled", "Manual"}, Values{"Automatic", "Disabled", "Manual"}] String BrowserSvcStartupType;
     [Write, Description("The name of the resource group to create for the clustered SQL Server instance")] String FailoverClusterGroup;
-    [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance)] IPAddress[] FailoverClusterIPAddress;
+    [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance")] String FailoverClusterIPAddress[];
     [Write, Description("Host name to be assigend to the clustered SQL Server instance.")] String FailoverClusterNetworkName;
 };

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -48,7 +48,7 @@ class MSFT_xSQLServerSetup : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Service account for Integration Services service.")] String ISSvcAccount;
     [Read, Description("Output username for the Integration Services service.")] String ISSvcAccountUsername;
     [Write, Description("Specifies the startup mode for SQL Server Browser service."), ValueMap{"Automatic", "Disabled", "Manual"}, Values{"Automatic", "Disabled", "Manual"}] String BrowserSvcStartupType;
-    [Write, Description("The name of the resource group to create for the clustered SQL Server instance.")] String FailoverClusterGroup;
+    [Write, Description("The name of the resource group to create for the clustered SQL Server instance.")] String FailoverClusterGroupName;
     [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance.")] String FailoverClusterIPAddress[];
     [Write, Description("Host name to be assigend to the clustered SQL Server instance.")] String FailoverClusterNetworkName;
 };

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -49,4 +49,7 @@ class MSFT_xSQLServerSetup : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Service account for Integration Services service.")] String ISSvcAccount;
     [Read, Description("Output username for the Integration Services service.")] String ISSvcAccountUsername;
     [Write, Description("Specifies the startup mode for SQL Server Browser service."), ValueMap{"Automatic", "Disabled", "Manual"}, Values{"Automatic", "Disabled", "Manual"}] String BrowserSvcStartupType;
+    [Write, Description("The name of the resource group to create for the clustered SQL Server instance")] String FailoverClusterGroup;
+    [Write, Description("Array of IP Addresses to be assigned to the clustered SQL Server instance)] IPAddress[] FailoverClusterIPAddress;
+    [Write, Description("Host name to be assigend to the clustered SQL Server instance.")] String FailoverClusterNetworkName;
 };

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.schema.mof
@@ -1,7 +1,9 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerSetup")]
 class MSFT_xSQLServerSetup : OMI_BaseResource
 {
+    [Write, Description("The action to be performed. Default value is 'Install'."), ValueMap{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}] String Action;
     [Write, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.")] String SourcePath;
+    [Write, Description("Folder within the source path containing the source files for installation. Default value is 'Source'.")] String SourceFolder;
     [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to be used to perform the installation.")] String SetupCredential;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to access the path set in the parameter 'SourcePath'.")] String SourceCredential;
     [Write, Description("Suppresses reboot.")] Boolean SuppressReboot;

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ Installs SQL Server on the target node.
 * **[PSCredential] ISSvcAccount** _(Write)_: Service account for Integration Services service.
 * **[String] BrowserSvcStartupType** _(Write)_: Specifies the startup mode for SQL Server Browser service. { Automatic | Disabled | 'Manual' }
 * **[String] FailoverClusterGroupName** _(Write)_: The name of the resource group to create for the clustered SQL Server instance. Defaults to 'SQL Server (_InstanceName_)'.
-* **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance. If no IP address is specified, uses 'DEFAULT' for this setup parameter.
+* **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance. IP addresses must be in [dotted-decimal notation](https://en.wikipedia.org/wiki/Dot-decimal_notation), for example ````10.0.0.100````. If no IP address is specified, uses 'DEFAULT' for this setup parameter.
 * **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -418,8 +418,7 @@ None.
 
 ### xSQLServerFailoverClusterSetup
 
-**This resource is deprecated.** 
-The functionality of this resource has been merged with [xSQLServerSetup](#xsqlserversetup). Please do not use this resource for new development efforts.
+**This resource is deprecated.** The functionality of this resource has been merged with [xSQLServerSetup](#xsqlserversetup). Please do not use this resource for new development efforts.
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -757,7 +757,8 @@ Installs SQL Server on the target node.
 * Target machine must be running Windows Server 2008 R2.
 
 #### Parameters
-* **[String] Action** _(Write)_: The action to be performed. Default value is 'Install'. {'Install' | 'InstallFailoverCluster' | 'AddNode' | 'PrepareFailoverCluster' | 'CompleteFailoverCluster'}
+
+* **[String] Action** _(Write)_: The action to be performed. Defaults to 'Install'. { _Install_ | InstallFailoverCluster | AddNode | PrepareFailoverCluster | CompleteFailoverCluster }
 * **[String] InstanceName** _(Key)_: SQL instance to be installed.
 * **[PSCredential] SetupCredential** _(Required)_: Credential to be used to perform the installation.
 * **[String] SourcePath** _(Write)_: The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.
@@ -796,10 +797,10 @@ Installs SQL Server on the target node.
 * **[String] ASBackupDir** _(Write)_: Path for Analysis Services backup files.
 * **[String] ASTempDir** _(Write)_: Path for Analysis Services temp files.
 * **[String] ASConfigDir** _(Write)_: Path for Analysis Services config.
-* **ISSvcAccount** _(Write)_: Service account for Integration Services service.
+* **[PSCredential] ISSvcAccount** _(Write)_: Service account for Integration Services service.
 * **[String] BrowserSvcStartupType** _(Write)_: Specifies the startup mode for SQL Server Browser service. { Automatic | Disabled | 'Manual' }
-* **[String] FailoverClusterGroup** _(Write)_: The name of the resource group to create for the clustered SQL Server instance.
-* **[IPAddress[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance.
+* **[String] FailoverClusterGroup** _(Write)_: The name of the resource group to create for the clustered SQL Server instance. Defaults to 'SQL Server (_InstanceName_)'.
+* **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance.
 * **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -798,6 +798,9 @@ Installs SQL Server on the target node.
 * **[String] ASConfigDir** _(Write)_: Path for Analysis Services config.
 * **ISSvcAccount** _(Write)_: Service account for Integration Services service.
 * **[String] BrowserSvcStartupType** _(Write)_: Specifies the startup mode for SQL Server Browser service. { Automatic | Disabled | 'Manual' }
+* **[String] FailoverClusterGroup**: The name of the resource group to create for the clustered SQL Server instance
+* **[IPAddress[]]FailoverClusterIPAddress**: Array of IP Addresses to be assigned to the clustered SQL Server instance
+* **[String] FailoverClusterNetworkName**: Host name to be assigned to the clustered SQL Server instance
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,8 @@ None.
 
 ### xSQLServerFailoverClusterSetup
 
-No description.
+**This resource is deprecated.** 
+The functionality of this resource has been merged with [xSQLServerSetup](#xsqlserversetup). Please do not use this resource for new development efforts.
 
 #### Requirements
 
@@ -799,8 +800,8 @@ Installs SQL Server on the target node.
 * **[String] ASConfigDir** _(Write)_: Path for Analysis Services config.
 * **[PSCredential] ISSvcAccount** _(Write)_: Service account for Integration Services service.
 * **[String] BrowserSvcStartupType** _(Write)_: Specifies the startup mode for SQL Server Browser service. { Automatic | Disabled | 'Manual' }
-* **[String] FailoverClusterGroup** _(Write)_: The name of the resource group to create for the clustered SQL Server instance. Defaults to 'SQL Server (_InstanceName_)'.
-* **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance.
+* **[String] FailoverClusterGroupName** _(Write)_: The name of the resource group to create for the clustered SQL Server instance. Defaults to 'SQL Server (_InstanceName_)'.
+* **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance. If no IP address is specified, uses 'DEFAULT' for this setup parameter.
 * **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Installs SQL Server on the target node.
 * Target machine must be running Windows Server 2008 R2.
 
 #### Parameters
-
+* **[String] Action** _(Write)_: The action to be performed. Default value is 'Install'. {'Install' | 'InstallFailoverCluster' | 'AddNode' | 'PrepareFailoverCluster' | 'CompleteFailoverCluster'}
 * **[String] InstanceName** _(Key)_: SQL instance to be installed.
 * **[PSCredential] SetupCredential** _(Required)_: Credential to be used to perform the installation.
 * **[String] SourcePath** _(Write)_: The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.
@@ -798,9 +798,9 @@ Installs SQL Server on the target node.
 * **[String] ASConfigDir** _(Write)_: Path for Analysis Services config.
 * **ISSvcAccount** _(Write)_: Service account for Integration Services service.
 * **[String] BrowserSvcStartupType** _(Write)_: Specifies the startup mode for SQL Server Browser service. { Automatic | Disabled | 'Manual' }
-* **[String] FailoverClusterGroup**: The name of the resource group to create for the clustered SQL Server instance
-* **[IPAddress[]]FailoverClusterIPAddress**: Array of IP Addresses to be assigned to the clustered SQL Server instance
-* **[String] FailoverClusterNetworkName**: Host name to be assigned to the clustered SQL Server instance
+* **[String] FailoverClusterGroup** _(Write)_: The name of the resource group to create for the clustered SQL Server instance.
+* **[IPAddress[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance.
+* **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3260,54 +3260,6 @@ try
             Assert-VerifiableMocks
         }
 
-        Describe 'Join-ServiceAccountInfo' -Tag 'Helper' {
-            Context 'When called it should return a string with service account information appended to the original argument string' {
-
-                $Params = @{ UsernameArgumentname = 'SQLSVCACCOUNT'; PasswordArgumentName = 'SQLSVCPASSWORD'; ArgumentString = "C:\Install\SQLSource\setup.exe" }
-
-                $mockSetupDomainCredential = New-Object System.Management.Automation.PSCredential( 'Company\SQLServer', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupMSACredential = New-Object System.Management.Automation.PSCredential( 'Company\SQLServer$', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupSystemCredential = New-Object System.Management.Automation.PSCredential( 'SYSTEM', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupLocalServiceCredential = New-Object System.Management.Automation.PSCredential( 'LOCALSERVICE', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupNetworkServiceCredential = New-Object System.Management.Automation.PSCredential( 'NETWORKSERVICE', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupNTSystemCredential = New-Object System.Management.Automation.PSCredential( 'NT AUTHORITY\SYSTEM', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupNTLocalServiceCredential = New-Object System.Management.Automation.PSCredential( 'NT AUTHORITY\LOCALSERVICE', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-                $mockSetupNTNetworkServiceCredential = New-Object System.Management.Automation.PSCredential( 'NT AUTHORITY\NETWORKSERVICE', (ConvertTo-SecureString 'password' -AsPlainText -Force) )
-
-                It 'Should return string with service account information and password appended Domain/Local Account' {
-                   Join-ServiceAccountInfo @Params -User $mockSetupDomainCredential | Should BeExactly ('{0} /{1}="{2}" /{3}="{4}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupDomainCredential.UserName, $Params['PasswordArgumentname'], $mockSetupDomainCredential.GetNetworkCredential().Password)
-                }
-
-                It 'Should return string service account information and no password appended for Managed Service Account' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupMSACredential | Should BeExactly ('{0} /{1}="{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupMSACredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\SYSTEM. Test without NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupSystemCredential | Should BeExactly ('{0} /{1}="NT AUTHORITY\{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupSystemCredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\LOCALSERVICE. Test without NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupLocalServiceCredential | Should BeExactly ('{0} /{1}="NT AUTHORITY\{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupLocalServiceCredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\NETWORKSERVICE. Test without NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupNetworkServiceCredential | Should BeExactly ('{0} /{1}="NT AUTHORITY\{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupNetworkServiceCredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\SYSTEM. Test with NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupNTSystemCredential | Should BeExactly ('{0} /{1}="{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupNTSystemCredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\LOCALSERVICE. Test with NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupNTLocalServiceCredential | Should BeExactly ('{0} /{1}="{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupNTLocalServiceCredential.UserName)
-                }
-
-                It 'Should return string service account information and no password appended for NT AUTHORITY\NETWORKSERVICE. Test with NT AUTHORITY prepended' {
-                    Join-ServiceAccountInfo @Params -User $mockSetupNTNetworkServiceCredential | Should BeExactly ('{0} /{1}="{2}"' -f $Params['ArgumentString'], $Params['UsernameArgumentname'], $mockSetupNTNetworkServiceCredential.UserName)
-                }
-            }
-        }
-
         # Tests only the parts of the code that does not already get tested thru the other tests.
         Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
             Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3492,32 +3492,35 @@ try
 
                 $serviceType = $_
 
-                It "Should return the correct parameters when the service type is $serviceType and the account is a system account." {
-                    $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
+                Context "When service type is $serviceType" {
 
-                    $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
-                    $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                }
+                    It "Should return the correct parameters when the account is a system account." {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
 
-                It "Should return the correct parameters when the service type is $serviceType and the account is a virtual service account" {
-                    $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
 
-                    $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
-                    $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                }
+                    It "Should return the correct parameters when the account is a virtual service account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
 
-                It "Should return the correct parameters when the servie type is $serviceType and the account is a managed service account" {
-                    $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
 
-                    $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
-                    $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                }
+                    It "Should return the correct parameters when the account is a managed service account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
 
-                It "Should return the correct parameters when the servie type is $serviceType and the account is a domain account" {
-                    $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
 
-                    $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
-                    $result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
+                    It "Should return the correct parameters when the account is a domain account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
+
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
+                        $result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
+                    }
                 }
             }
         }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1496,6 +1496,33 @@ try
                         $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
                     }
                 }
+
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered instance" {
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        @('MSSQLSERVER', $mockNamedInstance_InstanceName) | ForEach-Object {
+                            $mock = New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster'
+                            
+                            $mock | Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($($_))" -TypeName 'String'
+                            $mock | Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String'
+                            $mock | Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $_ }
+
+                            return $mock
+                        }
+                    } -Verifiable -ParameterFilter { ($ClassName -eq 'MSCluster_Resource') -and ($Filter -eq "Type = 'SQL Server'") }
+
+                    Mock -CommandName Get-CimAssociatedInstance -MockWith {
+                        @('MSSQLSERVER', $mockNamedInstance_InstanceName) | ForEach-Object {
+                        $mock = New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster'
+                        
+                        $mock | Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($($_))"
+                    } -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+
+                }
+
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered instance" {
+                    throw "Not Implemented"
+                }
             }
 
             Assert-VerifiableMocks

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -99,7 +99,6 @@ try
 
         $mockSqlServiceAccount = 'COMPANY\SqlAccount'
         $mockAgentServiceAccount = 'COMPANY\AgentAccount'
-        $mockSourceFolder = 'Source' #  The parameter SourceFolder has a default value of 'Source', so lets mock that as well.
 
         $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
 
@@ -650,7 +649,7 @@ try
             )
         }
 
-        ## mock to return physical disks that are part of the "Available Storage" cluster role
+        # Mock to return physical disks that are part of the "Available Storage" cluster role
         $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
             return @(
                 (
@@ -699,7 +698,7 @@ try
         $mockStartWin32Process = {
             $argumentHashTable = @{}
 
-            ## break the argument string into a hash table
+            # Break the argument string into a hash table
             ($Arguments -split ' ?/') | ForEach-Object {
                 if ($_ -imatch '(\w+)="?([^/]+)"?') 
                 {
@@ -733,15 +732,14 @@ try
         $mockDefaultClusterParameters = @{
             SetupCredential = $mockSetupCredential
 
-            ## Feature support is tested elsewhere, so just include the minimum
+            # Feature support is tested elsewhere, so just include the minimum
             Features = 'SQLEngine'
 
-            ## ensure we use "clustered" disks for our paths
+            # Ensure we use "clustered" disks for our paths
             SQLUserDBDir = 'K:\MSSQL\Data\'
             SQLUserDBLogDir = 'L:\MSSQL\Logs'
             SQLTempDbDir = 'M:\MSSQL\TempDb\Data\'
             SQLTempDbLogDir = 'N:\MSSQL\TempDb\Logs'
-            #SQLBackupDir = 'O:\MSSQL\Backup\'
         }
 
         Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
@@ -3163,7 +3161,8 @@ try
 
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {
                         $badPathParameters = $testParameters.Clone()
-                        ## pass in a bad path
+                        
+                        # Pass in a bad path
                         $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
 
                         { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: TempDbLogs; UserLogs; TempDbData'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1746,9 +1746,9 @@ try
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
 
-                        $currentState.FailoverClusterGroupName | Should Be ''
-                        $currentState.FailoverClusterNetworkName | Should Be ''
-                        $currentState.FailoverClusterIPAddress | Should Be ''
+                        $currentState.FailoverClusterGroupName | Should BeNullOrEmpty
+                        $currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
+                        $currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
                     }
                 }
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2532,15 +2532,6 @@ try
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters.Features = 'ADV_SSMS'
 
-                            <#
-                            ### REMOVE ME ###
-                            $mockStartWin32ProcessExpectedArgument =
-                                '/Quiet="True"',
-                                '/IAcceptSQLServerLicenseTerms="True"',
-                                '/Action="Install"',
-                                '/InstanceName="MSSQLSERVER"',
-                                '/Features="ADV_SSMS"' -join ' '
-                            #>
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -2605,18 +2596,7 @@ try
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
-                        <#
-                        ### REMOVE ME ###
-                        $mockStartWin32ProcessExpectedArgument =
-                            '/Quiet="True"',
-                            '/IAcceptSQLServerLicenseTerms="True"',
-                            '/Action="Install"',
-                            '/AGTSVCSTARTUPTYPE=Automatic',
-                            '/InstanceName="MSSQLSERVER"',
-                            '/Features="SQLENGINE,REPLICATION,FULLTEXT,RS,IS,AS"',
-                            '/SQLSysAdminAccounts="COMPANY\sqladmin"',
-                            '/ASSysAdminAccounts="COMPANY\sqladmin"' -join ' '
-                        #>
+                        
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -2677,15 +2657,6 @@ try
                         It 'Should set the system in the desired state when feature is SSMS' {
                             $testParameters.Features = 'SSMS'
 
-                            <#
-                            ### REMOVE ME ###
-                            $mockStartWin32ProcessExpectedArgument =
-                                '/Quiet="True"',
-                                '/IAcceptSQLServerLicenseTerms="True"',
-                                '/Action="Install"',
-                                '/InstanceName="MSSQLSERVER"',
-                                '/Features="SSMS"' -join ' '
-                            #>
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -2723,15 +2694,6 @@ try
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters.Features = 'ADV_SSMS'
 
-                            <#
-                            ### REMOVE ME ###
-                            $mockStartWin32ProcessExpectedArgument =
-                                '/Quiet="True"',
-                                '/IAcceptSQLServerLicenseTerms="True"',
-                                '/Action="Install"',
-                                '/InstanceName="MSSQLSERVER"',
-                                '/Features="ADV_SSMS"' -join ' '
-                            #>
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -52,4 +52,8 @@ PasswordChangeFailed = Setting the password failed for the SQL Login '{0}'.
 AlterLoginFailed = Altering the login '{0}' failed.
 CreateLoginFailed = Creating the login '{0}' failed.
 DropLoginFailed = Dropping the login '{0}' failed.
+
+# Clustered Setup
+FailoverClusterDiskMappingError = Unable to map the specified paths to valid cluster storage. Drives mapped: {0}
+FailoverClusterIPAddressNotValid = Unable to map the specified IP Address(es) to valid cluster networks.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -56,4 +56,5 @@ DropLoginFailed = Dropping the login '{0}' failed.
 # Clustered Setup
 FailoverClusterDiskMappingError = Unable to map the specified paths to valid cluster storage. Drives mapped: {0}
 FailoverClusterIPAddressNotValid = Unable to map the specified IP Address(es) to valid cluster networks.
+FailoverClusterResourceNotFound = Could not locate a SQL Server cluster resource for instance {0}.
 '@


### PR DESCRIPTION
Added support to xSQLServerSetup for clustered installations. Ported code from existing xSQLServerFailoverCluster resource and updated to correct issues and add additional functionality.
 - Added support for multi-subnet clusters
 - Corrected clustered disk detection issue with asymmetric storage
 - Removed Get-WmiObject calls
 - Added localized error messages

This Pull Request (PR) fixes the following issues:
Fixes #227 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/326)
<!-- Reviewable:end -->
