### PR TITLE
xSQLServerSetup: fixes for PrepareFailoverCluster action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Now the only mandatory path parameter is InstallSQLDataDir when installing Database Engine (issue #400).
   - It now can handle mandatory parameters, and are not using wildcards to find the variables containing paths (issue #394).
   - Changed to that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
+  - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
 - Enables CodeCov.io code coverage reporting.
 - Added badge for CodeCov.io to README.md.
 - Examples

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -880,10 +880,16 @@ function Set-TargetResource
     if ($Action -in @('PrepareFailoverCluster','CompleteFailoverCluster','InstallFailoverCluster'))
     {
         # Set the group name for this clustered instance.
-        $setupArguments += @{
-            FailoverClusterGroup = $FailoverClusterGroupName
+        # This is only required for CompleteFailoverCluster or InstallFailoverCluster
+        if ($Action -in @('CompleteFailoverCluster','InstallFailoverCluster'))
+        {
+            $setupArguments += @{
+                FailoverClusterGroup = $FailoverClusterGroupName
+            }
+        }
 
-            # This was brought over from the old module. Should be removed (breaking change).
+        # This was brought over from the old module. Should be removed (breaking change).
+        $setupArguments += @{
             SkipRules = 'Cluster_VerifyForErrors'
         }
     }
@@ -1118,10 +1124,14 @@ function Set-TargetResource
             $setupArguments += (Get-ServiceAccountParameters -ServiceAccount $AgtSvcAccount -ServiceType 'AGT')
         }
 
-        $setupArguments += @{ SQLSysAdminAccounts =  @($SetupCredential.UserName) }
-        if ($PSBoundParameters.ContainsKey('SQLSysAdminAccounts'))
+        # Should not be passed when PrepareFailoverCluster is specified
+        if ($Action -notin @('PrepareFailoverCluster'))
         {
-            $setupArguments['SQLSysAdminAccounts'] += $SQLSysAdminAccounts
+            $setupArguments += @{ SQLSysAdminAccounts =  @($SetupCredential.UserName) }
+            if ($PSBoundParameters.ContainsKey('SQLSysAdminAccounts'))
+            {
+                $setupArguments['SQLSysAdminAccounts'] += $SQLSysAdminAccounts
+            }
         }
 
         if ($SecurityMode -eq 'SQL')

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3786,7 +3786,7 @@ try
                         $testParameters.Remove('Features')
                         $testParameters.Remove('SourceCredential')
                         $testParameters.Remove('ASSysAdminAccounts')
-
+                        
                         $testParameters += @{
                             Features = 'SQLENGINE'
                             InstanceName = 'MSSQLSERVER'
@@ -3830,13 +3830,15 @@ try
                         } -Verifiable
                     }
 
-                    It 'Should add the SkipRules parameter to the installation arguments' {
+                    It 'Should pass correct arguments to the setup process' {
 
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'PrepareFailoverCluster'
                             SkipRules = 'Cluster_VerifyForErrors'
                         }
+                        $mockStartWin32ProcessExpectedArgument.Remove('FailoverClusterGroup')
+                        $mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
 
                         { Set-TargetResource @testParameters } | Should Not throw
 


### PR DESCRIPTION
This includes fixes for when the xSQLServerSetup resource is called and has a value of PrepareFailoverCluster specified for the Action parameter.

This Pull Request (PR) fixes the following issues:
Fixes #410 
Fixes #411 

- [ x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/421)
<!-- Reviewable:end -->
