### PR TITLE
xSQLServerSetup: Allow Multiple DB Instances on One Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changes to xSQLServerConfiguration
+  - Updated xSQLServerConfiguration.schema.mof so SQLInstance parameter is now a Key. This allows for the use case scenario where there     are multiple DB Instances on one box.
 - Improvements how tests are initiated in AppVeyor
   - Removed previous workaround (issue #201) from unit tests.
   - Changes in appveyor.yml so that SQL modules are removed before common test is run.

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_xSQLServerConfiguration : OMI_BaseResource
 {
     [Key, Description("The hostname of the SQL Server to be configured")] String SQLServer;
-    [Write, Description("Name of the SQL instance to be configured. Default is 'MSSQLSERVER'")] String SQLInstanceName;
+    [Key, Description("Name of the SQL instance to be configured. Default is 'MSSQLSERVER'")] String SQLInstanceName;
     [Key, Description("The name of the SQL configuration option to be checked")] String OptionName;
     [Required, Description("The desired value of the SQL configuration option")] Sint32 OptionValue;
     [Write, Description("Determines whether the instance should be restarted after updating the configuration option")] Boolean RestartService;


### PR DESCRIPTION
We have updated the xSQLServerConfiguration.schema.mof file so SQLInstance is now a Key. This allows the SQLServerConfiguration resource to configure multiple instances on the same box as every schema.mof file entry will be uniquely named.

This Pull Request (PR) fixes the following issues:
n/a

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/348)
<!-- Reviewable:end -->
