### PR TITLE
xSQLServerSetup: Use the correct hostname for cluster installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Now it can correctly determine the right cluster when only parameter InstallSQLDataDir is assigned a path (issue #401).
   - Now the only mandatory path parameter is InstallSQLDataDir when installing Database Engine (issue #400).
   - It now can handle mandatory parameters, and are not using wildcards to find the variables containing paths (issue #394).
+  - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - Changed to that instead of connection to localhost it is using `$env:COMPUTERNAME` as the host name to which it connects. And for cluster installation it uses the parameter `FailoverClusterNetworkName` as the host name to which it connects. Resolves issue #407.

This Pull Request (PR) fixes the following issues:
Fixes #407 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/415)
<!-- Reviewable:end -->
