### PR TITLE
xSQLServerSetup: fixes and enhancements for supporting clustered installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - xSQLServerAlwaysOnAvailabilityGroup
 - Changes to xSQLServerSetup
   - Properly checks for use of SQLSysAdminAccounts parameter in $PSBoundParameters. The test now also properly evaluates the setup argument for SQLSysAdminAccounts.
+- Changes to xSQLServerSetup
+  - xSQLServerSetup should now function correctly for the InstallFailoverCluster action, and also supports cluster shared volumes. Note that the AddNode action is not currently working.
 - Enables CodeCov.io code coverage reporting
 
 ## 5.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
   - xSQLServerAlwaysOnAvailabilityGroup
 - Changes to xSQLServerSetup
   - Properly checks for use of SQLSysAdminAccounts parameter in $PSBoundParameters. The test now also properly evaluates the setup argument for SQLSysAdminAccounts.
-- Changes to xSQLServerSetup
   - xSQLServerSetup should now function correctly for the InstallFailoverCluster action, and also supports cluster shared volumes. Note that the AddNode action is not currently working.
 - Enables CodeCov.io code coverage reporting
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1061,7 +1061,15 @@ function Set-TargetResource
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
     $arguments = $arguments.Trim()
-    $process = StartWin32Process -Path $pathToSetupExecutable -Arguments $arguments
+    $processArgs = @{
+        Path = $pathToSetupExecutable
+        Arguments = $arguments
+    };
+    if ($Action -in @('InstallFailoverCluster'))
+    {
+        $processArgs.Add('Credential',$SetupCredential);
+    }
+    $process = StartWin32Process @processArgs;
 
     New-VerboseMessage -Message $process
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -788,6 +788,14 @@ function Set-TargetResource
         }
     }
 
+    # Add the failover cluster network name if the action is either installing or completing a cluster
+    if ($Action -in @('CompleteFailoverCluster','InstallFailoverCluster'))
+    {
+        $setupArguments += @{
+            FailoverClusterNetworkName = $FailoverClusterNetworkName
+        };
+    }
+
     # Perform disk mapping for specific cluster installation types
     if ($Action -in @('CompleteFailoverCluster','InstallFailoverCluster'))
     {

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1124,15 +1124,16 @@ function Set-TargetResource
     New-VerboseMessage -Message "Starting setup using arguments: $log"
 
     $arguments = $arguments.Trim()
-    $processArgs = @{
+    $processArguments = @{
         Path = $pathToSetupExecutable
         Arguments = $arguments
-    };
+    }
+    
     if ($Action -in @('InstallFailoverCluster','AddNode'))
     {
-        $processArgs.Add('Credential',$SetupCredential);
+        $processArguments.Add('Credential',$SetupCredential)
     }
-    $process = StartWin32Process @processArgs;
+    $process = StartWin32Process @processArguments
 
     New-VerboseMessage -Message $process
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments
@@ -1451,7 +1452,7 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $boundParams = $PSBoundParameters;
+    $boundParameters = $PSBoundParameters
 
     $getTargetResourceResult = Get-TargetResource @parameters
     New-VerboseMessage -Message "Features found: '$($getTargetResourceResult.Features)'"
@@ -1480,11 +1481,11 @@ function Test-TargetResource
 
         $result = $true
 
-        $boundParams.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
+        $boundParameters.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
             $variableName = $_
 
-            if ($getTargetResourceResult.$variableName -ne $boundParams[$variableName]) {
-                New-VerboseMessage -Message "$variableName '$($boundParams[$variableName])' is not in the desired state for this cluster."
+            if ($getTargetResourceResult.$variableName -ne $boundParameters[$variableName]) {
+                New-VerboseMessage -Message "$variableName '$($boundParameters[$variableName])' is not in the desired state for this cluster."
                 $result = $false
             }
         }

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -793,7 +793,7 @@ function Set-TargetResource
     {
         $setupArguments += @{
             FailoverClusterNetworkName = $FailoverClusterNetworkName
-        };
+        }
     }
 
     # Perform disk mapping for specific cluster installation types
@@ -802,12 +802,12 @@ function Set-TargetResource
         $failoverClusterDisks = @()
 
         # Get a required lising of drives based on user parameters
-        $requiredDrives = Get-Variable -Name 'SQL*Dir' -ValueOnly | Where-Object { -not [String]::IsNullOrEmpty($_) } | Sort-Object -Unique | Add-Member -MemberType NoteProperty -Name IsMapped -Value $false -PassThru;
+        $requiredDrives = Get-Variable -Name 'SQL*Dir' -ValueOnly | Where-Object { -not [String]::IsNullOrEmpty($_) } | Sort-Object -Unique | Add-Member -MemberType NoteProperty -Name IsMapped -Value $false -PassThru
 
         # Get the disk resources that are available (not assigned to a cluster role)
         $availableStorage = Get-CimInstance -Namespace 'root/MSCluster' -ClassName 'MSCluster_ResourceGroup' -Filter "Name = 'Available Storage'" |
                                 Get-CimAssociatedInstance -Association MSCluster_ResourceGroupToResource -ResultClassName MSCluster_Resource | `
-                                Add-Member -MemberType NoteProperty -Name "IsPossibleOwner" -Value $false -PassThru;
+                                Add-Member -MemberType NoteProperty -Name 'IsPossibleOwner' -Value $false -PassThru
 
         # First map regular cluster volumes
         foreach ($diskResource in $availableStorage)
@@ -817,8 +817,7 @@ function Set-TargetResource
 
             if ($possibleOwners -icontains $env:COMPUTERNAME)
             {
-                
-                $diskResource.IsPossibleOwner = $true;
+                $diskResource.IsPossibleOwner = $true
             }
         }
 
@@ -826,29 +825,31 @@ function Set-TargetResource
         {
             foreach ($diskResource in ($availableStorage | Where-Object {$_.IsPossibleOwner -eq $true}))
             {
-                $partitions = $diskResource | Get-CimAssociatedInstance -ResultClassName 'MSCluster_DiskPartition' | Select-Object -ExpandProperty Path;
+                $partitions = $diskResource | Get-CimAssociatedInstance -ResultClassName 'MSCluster_DiskPartition' | Select-Object -ExpandProperty Path
                 foreach ($partition in $partitions)
                 {
                     if ($requiredDrive -imatch $partition.Replace('\','\\'))
                     {
-                        $requiredDrive.IsMapped = $true;
-                        $failoverClusterDisks += $diskResource.Name;
-                        break;
+                        $requiredDrive.IsMapped = $true
+                        $failoverClusterDisks += $diskResource.Name
+                        break
                     }
+
                     if ($requiredDrive.IsMapped)
                     {
-                        break;
+                        break
                     }
                 }
+
                 if ($requiredDrive.IsMapped)
                 {
-                    break;
+                    break
                 }
             }
         }
 
         # Now we handle cluster shared volumes
-        $clusterSharedVolumes = Get-CimInstance -ClassName "MSCluster_ClusterSharedVolume" -Namespace "root/MSCluster";
+        $clusterSharedVolumes = Get-CimInstance -ClassName 'MSCluster_ClusterSharedVolume' -Namespace 'root/MSCluster'
 
         foreach ($clusterSharedVolume in $clusterSharedVolumes)
         {
@@ -856,12 +857,12 @@ function Set-TargetResource
             {
                 if ($requiredDrive -imatch $clusterSharedVolume.Name.Replace('\','\\'))
                 {
-                    $diskName = Get-CimInstance -ClassName "MSCluster_ClusterSharedVolumeToResource" -Namespace "root/MSCluster" | `
+                    $diskName = Get-CimInstance -ClassName 'MSCluster_ClusterSharedVolumeToResource' -Namespace 'root/MSCluster' | `
                         Where-Object {$_.GroupComponent.Name -eq $clusterSharedVolume.Name} | `
                         Select-Object -ExpandProperty PartComponent | `
-                        Select-Object -ExpandProperty Name;
-                    $failoverClusterDisks += $diskName;
-                    $requiredDrive.IsMapped = $true;
+                        Select-Object -ExpandProperty Name
+                    $failoverClusterDisks += $diskName
+                    $requiredDrive.IsMapped = $true
                 }
             }
         }
@@ -870,7 +871,7 @@ function Set-TargetResource
         $failoverClusterDisks = $failoverClusterDisks | Sort-Object -Unique
 
         # Ensure we mapped all required drives
-        $unMappedRequiredDrives = $requiredDrives | Where-Object {$_.IsMapped -eq $false} | Measure-Object;
+        $unMappedRequiredDrives = $requiredDrives | Where-Object {$_.IsMapped -eq $false} | Measure-Object
         if ($unMappedRequiredDrives.Count -gt 0)
         {
             throw New-TerminatingError -ErrorType FailoverClusterDiskMappingError -FormatArgs ($failoverClusterDisks -join '; ') -ErrorCategory InvalidResult
@@ -950,7 +951,7 @@ function Set-TargetResource
         $argumentVars += 'BrowserSvcStartupType'
     }
 
-    if ($Action -eq "AddNode")
+    if ($Action -eq 'AddNode')
     {
         if ($PSBoundParameters.ContainsKey('SQLSvcAccount'))
         {

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -1450,6 +1450,8 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
+    $boundParams = $PSBoundParameters;
+
     $getTargetResourceResult = Get-TargetResource @parameters
     New-VerboseMessage -Message "Features found: '$($getTargetResourceResult.Features)'"
 
@@ -1477,11 +1479,11 @@ function Test-TargetResource
 
         $result = $true
 
-        Get-Variable -Name FailoverCluster* | ForEach-Object {
-            $variableName = $_.Name
+        $boundParams.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
+            $variableName = $_
 
-            if ($getTargetResourceResult.$variableName -ne $_.Value) {
-                New-VerboseMessage -Message "$variableName '$($_.Value)' is not in the desired state for this cluster."
+            if ($getTargetResourceResult.$variableName -ne $boundParams[$variableName]) {
+                New-VerboseMessage -Message "$variableName '$($boundParams[$variableName])' is not in the desired state for this cluster."
                 $result = $false
             }
         }

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -863,7 +863,7 @@ function Set-TargetResource
                     if (Test-IPAddress -IPAddress $address -NetworkID $network.Address -SubnetMask $network.AddressMask)
                     {
                         # Add the formatted string to our array
-                        $clusterIPAddresses += "IPv4; $address; $($network.Name); $($network.AddressMask)"
+                        $clusterIPAddresses += "IPv4;$address;$($network.Name);$($network.AddressMask)"
                     }
                 }
             }

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -935,7 +935,10 @@ function Set-TargetResource
             $setupArguments += @{ SAPwd = $SAPwd.GetNetworkCredential().Password }
         }
 
-        $setupArguments += @{ AgtSvcStartupType = 'Automatic' }
+        if ($Action -notin @('PrepareFailoverCluster','CompleteFailoverCluster','InstallFailoverCluster','AddNode'))
+        {
+            $setupArguments += @{ AgtSvcStartupType = 'Automatic' }
+        }
     }
 
     if ($Features.Contains('FULLTEXT'))

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -777,7 +777,7 @@ function Set-TargetResource
 
     $setupArguments = @{}
 
-    if ($Action -in @('PrepareFailoverCluster','CompleteFailoverCluster','InstallFailoverCluster','AddNode'))
+    if ($Action -in @('PrepareFailoverCluster','CompleteFailoverCluster','InstallFailoverCluster'))
     {
         # Set the group name for this clustered instance.
         $setupArguments += @{ 
@@ -840,7 +840,7 @@ function Set-TargetResource
     }
 
     # Determine network mapping for specific cluster installation types
-    if ($Action -in @('CompleteFailoverCluster','InstallFailoverCluster','AddNode'))
+    if ($Action -in @('CompleteFailoverCluster','InstallFailoverCluster'))
     {
         $clusterIPAddresses = @()
 
@@ -907,6 +907,19 @@ function Set-TargetResource
     if ($null -ne $BrowserSvcStartupType)
     {
         $argumentVars += 'BrowserSvcStartupType'
+    }
+
+    if ($Action -eq "AddNode")
+    {
+        if ($PSBoundParameters.ContainsKey('SQLSvcAccount'))
+        {
+            $setupArguments += (Get-ServiceAccountParameters -ServiceAccount $SQLSvcAccount -ServiceType 'SQL')
+        }
+
+        if($PSBoundParameters.ContainsKey('AgtSvcAccount'))
+        {
+            $setupArguments += (Get-ServiceAccountParameters -ServiceAccount $AgtSvcAccount -ServiceType 'AGT')
+        }
     }
 
     if ($Features.Contains('SQLENGINE'))
@@ -1073,7 +1086,7 @@ function Set-TargetResource
         Path = $pathToSetupExecutable
         Arguments = $arguments
     };
-    if ($Action -in @('InstallFailoverCluster'))
+    if ($Action -in @('InstallFailoverCluster','AddNode'))
     {
         $processArgs.Add('Credential',$SetupCredential);
     }

--- a/README.md
+++ b/README.md
@@ -868,6 +868,30 @@ Installs SQL Server on the target node.
 * **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance. IP addresses must be in [dotted-decimal notation](https://en.wikipedia.org/wiki/Dot-decimal_notation), for example ````10.0.0.100````. If no IP address is specified, uses 'DEFAULT' for this setup parameter.
 * **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
 
+##### Required Parameters
+
+For configurations that utilize the 'InstallFailoverCluster' action, the following parameters are required (beyond those required for the standalone installation:
+- InstanceName (can be MSSQLSERVER if you want to install a default clustered instance)
+- FailoverClusterNetworkName
+- When installation SQL Server database engine:
+  - InstallSQLDataDir
+  - SQLUserDBDir
+  - SQLUserDBLogDir
+  - SQLTempDBDir
+  - SQLTempDBLogDir
+  - SQLBackupDir
+  - AgtSvcAccount
+  - SQLSvcAccount
+- When installing SQL Analysis Services
+  - ASDataDir
+  - ASLogDir
+  - ASBackupDir
+  - ASTempDir
+  - ASConfigDir
+  - AsSvcAccount
+
+
+
 #### Read-Only Properties from Get-TargetResource
 
 * **SQLSvcAccountUsername** _(Read)_: Output user name for the SQL service.

--- a/README.md
+++ b/README.md
@@ -871,26 +871,25 @@ Installs SQL Server on the target node.
 ##### Required Parameters
 
 For configurations that utilize the 'InstallFailoverCluster' action, the following parameters are required (beyond those required for the standalone installation:
-- InstanceName (can be MSSQLSERVER if you want to install a default clustered instance)
-- FailoverClusterNetworkName
-- When installation SQL Server database engine:
-  - InstallSQLDataDir
-  - SQLUserDBDir
-  - SQLUserDBLogDir
-  - SQLTempDBDir
-  - SQLTempDBLogDir
-  - SQLBackupDir
-  - AgtSvcAccount
-  - SQLSvcAccount
-- When installing SQL Analysis Services
-  - ASDataDir
-  - ASLogDir
-  - ASBackupDir
-  - ASTempDir
-  - ASConfigDir
-  - AsSvcAccount
 
-
+* InstanceName (can be MSSQLSERVER if you want to install a default clustered instance)
+* FailoverClusterNetworkName
+* When installation SQL Server database engine:
+  * InstallSQLDataDir
+  * SQLUserDBDir
+  * SQLUserDBLogDir
+  * SQLTempDBDir
+  * SQLTempDBLogDir
+  * SQLBackupDir
+  * AgtSvcAccount
+  * SQLSvcAccount
+* When installing SQL Analysis Services
+  * ASDataDir
+  * ASLogDir
+  * ASBackupDir
+  * ASTempDir
+  * ASConfigDir
+  * AsSvcAccount
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -821,9 +821,30 @@ Installs SQL Server on the target node.
 
 * Target machine must be running Windows Server 2008 R2.
 
+For configurations that utilize the 'InstallFailoverCluster' action, the following parameters are required (beyond those required for the standalone installation):
+
+* InstanceName (can be MSSQLSERVER if you want to install a default clustered instance)
+* FailoverClusterNetworkName
+* When installation SQL Server database engine:
+  * InstallSQLDataDir
+  * SQLUserDBDir
+  * SQLUserDBLogDir
+  * SQLTempDBDir
+  * SQLTempDBLogDir
+  * SQLBackupDir
+  * AgtSvcAccount
+  * SQLSvcAccount
+* When installing SQL Analysis Services
+  * ASDataDir
+  * ASLogDir
+  * ASBackupDir
+  * ASTempDir
+  * ASConfigDir
+  * AsSvcAccount
+
 #### Parameters
 
-* **[String] Action** _(Write)_: The action to be performed. Defaults to 'Install'. { _Install_ | InstallFailoverCluster | AddNode | PrepareFailoverCluster | CompleteFailoverCluster }
+* **[String] Action** _(Write)_: The action to be performed. Defaults to 'Install'. *Note: AddNode is not currently functional.* { _Install_ | InstallFailoverCluster | AddNode | PrepareFailoverCluster | CompleteFailoverCluster }
 * **[String] InstanceName** _(Key)_: SQL instance to be installed.
 * **[PSCredential] SetupCredential** _(Required)_: Credential to be used to perform the installation.
 * **[String] SourcePath** _(Write)_: The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.
@@ -867,29 +888,6 @@ Installs SQL Server on the target node.
 * **[String] FailoverClusterGroupName** _(Write)_: The name of the resource group to create for the clustered SQL Server instance. Defaults to 'SQL Server (_InstanceName_)'.
 * **[String[]]FailoverClusterIPAddress** _(Write)_: Array of IP Addresses to be assigned to the clustered SQL Server instance. IP addresses must be in [dotted-decimal notation](https://en.wikipedia.org/wiki/Dot-decimal_notation), for example ````10.0.0.100````. If no IP address is specified, uses 'DEFAULT' for this setup parameter.
 * **[String] FailoverClusterNetworkName** _(Write)_: Host name to be assigned to the clustered SQL Server instance.
-
-##### Required Parameters
-
-For configurations that utilize the 'InstallFailoverCluster' action, the following parameters are required (beyond those required for the standalone installation:
-
-* InstanceName (can be MSSQLSERVER if you want to install a default clustered instance)
-* FailoverClusterNetworkName
-* When installation SQL Server database engine:
-  * InstallSQLDataDir
-  * SQLUserDBDir
-  * SQLUserDBLogDir
-  * SQLTempDBDir
-  * SQLTempDBLogDir
-  * SQLBackupDir
-  * AgtSvcAccount
-  * SQLSvcAccount
-* When installing SQL Analysis Services
-  * ASDataDir
-  * ASLogDir
-  * ASBackupDir
-  * ASTempDir
-  * ASConfigDir
-  * AsSvcAccount
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -79,8 +79,8 @@ try
         $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
         $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
         $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4; 10.0.0.10; SiteA_Prod; 255.255.255.0'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4; 10.0.0.10; SiteA_Prod; 255.255.255.0; IPv4; 10.0.10.100; SiteB_Prod; 255.255.255.0'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
         $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
 
         $mockNamedInstance_InstanceName = 'TEST'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -118,11 +118,11 @@ try
         }
 
         $mockCSVClusterDiskMap = @{
-            UserData = 'C:\ClusterStorage\SQLData'
-            UserLogs = 'C:\ClusterStorage\SQLLogs'
-            TempDbData = 'C:\ClusterStorage\TempDBData'
-            TempDbLogs = 'C:\ClusterStorage\TempDBLogs'
-            SQLBackup = 'C:\ClusterStorage\SQLBackup'
+            UserData = @{Path='C:\ClusterStorage\SQLData';Name="Cluster Virtual Disk (SQL Data Disk)"}
+            UserLogs = @{Path='C:\ClusterStorage\SQLLogs';Name="Cluster Virtual Disk (SQL Log Disk)"}
+            TempDbData = @{Path='C:\ClusterStorage\TempDBData';Name="Cluster Virtual Disk (SQL TempDBData Disk)"}
+            TempDbLogs = @{Path='C:\ClusterStorage\TempDBLogs';Name="Cluster Virtual Disk (SQL TempDBLog Disk)"}
+            Backup = @{Path='C:\ClusterStorage\SQLBackup';Name="Cluster Virtual Disk (SQL Backup Disk)"}
         }
 
         $mockClusterSites = @(
@@ -605,50 +605,63 @@ try
             )
         }
 
-        $mockGetClusterSharedVolume = {
+        $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
             return @(
                 (
-                    New-Object PSObject -Property @{
-                        Name = 'Cluster Virtual Disk (SQL Data Disk)'
-                        SharedVolumeInfo = (New-Object PSObject -Property @{
-                            FriendlyVolumeName = 'C:\ClusterStorage\SQLData'
-                        })
-                    }
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["UserData"].Path -PassThru -Force
                 ),
                 (
-                    New-Object PSObject -Property @{
-                        Name = 'Cluster Virtual Disk (SQL Log Disk)'
-                        SharedVolumeInfo = (New-Object PSObject -Property @{
-                            FriendlyVolumeName = 'C:\ClusterStorage\SQLLog'
-                        })
-                    }
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["UserLogs"].Path -PassThru -Force
                 ),
                 (
-                    New-Object PSObject -Property @{
-                        Name = 'Cluster Virtual Disk (SQL TempDBData Disk)'
-                        SharedVolumeInfo = (New-Object PSObject -Property @{
-                            FriendlyVolumeName = 'C:\ClusterStorage\TempDBData'
-                        })
-                    }
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["TempDBData"].Path -PassThru -Force
                 ),
                 (
-                    New-Object PSObject -Property @{
-                        Name = 'Cluster Virtual Disk (SQL TempDBLog Disk)'
-                        SharedVolumeInfo = (New-Object PSObject -Property @{
-                            FriendlyVolumeName = 'C:\ClusterStorage\TempDBLog'
-                        })
-                    }
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["TempDBLogs"].Path -PassThru -Force
                 ),
                 (
-                    New-Object PSObject -Property @{
-                        Name = 'Cluster Virtual Disk (Backup)'
-                        SharedVolumeInfo = (New-Object PSObject -Property @{
-                            FriendlyVolumeName = 'C:\ClusterStorage\SQLBackup'
-                        })
-                    }
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["Backup"].Path -PassThru -Force
                 )
             );
         }
+
+        $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserData"].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserData"].Name}) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserLogs"].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserLogs"].Name}) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBData"].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBData"].Name}) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBLogs"].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBLogs"].Name}) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["Backup"].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["Backup"].Name}) -PassThru -Force
+                )
+            );
+        }
+        
+
+
 
         $mockGetCimInstance_MSClusterNetwork = {
             return @(
@@ -3185,7 +3198,14 @@ try
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
 
-                        Mock -CommandName Get-ClusterSharedVolume -MockWith $mockGetClusterSharedVolume;
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3249,11 +3269,18 @@ try
                             $ResultClassName -eq 'MSCluster_DiskPartition'
                         } -Verifiable
 
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter { 
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
 
-                        Mock -CommandName Get-ClusterSharedVolume -MockWith $mockGetClusterSharedVolume;
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3401,10 +3428,10 @@ try
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
                         $csvTestParameters = $testParameters.Clone();
                         
-                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"];
-                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserLogs"];
-                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["TempDBData"];
-                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["TempDBLogs"];
+                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"].Path;
+                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserLogs"].Path;
+                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["TempDBData"].Path;
+                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["TempDBLogs"].Path;
                         
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3414,14 +3441,14 @@ try
                             Action = 'InstallFailoverCluster'
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
-                            FailoverClusterDisks = 'Cluster Virtual Disk (SQL Data Disk); Cluster Virtual Disk (SQL Log Disk); Cluster Virtual Disk (SQL TempDBData Disk); Cluster Virtual Disk (SQL TempDBLog Disk)'
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap["UserData"].Name); $($mockCSVClusterDiskMap["UserLogs"].Name); $($mockCSVClusterDiskMap["TempDBData"].Name); $($mockCSVClusterDiskMap["TempDBLogs"].Name)"
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SQLUserDBDir = 'C:\ClusterStorage\SQLData'
-                            SQLUserDBLogDir = 'C:\ClusterStorage\SQLLogs'
-                            SQLTempDBDir = 'C:\ClusterStorage\TempDBData'
-                            SQLTempDBLogDir = 'C:\ClusterStorage\TempDBLogs'
+                            SQLUserDBDir = $mockCSVClusterDiskMap["UserData"].Path
+                            SQLUserDBLogDir = $mockCSVClusterDiskMap["UserLogs"].Path
+                            SQLTempDBDir = $mockCSVClusterDiskMap["TempDBData"].Path
+                            SQLTempDBLogDir = $mockCSVClusterDiskMap["TempDBLogs"].Path
                         }
 
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
@@ -3430,11 +3457,11 @@ try
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
                         $csvTestParameters = $testParameters.Clone();
                         
-                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"] + '\Data';
-                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserData"] + '\Logs';
-                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["UserData"] + '\TEMPDB';
-                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["UserData"] + '\TEMPDBLOG';
-                        $csvTestParameters["SQLBackupDir"] = "C:\ClusterStorage\SQLBackup\Backup";
+                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\Data';
+                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\Logs';
+                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\TEMPDB';
+                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\TEMPDBLOG';
+                        $csvTestParameters["SQLBackupDir"] = $mockCSVClusterDiskMap["Backup"].Path + '\Backup';
                         
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3444,15 +3471,15 @@ try
                             Action = 'InstallFailoverCluster'
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
-                            FailoverClusterDisks = 'Cluster Virtual Disk (Backup); Cluster Virtual Disk (SQL Data Disk)'
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap["Backup"].Name); $($mockCSVClusterDiskMap["UserData"].Name)"
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SQLUserDBDir = 'C:\ClusterStorage\SQLData\Data'
-                            SQLUserDBLogDir = 'C:\ClusterStorage\SQLData\Logs'
-                            SQLTempDBDir = 'C:\ClusterStorage\SQLData\TEMPDB'
-                            SQLTempDBLogDir = 'C:\ClusterStorage\SQLData\TEMPDBLOG'
-                            SQLBackupDir = 'C:\ClusterStorage\SQLBackup\Backup'
+                            SQLUserDBDir = "$($mockCSVClusterDiskMap["UserData"].Path)\Data"
+                            SQLUserDBLogDir = "$($mockCSVClusterDiskMap["UserData"].Path)\Logs"
+                            SQLTempDBDir = "$($mockCSVClusterDiskMap["UserData"].Path)\TEMPDB"
+                            SQLTempDBLogDir = "$($mockCSVClusterDiskMap["UserData"].Path)\TEMPDBLOG"
+                            SQLBackupDir = "$($mockCSVClusterDiskMap["Backup"].Path)\Backup"
                         }
 
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
@@ -3511,7 +3538,6 @@ try
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
 
-                        Mock -CommandName Get-ClusterSharedVolume -MockWith $mockGetClusterSharedVolume;
                     }
 
                     It 'Should add the SkipRules parameter to the installation arguments' {
@@ -3592,7 +3618,14 @@ try
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
 
-                        Mock -CommandName Get-ClusterSharedVolume -MockWith $mockGetClusterSharedVolume;
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+
                     }
 
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -78,6 +78,9 @@ try
 
         $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
         $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+        $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4; 10.0.0.10; SiteA_Prod; 255.255.255.0'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4; 10.0.0.10; SiteA_Prod; 255.255.255.0; IPv4; 10.0.10.100; SiteB_Prod; 255.255.255.0'
         $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
 
         $mockNamedInstance_InstanceName = 'TEST'
@@ -113,12 +116,12 @@ try
         $mockClusterSites = @(
             @{
                 Name = 'SiteA'
-                Address = '10.0.0.100'
+                Address = $mockDefaultInstance_FailoverClusterIPAddress
                 Mask = '255.255.255.0'
             },
             @{
                 Name = 'SiteB'
-                Address = '10.0.10.100'
+                Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
                 Mask = '255.255.255.0'
             }
         )
@@ -3126,7 +3129,6 @@ try
 
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {
                         $badPathParameters = $testParameters.Clone()
                         
@@ -3342,8 +3344,8 @@ try
                             SourcePath = $mockSourcePath
                             Action = 'CompleteFailoverCluster'
                             FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = 'TestCluster'
-                            FailoverClusterIPAddress = '10.0.0.100'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         }
                     }
 
@@ -3383,14 +3385,14 @@ try
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'CompleteFailoverCluster'
-                            FailoverClusterIPAddresses = 'IPV4; 10.0.0.100; SiteA_Prod; 255.255.255.0'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             SQLUserDBDir = 'K:\MSSQL\Data'
                             SQLUserDBLogDir = 'L:\MSSQL\Logs'
                             SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
                             SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
                             SkipRules = 'Cluster_VerifyForErrors'
-
-                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs' 
                         }
 
                         { Set-TargetResource @testParameters } | Should Not Throw
@@ -3404,7 +3406,7 @@ try
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'CompleteFailoverCluster'
                             FailoverClusterIPAddresses = 'DEFAULT'
-
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             SQLUserDBDir = 'K:\MSSQL\Data'
                             SQLUserDBLogDir = 'L:\MSSQL\Logs'
                             SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
@@ -3442,8 +3444,8 @@ try
 
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = 'IPv4; 10.0.0.100; SiteA_Prod; 255.255.255.0'
-
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             SQLUserDBDir = 'K:\MSSQL\Data'
                             SQLUserDBLogDir = 'L:\MSSQL\Logs'
                             SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
@@ -3465,8 +3467,8 @@ try
 
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = 'IPv4; 10.0.0.100; SiteA_Prod; 255.255.255.0; IPv4; 10.0.10.100; SiteB_Prod; 255.255.255.0'
-
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             SQLUserDBDir = 'K:\MSSQL\Data'
                             SQLUserDBLogDir = 'L:\MSSQL\Logs'
                             SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
@@ -3490,8 +3492,9 @@ try
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
                             FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs'
-                            FailoverClusterIPAddresses = 'IPV4; 10.0.0.100; SiteA_Prod; 255.255.255.0'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             SQLUserDBDir = 'K:\MSSQL\Data'
                             SQLUserDBLogDir = 'L:\MSSQL\Logs'
                             SQLTempDBDir = 'M:\MSSQL\TempDb\Data'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -101,11 +101,11 @@ try
         $mockSetupCredential = New-Object System.Management.Automation.PSCredential( $mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword )
 
         $mockSqlServiceAccount = 'COMPANY\SqlAccount'
-        $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd';
-        $mockSQLServiceCredential = new-object System.Management.Automation.PSCredential($mockSqlServiceAccount,($mockSQLServicePassword | Convertto-SecureString -AsPlainText -Force));
+        $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
+        $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
         $mockAgentServiceAccount = 'COMPANY\AgentAccount'
-        $mockAgentServicePassword = 'Ag3ntP@ssw0rd';
-        $mockSQLAgentCredential = new-object System.Management.Automation.PSCredential($mockAgentServiceAccount,($mockAgentServicePassword | Convertto-SecureString -AsPlainText -Force));
+        $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
+        $mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount,($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
 
         $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
 
@@ -609,55 +609,55 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["UserData"].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["UserLogs"].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["TempDBData"].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["TempDBLogs"].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name "Name" -Value $mockCSVClusterDiskMap["Backup"].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
                 )
-            );
+            )
         }
 
         $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserData"].Path}) -PassThru -Force | 
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserData"].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserLogs"].Path}) -PassThru -Force | 
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["UserLogs"].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBData"].Path}) -PassThru -Force | 
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBData"].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBLogs"].Path}) -PassThru -Force | 
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["TempDBLogs"].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["Backup"].Path}) -PassThru -Force | 
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap["Backup"].Name}) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force | 
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
                 )
-            );
+            )
         }
         
 
@@ -2400,7 +2400,7 @@ try
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
 
-                    New-Variable -Name "FailoverClusterDisks" -Value $mockClusterDiskMap["UserData"];
+                    New-Variable -Name 'FailoverClusterDisks' -Value $mockClusterDiskMap['UserData']
                     
                     $result = Test-TargetResource @testClusterParameters
 
@@ -3169,11 +3169,11 @@ try
                             SqlSvcAccount = $mockSQLServiceCredential
                         }
 
-                        $testParameters.Remove("Features");
-                        $testParameters.Remove("SQLUserDBDir");
-                        $testParameters.Remove("SQLUserDBLogDir");
-                        $testParameters.Remove("SQLTempDbDir");
-                        $testParameters.Remove("SQLTempDBlogDir");
+                        $testParameters.Remove('Features')
+                        $testParameters.Remove('SQLUserDBDir')
+                        $testParameters.Remove('SQLUserDBLogDir')
+                        $testParameters.Remove('SQLTempDbDir')
+                        $testParameters.Remove('SQLTempDBlogDir')
 
                     }
 
@@ -3206,6 +3206,8 @@ try
                             $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
                         } -Verifiable
 
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3226,11 +3228,11 @@ try
 
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not Be $null;
-                            return "Process started.";
+                            $Credential | Should Not Be $null
+                            return "Process started."
                         }
 
-                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential;
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
 
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
@@ -3281,6 +3283,16 @@ try
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
 
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3307,11 +3319,11 @@ try
 
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not Be $null;
-                            return "Process started.";
+                            $Credential | Should Not Be $null
+                            return "Process started."
                         }
 
-                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential;
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
 
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
@@ -3426,12 +3438,12 @@ try
                     }
 
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
-                        $csvTestParameters = $testParameters.Clone();
+                        $csvTestParameters = $testParameters.Clone()
                         
-                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"].Path;
-                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserLogs"].Path;
-                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["TempDBData"].Path;
-                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["TempDBLogs"].Path;
+                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
+                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
+                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
+                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
                         
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3441,27 +3453,27 @@ try
                             Action = 'InstallFailoverCluster'
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
-                            FailoverClusterDisks = "$($mockCSVClusterDiskMap["UserData"].Name); $($mockCSVClusterDiskMap["UserLogs"].Name); $($mockCSVClusterDiskMap["TempDBData"].Name); $($mockCSVClusterDiskMap["TempDBLogs"].Name)"
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['UserData'].Name); $($mockCSVClusterDiskMap['UserLogs'].Name); $($mockCSVClusterDiskMap['TempDBData'].Name); $($mockCSVClusterDiskMap['TempDBLogs'].Name)"
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SQLUserDBDir = $mockCSVClusterDiskMap["UserData"].Path
-                            SQLUserDBLogDir = $mockCSVClusterDiskMap["UserLogs"].Path
-                            SQLTempDBDir = $mockCSVClusterDiskMap["TempDBData"].Path
-                            SQLTempDBLogDir = $mockCSVClusterDiskMap["TempDBLogs"].Path
+                            SQLUserDBDir = $mockCSVClusterDiskMap['UserData'].Path
+                            SQLUserDBLogDir = $mockCSVClusterDiskMap['UserLogs'].Path
+                            SQLTempDBDir = $mockCSVClusterDiskMap['TempDBData'].Path
+                            SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
                         }
 
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
                     }
 
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
-                        $csvTestParameters = $testParameters.Clone();
+                        $csvTestParameters = $testParameters.Clone()
                         
-                        $csvTestParameters["SQLUserDBDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\Data';
-                        $csvTestParameters["SQLUserDBLogDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\Logs';
-                        $csvTestParameters["SQLTempDBDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\TEMPDB';
-                        $csvTestParameters["SQLTempDBLogDir"] = $mockCSVClusterDiskMap["UserData"].Path + '\TEMPDBLOG';
-                        $csvTestParameters["SQLBackupDir"] = $mockCSVClusterDiskMap["Backup"].Path + '\Backup';
+                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
+                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
+                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
+                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
+                        $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
                         
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3471,24 +3483,21 @@ try
                             Action = 'InstallFailoverCluster'
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
-                            FailoverClusterDisks = "$($mockCSVClusterDiskMap["Backup"].Name); $($mockCSVClusterDiskMap["UserData"].Name)"
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name)"
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
                             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SQLUserDBDir = "$($mockCSVClusterDiskMap["UserData"].Path)\Data"
-                            SQLUserDBLogDir = "$($mockCSVClusterDiskMap["UserData"].Path)\Logs"
-                            SQLTempDBDir = "$($mockCSVClusterDiskMap["UserData"].Path)\TEMPDB"
-                            SQLTempDBLogDir = "$($mockCSVClusterDiskMap["UserData"].Path)\TEMPDBLOG"
-                            SQLBackupDir = "$($mockCSVClusterDiskMap["Backup"].Path)\Backup"
+                            SQLUserDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
+                            SQLUserDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Logs"
+                            SQLTempDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDB"
+                            SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
+                            SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
                         }
 
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
                     }
-
-
                 }
 
-               
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
                     BeforeAll {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -3537,7 +3546,6 @@ try
                         Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
-
                     }
 
                     It 'Should add the SkipRules parameter to the installation arguments' {
@@ -3626,6 +3634,7 @@ try
                             $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
                         } -Verifiable
 
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                     }
 
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3228,8 +3228,8 @@ try
 
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not Be $null
-                            return "Process started."
+                            $Credential | Should Not BeNullOrEmpty
+                            return 'Process started.'
                         }
 
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
@@ -3319,8 +3319,8 @@ try
 
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not Be $null
-                            return "Process started."
+                            $Credential | Should Not BeNullOrEmpty
+                            return 'Process started.'
                         }
 
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3056,6 +3056,190 @@ try
                     }
                 }
 
+                # For testing InstallFailoverCluster action
+                Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
+                    BeforeAll {
+                        $testParameters = $mockDefaultClusterParameters.Clone()
+
+                        $testParameters += @{
+                            InstanceName = 'MSSQLSERVER'
+                            SourcePath = $mockSourcePath
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        }
+
+                    }
+
+                    BeforeAll {
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter { 
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Verfiable
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        } -Verifiable
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter { 
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Verifiable
+                    }
+
+                    It 'Should pass proper parameters to setup' {
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Quiet = 'True'
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            Action = 'InstallFailoverCluster'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = 'SQLEngine'
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SQLUserDBDir = 'K:\MSSQL\Data'
+                            SQLUserDBLogDir = 'L:\MSSQL\Logs'
+                            SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
+                            SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should pass the SetupCredential object to the StartWin32Process function' {
+                        $mockStartWin32Process_SetupCredential = {
+                            $Credential | Should Not Be $null;
+                            return "Process started.";
+                        }
+
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential;
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should throw an error when one or more paths are not resolved to clustered storage' {
+                        $badPathParameters = $testParameters.Clone()
+                        
+                        # Pass in a bad path
+                        $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
+
+                        { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: TempDbData; TempDbLogs; UserLogs'
+                    }
+
+                    It 'Should properly map paths to clustered disk resources' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{ 
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            SQLUserDBDir = 'K:\MSSQL\Data'
+                            SQLUserDBLogDir = 'L:\MSSQL\Logs'
+                            SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
+                            SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs' 
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should build a DEFAULT address string when no network is specified' {
+                        $missingNetworkParams = $testParameters.Clone()
+                        $missingNetworkParams.Remove('FailoverClusterIPAddress')
+
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterIPAddresses = 'DEFAULT'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SQLUserDBDir = 'K:\MSSQL\Data'
+                            SQLUserDBLogDir = 'L:\MSSQL\Logs'
+                            SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
+                            SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                        }
+
+                        { Set-TargetResource @missingNetworkParams } | Should Not Throw
+                    }
+
+                    It 'Should throw an error when an invalid IP Address is specified' {
+                        $invalidAddressParameters = $testParameters.Clone()
+
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = '192.168.0.100'
+                        }
+
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+
+                    It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
+                        $invalidAddressParameters = $testParameters.Clone()
+
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = @('10.0.0.100','192.168.0.100')
+                        }
+
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+
+                    It 'Should build a valid IP address string for a single address' {
+
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SQLUserDBDir = 'K:\MSSQL\Data'
+                            SQLUserDBLogDir = 'L:\MSSQL\Logs'
+                            SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
+                            SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'InstallFailoverCluster'
+                        }
+
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+
+                    It 'Should build a valid IP address string for a multi-subnet cluster' {
+                        $multiSubnetParameters = $testParameters.Clone()
+                        $multiSubnetParameters.Remove('FailoverClusterIPAddress')
+                        $multiSubnetParameters += @{
+                            FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
+                        }
+
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SQLUserDBDir = 'K:\MSSQL\Data'
+                            SQLUserDBLogDir = 'L:\MSSQL\Logs'
+                            SQLTempDBDir = 'M:\MSSQL\TempDb\Data'
+                            SQLTempDBLogDir = 'N:\MSSQL\TempDb\Logs'
+                            FailoverClusterDisks = 'TempDbData; TempDbLogs; UserData; UserLogs' 
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'InstallFailoverCluster'
+                        }
+
+                        { Set-TargetResource @multiSubnetParameters } | Should Not Throw
+                    }
+
+
+                }
+                
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
                     BeforeAll {
                         $testParameters = $mockDefaultParameters.Clone()

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -699,7 +699,6 @@ try
             IAcceptSQLServerLicenseTerms = 'True'
             Quiet = 'True'
             InstanceName = 'MSSQLSERVER'
-            AGTSVCSTARTUPTYPE = 'Automatic'
             Features = 'SQLENGINE'
             SQLSysAdminAccounts = 'COMPANY\sqladmin'
             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
@@ -3301,7 +3300,6 @@ try
                             IAcceptSQLServerLicenseTerms = 'True'
                             SkipRules = 'Cluster_VerifyForErrors'
                             Quiet = 'True'
-                            AgtSvcStartupType = 'Automatic'
                             SQLSysAdminAccounts = 'COMPANY\sqladmin'
 
                             Action = 'CompleteFailoverCluster'


### PR DESCRIPTION
This pull request includes multiple fixes and enhancements to allow for clustered installations (currently only fully tested the InstallFailoverCluster action, but all unit tests for others were successful). The AddNode action is the only one I know will not work due to some complexities with checking desired state. I'll open a separate issue for that.

This Pull Request (PR) fixes the following issues:
Fixes #362 
Fixes #353 
Fixes #352 
Fixes #345 
Fixes #344 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/363)
<!-- Reviewable:end -->
