### PR TITLE
xSQLServerSetup: $SQLSysAdminAccounts never added to list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Change log for xSQLServer
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Change log for xSQLServer
 
 ## Unreleased
@@ -41,6 +42,7 @@
       - Function `NetUse` has been replaced with `New-SmbMapping` and `Remove-SmbMapping`.
   - Renamed function `GetSQLVersion` to `Get-SqlMajorVersion`.
   - BREAKING CHANGE: Renamed parameter PID to ProductKey to avoid collision with automatic variable $PID
+  - Properly checks for use of SQLSysAdminAccounts parameter in $PSBoundParameters
 - Changes to xSQLServerScript
   - All credential parameters now also has the type [System.Management.Automation.Credential()] to better work with PowerShell 4.0.
   - It is now possible to configure two instances on the same node, with the same script.

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -925,7 +925,7 @@ function Set-TargetResource
         }
 
         $setupArguments += @{ SQLSysAdminAccounts =  @($SetupCredential.UserName) }
-        if ($PSBoundParameters -icontains 'SQLSysAdminAccounts')
+        if ($PSBoundParameters.ContainsKey('SQLSysAdminAccounts'))
         {
             $setupArguments['SQLSysAdminAccounts'] += $SQLSysAdminAccounts
         }


### PR DESCRIPTION
[The code for $SQLSysAdminAccounts being checked in PSBoundParameters is updated to use .ContainsKey method instead of -contains]

This Pull Request (PR) fixes the following issues:
Fixes #371

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/370)
<!-- Reviewable:end -->
