### PR TITLE
xSQLServerHelper: Confirm-SqlServerRoleMember has parameter name LoginName but uses variable Name where it should be using LoginName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log for xSQLServer
 
 ## Unreleased
-
+-Changes to xSQLServerRole  
+  -xSQLServerRole now correctly reports that the desired state is present when the login is already a member of the server roles
 ## 5.0.0.0
 
 - Improvements how tests are initiated in AppVeyor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change log for xSQLServer
 
 ## Unreleased
--Changes to xSQLServerRole  
-  -xSQLServerRole now correctly reports that the desired state is present when the login is already a member of the server roles
+
+- Changes to xSQLServerRole
+  - xSQLServerRole now correctly reports that the desired state is present when the login is already a member of the server roles
+
 ## 5.0.0.0
 
 - Improvements how tests are initiated in AppVeyor

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -1050,14 +1050,14 @@ function Confirm-SqlServerRoleMember
             if ($sqlRole[$currentServerRole])
             {
                 $membersInRole = $sqlRole[$currentServerRole].EnumMemberNames()
-                if ($membersInRole.Contains($Name))
+                if ($membersInRole.Contains($LoginName))
                 {
                     $confirmServerRole = $true
-                    New-VerboseMessage -Message "$Name is present in SQL role name $currentServerRole"
+                    New-VerboseMessage -Message "$LoginName is present in SQL role name $currentServerRole"
                 }
                 else
                 {
-                    New-VerboseMessage -Message "$Name is absent in SQL role name $currentServerRole"
+                    New-VerboseMessage -Message "$LoginName is absent in SQL role name $currentServerRole"
                     $confirmServerRole = $false
                 }
             }


### PR DESCRIPTION
The parameter name in Confirm-SqlServerRoleMember is LoginName but when used in the function it is referenced as $Name.  Not sure how this is working for anyone as written.

This Pull Request (PR) fixes the following issues:
Fixes #355

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/349)
<!-- Reviewable:end -->
