### PR TITLE
xSQLServerSetup: Support feature CONN and BC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changes to xSQLServerSetup
   - Properly checks for use of SQLSysAdminAccounts parameter in $PSBoundParameters. The test now also properly evaluates the setup argument for SQLSysAdminAccounts.
   - xSQLServerSetup should now function correctly for the InstallFailoverCluster action, and also supports cluster shared volumes. Note that the AddNode action is not currently working.
+  - It now detects that feature Client Connectivity Tools (CONN) and Client Connectivity Backwards Compatibility Tools (BC) is installed.
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -122,7 +122,7 @@ function Get-TargetResource
 
         $featuresVersion = $sqlVersion + "0"
         New-VerboseMessage -Message "Detecting Client Connectivity Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full").FeatureList
+        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityToolsInstalled -like '*Connectivity_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
@@ -134,7 +134,7 @@ function Get-TargetResource
         }
 
         New-VerboseMessage -Message "Detecting Client Connectivity Backwards Compatibility Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full").FeatureList
+        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityBackwardsCompatibilityToolsInstalled -like '*Tools_Legacy_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -121,8 +121,9 @@ function Get-TargetResource
         }
 
         $featuresVersion = $sqlVersion + "0"
-        New-VerboseMessage -Message "Detecting Client Connectivity Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
+        $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full"
+        New-VerboseMessage -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
+        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityToolsInstalled -like '*Connectivity_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
@@ -133,8 +134,8 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
         }
 
-        New-VerboseMessage -Message "Detecting Client Connectivity Backwards Compatibility Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
+        New-VerboseMessage -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
+        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityBackwardsCompatibilityToolsInstalled -like '*Tools_Legacy_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -121,10 +121,10 @@ function Get-TargetResource
         }
 
         $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
+        $registryClientComponentsFullFeatureList = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
 
-        New-VerboseMessage -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
-        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
-        if ($isClientConnectivityToolsInstalled -like '*Connectivity_FNS=3*')
+        Write-Debug -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
+        if ($registryClientComponentsFullFeatureList -like '*Connectivity_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
             $features += 'CONN,'
@@ -134,9 +134,8 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
         }
 
-        New-VerboseMessage -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
-        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
-        if ($isClientConnectivityBackwardsCompatibilityToolsInstalled -like '*Tools_Legacy_FNS=3*')
+        Write-Debug -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
+        if ($registryClientComponentsFullFeatureList -like '*Tools_Legacy_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
             $features += 'BC,'

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -122,7 +122,7 @@ function Get-TargetResource
 
         $featuresVersion = $sqlVersion + "0"
         New-VerboseMessage -Message "Detecting Client Connectivity Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
+        $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityToolsInstalled -like '*Connectivity_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
@@ -134,7 +134,7 @@ function Get-TargetResource
         }
 
         New-VerboseMessage -Message "Detecting Client Connectivity Backwards Compatibility Tools feature (HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full)"
-        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tooss\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
+        $isClientConnectivityBackwardsCompatibilityToolsInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full" -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityBackwardsCompatibilityToolsInstalled -like '*Tools_Legacy_FNS=3*')
         {
             New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -120,8 +120,8 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Replication feature not detected'
         }
 
-        $featuresVersion = $sqlVersion + "0"
-        $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$featuresVersion\Tools\Setup\Client_Components_Full"
+        $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
+
         New-VerboseMessage -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
         $isClientConnectivityToolsInstalled = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
         if ($isClientConnectivityToolsInstalled -like '*Connectivity_FNS=3*')


### PR DESCRIPTION
It now detects that feature Client Connectivity Tools (CONN) and Client Connectivity Backwards Compatibility Tools (BC) is installed. This is based on the work of @joshan1120 in PR #163. This resolved issue #159 and might also resolve #142.

This Pull Request (PR) fixes the following issues:
Fixes #159 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/383)
<!-- Reviewable:end -->
