### PR TITLE
xSQLServerSetup: Paths can be set to just the qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   - Now it can correctly determine the right cluster when only parameter InstallSQLDataDir is assigned a path (issue #401).
   - Now the only mandatory path parameter is InstallSQLDataDir when installing Database Engine (issue #400).
   - It now can handle mandatory parameters, and are not using wildcards to find the variables containing paths (issue #394).
-  - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
+  - Changed so that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
   - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier, i.e 'E:' (issue #418). All paths (except SourcePath) can now be set to just the qualifier.
 - Enables CodeCov.io code coverage reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   - It now can handle mandatory parameters, and are not using wildcards to find the variables containing paths (issue #394).
   - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
+  - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier 'E:'. Now all paths (except SourcePath) can be set to just the qualifier (issue #418).
+  - Improved the mock that tests the setup arguments.
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
   - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
   - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier 'E:'. Now all paths (except SourcePath) can be set to just the qualifier (issue #418).
-  - Improved the mock that tests the setup arguments.
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - It now can handle mandatory parameters, and are not using wildcards to find the variables containing paths (issue #394).
   - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
-  - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier 'E:'. Now all paths (except SourcePath) can be set to just the qualifier (issue #418).
+  - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier, i.e 'E:' (issue #418). All paths (except SourcePath) can now be set to just the qualifier.
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2917,21 +2917,11 @@ try
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                         } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
-                        Mock -CommandName Get-Item -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                        } -MockWith $mockGetItem_SharedDirectory -Verifiable
-
                         # Mocking SharedWowDirectory (when previously installed and should not be installed again).
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                         } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-
-                        Mock -CommandName Get-Item -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                        } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
 
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -907,6 +907,7 @@ try
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
@@ -2085,6 +2086,7 @@ try
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
@@ -2915,6 +2917,7 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                         } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                         # Mocking SharedWowDirectory (when previously installed and should not be installed again).

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -837,13 +837,15 @@ try
             }
 
             # Start by checking whether we have the same number of parameters
-            Write-Verbose 'Verifying argument count (expected vs actual)' -Verbose
-            $mockStartWin32ProcessExpectedArgument.Keys.Count | Should BeExactly $argumentHashTable.Keys.Count
+            Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
+            
+            $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
 
+            Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
             foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
             {
-                $argumentPassed = $argumentHashTable.ContainsKey($argumentKey)
-                $argumentPassed | Should Be $true
+                $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
+                $argumentKeyName | Should Be $argumentKey
 
                 $argumentValue = $argumentHashTable.$argumentKey
                 $argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
@@ -2664,27 +2666,8 @@ try
                     $Name -eq 'ImagePath'
                 } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
 
-                # Mocking SharedDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItem_SharedDirectory -Verifiable
-
-                # Mocking SharedWowDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
+                # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
+                Mock -CommandName Get-ItemProperty -Verifiable
 
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
@@ -2711,20 +2694,6 @@ try
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
                     BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                            ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-                            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
-                        }
-
-                        if ( $mockSqlMajorVersion -eq 13 )
-                        {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
-                        }
-
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Start-Process -Verifiable
@@ -2745,6 +2714,25 @@ try
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                            ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+                            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
+                            ASSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
+                            InstanceDir = 'D:'
+                            InstallSQLDataDir = 'E:'
+                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+                        }
+
+                        if ( $mockSqlMajorVersion -eq 13 )
+                        {
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
+                        }
+
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -2753,8 +2741,12 @@ try
                             InstanceName = 'MSSQLSERVER'
                             Features = $testParameters.Features
                             SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-                            ASSysAdminAccounts = 'COMPANY\sqladmin'
+                            ASSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
                             PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+                            InstanceDir = 'D:\'
+                            InstallSQLDataDir = 'E:\'
+                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
                         }
 
                         { Set-TargetResource @testParameters } | Should Not Throw
@@ -2789,6 +2781,13 @@ try
 
                     if( $mockSqlMajorVersion -eq 13 ) {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+
                             $testParameters.Features = 'SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{}
 
@@ -2796,6 +2795,13 @@ try
                         }
 
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+
                             $testParameters.Features = 'ADV_SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{}
 
@@ -2803,6 +2809,13 @@ try
                         }
                     } else {
                         It 'Should set the system in the desired state when feature is SSMS' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+
                             $testParameters.Features = 'SSMS'
 
                             $mockStartWin32ProcessExpectedArgument = @{
@@ -2811,7 +2824,6 @@ try
                                 Action = 'Install'
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'SSMS'
-                                PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
                             }
 
                             { Set-TargetResource @testParameters } | Should Not Throw
@@ -2840,6 +2852,13 @@ try
                         }
 
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+
                             $testParameters.Features = 'ADV_SSMS'
 
                             $mockStartWin32ProcessExpectedArgument = @{
@@ -2848,7 +2867,6 @@ try
                                 Action = 'Install'
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'ADV_SSMS'
-                                PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
                             }
 
                             { Set-TargetResource @testParameters } | Should Not Throw
@@ -2892,6 +2910,28 @@ try
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
+
+                        # Mocking SharedDirectory (when previously installed and should not be installed again).
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                        } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+
+                        Mock -CommandName Get-Item -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                        } -MockWith $mockGetItem_SharedDirectory -Verifiable
+
+                        # Mocking SharedWowDirectory (when previously installed and should not be installed again).
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                        } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+
+                        Mock -CommandName Get-Item -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                        } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
 
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -838,13 +838,13 @@ try
 
             # Start by checking whether we have the same number of parameters
             Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
-            
+
             $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
 
             Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
             foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
             {
-                $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
+                $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
                 $argumentKeyName | Should Be $argumentKey
 
                 $argumentValue = $argumentHashTable.$argumentKey
@@ -3819,7 +3819,7 @@ try
                         $testParameters.Remove('Features')
                         $testParameters.Remove('SourceCredential')
                         $testParameters.Remove('ASSysAdminAccounts')
-                        
+
                         $testParameters += @{
                             Features = 'SQLENGINE'
                             InstanceName = 'MSSQLSERVER'


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier (i.e. 'E:').
  - Improved the mock that tests the setup arguments.

This Pull Request (PR) fixes the following issues:
Fixes #418 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/419)
<!-- Reviewable:end -->
