### PR TITLE
xSQLServerSetup: Minor fixes for Analysis Services in Failover Cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
     - Three new parameters are added; Members, MembersToInclude and MembersToExclude.
       - Members can be set to one or more logins, and those will _replace all_ the memberships in the server role.
       - MembersToInclude and MembersToExclude can be set to one or more logins that will add or remove memberships, respectively, in the server role. MembersToInclude and MembersToExclude _can not_ be used at the same time as parameter Members. But both MembersToInclude and MembersToExclude can be used together at the same time.
+- Changes to xSQLServerSetup
+  - Added a note to the README.md saying that it is not possible to add or remove features from a SQL Server failover cluster (issue #433).
+  - Changed so that it reports false if the desired state is not correct (issue #432).
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
 - Changes to xSQLServerSetup
   - Added a note to the README.md saying that it is not possible to add or remove features from a SQL Server failover cluster (issue #433).
   - Changed so that it reports false if the desired state is not correct (issue #432).
+    - Added a test to make sure we always return false if a SQL Server failover cluster is missing features.
+  - Helper function Connect-SQLAnalysis
+    - Now has correct error handling, and throw does not used the unknown named parameter '-Message' (issue #436)
+    - Added tests for Connect-SQLAnalysis
+    - Changed to localized error messages.
+    - Minor changes to error handling.
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -953,7 +953,7 @@ function Set-TargetResource
         # Get the disk resources that are available (not assigned to a cluster role)
         $availableStorage = Get-CimInstance -Namespace 'root/MSCluster' -ClassName 'MSCluster_ResourceGroup' -Filter "Name = 'Available Storage'" |
                                 Get-CimAssociatedInstance -Association MSCluster_ResourceGroupToResource -ResultClassName MSCluster_Resource | `
-                                Add-Member -MemberType NoteProperty -Name 'IsPossibleOwner' -Value $false -PassThru
+                                    Add-Member -MemberType NoteProperty -Name 'IsPossibleOwner' -Value $false -PassThru
 
         # First map regular cluster volumes
         foreach ($diskResource in $availableStorage)
@@ -1651,11 +1651,10 @@ function Test-TargetResource
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
     New-VerboseMessage -Message "Features found: '$($getTargetResourceResult.Features)'"
 
-    $result = $false
+    $result = $true
+
     if ($getTargetResourceResult.Features )
     {
-        $result = $true
-
         foreach ($feature in $Features.Split(","))
         {
             # Given that all the returned features are uppercase, make sure that the feature to search for is also uppercase
@@ -1668,12 +1667,14 @@ function Test-TargetResource
             }
         }
     }
+    else
+    {
+        $result = $false
+    }
 
     if ($PSCmdlet.ParameterSetName -eq 'ClusterInstall')
     {
         New-VerboseMessage -Message "Clustered install, checking parameters."
-
-        $result = $true
 
         $boundParameters.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
             $variableName = $_
@@ -1685,7 +1686,7 @@ function Test-TargetResource
         }
     }
 
-    $result
+    return $result
 }
 
 <#

--- a/README.md
+++ b/README.md
@@ -895,6 +895,9 @@ Installs SQL Server on the target node.
     * ASSysAdminAccounts
     * AsSvcAccount
 
+> **Note:** It is not possible to add or remove features to a SQL Server failover cluster. This is a limitation of SQL Server.
+> See article [You cannot add or remove features to a SQL Server 2008, SQL Server 2008 R2, or SQL Server 2012 failover cluster](https://support.microsoft.com/en-us/help/2547273/you-cannot-add-or-remove-features-to-a-sql-server-2008,-sql-server-2008-r2,-or-sql-server-2012-failover-cluster).
+
 #### Parameters
 
 * **[String] Action** _(Write)_: The action to be performed. Defaults to 'Install'. *Note: AddNode is not currently functional.* { _Install_ | InstallFailoverCluster | AddNode | PrepareFailoverCluster | CompleteFailoverCluster }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2389,12 +2389,13 @@ try
                     $result | Should Be $false
                 }
 
-                It 'Should return false if SQL Server failover cluster is missing features ' {
+                # This is a test for regression testing of issue #432
+                It 'Should return false if a SQL Server failover cluster is missing features' {
                     $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
-                                Features = 'SQLEngine,AS'
+                                Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
                                 FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                                 FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                                 FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
@@ -2623,6 +2624,32 @@ try
 
                     $result = Test-TargetResource @testClusterParameters
 
+                    $result | Should Be $true
+                }
+
+                # This is a test for regression testing of issue #432
+                It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                                Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
+                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            }
+                    } -Verifiable
+
+                    $testClusterParameters = $testParameters.Clone()
+                    $testClusterParameters['Features'] = 'SQLEngine,AS'
+
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+
+                    $result = Test-TargetResource @testClusterParameters
                     $result | Should Be $true
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2388,6 +2388,31 @@ try
 
                     $result | Should Be $false
                 }
+
+                It 'Should return false if SQL Server failover cluster is missing features ' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                                Features = 'SQLEngine,AS'
+                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            }
+                    } -Verifiable
+
+                    $testClusterParameters = $testParameters.Clone()
+                    $testClusterParameters['Features'] = 'SQLEngine,AS'
+
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+
+                    $result = Test-TargetResource @testClusterParameters
+                    $result | Should Be $false
+                }
             }
 
             # For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -288,7 +288,7 @@ InModuleScope $script:moduleName {
                     -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter `
                     -Verifiable
 
-                $mockCorrectErrorMessage = 'Failed to connect to Analysis Services ''PC01''. InnerException: Did not get the expected Analysis Services server object.'
+                $mockCorrectErrorMessage = ('Failed to connect to Analysis Services ''{0}''. InnerException: Did not get the expected Analysis Services server object.' -f $env:COMPUTERNAME)
                 { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
 
                 Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
@@ -303,7 +303,7 @@ InModuleScope $script:moduleName {
                 # Force the mock of Connect() method to throw 'Unable to connect.'
                 $mockThrowInvalidOperation = $true
 
-                $mockCorrectErrorMessage = 'Failed to connect to Analysis Services ''PC01''. InnerException: Exception calling "Connect" with "1" argument(s): "Unable to connect."'
+                $mockCorrectErrorMessage = ('Failed to connect to Analysis Services ''{0}''. InnerException: Exception calling "Connect" with "1" argument(s): "Unable to connect."'  -f $env:COMPUTERNAME)
                 { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
 
                 Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -1,3 +1,7 @@
+# To run these tests, we have to fake login credentials
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 # Unit Test Template Version: 1.1.0
 
 $script:moduleName = 'xSQLServerHelper'
@@ -17,10 +21,41 @@ Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stub
 
 # Begin Testing
 InModuleScope $script:moduleName {
+    $mockNewObject_MicrosoftAnalysisServicesServer = {
+        return New-Object Object |
+                    Add-Member ScriptMethod Connect {
+                        param(
+                            [Parameter(Mandatory = $true)]
+                            [ValidateNotNullOrEmpty()]
+                            [System.String]
+                            $dataSource
+                        )
+
+                        if ($dataSource -ne $mockExpectedDataSource)
+                        {
+                            throw ("Datasource was expected to be '{0}', but was '{1}'." -f $mockExpectedDataSource,$dataSource)
+                        }
+
+                        if ($mockThrowInvalidOperation)
+                        {
+                            throw 'Unable to connect.'
+                        }
+                    } -PassThru -Force
+    }
+
+    $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter = {
+        $TypeName -eq 'Microsoft.AnalysisServices.Server'
+    }
+
+    $mockInstanceName = 'TEST'
+
+    $mockSetupCredentialUserName = 'TestUserName12345'
+    $mockSetupCredentialPassword = 'StrongOne7.'
+    $mockSetupCredentialSecurePassword = ConvertTo-SecureString -String $mockSetupCredentialPassword -AsPlainText -Force
+    $mockSetupCredential = New-Object PSCredential ($mockSetupCredentialUserName, $mockSetupCredentialSecurePassword)
+
     Describe 'Testing Restart-SqlService' {
-
         Context 'Restart-SqlService standalone instance' {
-
             Mock -CommandName Connect-SQL -MockWith {
                 return @{
                     Name = 'MSSQLSERVER'
@@ -51,7 +86,7 @@ InModuleScope $script:moduleName {
                     Name = 'MSSQLSERVER'
                     DisplayName = 'Microsoft SQL Server (MSSQLSERVER)'
                     DependentServices = @(
-                        @{ 
+                        @{
                             Name = 'SQLSERVERAGENT'
                             DisplayName = 'SQL Server Agent (MSSQLSERVER)'
                             Status = 'Running'
@@ -76,7 +111,7 @@ InModuleScope $script:moduleName {
                     Name = 'MSSQL$STOPPEDAGENT'
                     DisplayName = 'Microsoft SQL Server (STOPPEDAGENT)'
                     DependentServices = @(
-                        @{ 
+                        @{
                             Name = 'SQLAGENT$STOPPEDAGENT'
                             DisplayName = 'SQL Server Agent (STOPPEDAGENT)'
                             Status = 'Stopped'
@@ -119,7 +154,6 @@ InModuleScope $script:moduleName {
         }
 
         Context 'Restart-SqlService clustered instance' {
-            
             Mock -CommandName Connect-SQL -MockWith {
                 return @{
                     Name = 'MSSQLSERVER'
@@ -150,7 +184,7 @@ InModuleScope $script:moduleName {
             Mock -CommandName Get-CimInstance -MockWith {
                 @('MSSQLSERVER','NAMEDINSTANCE','STOPPEDAGENT') | ForEach-Object {
                     $mock = New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster'
-                    
+
                     $mock | Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($($_))" -TypeName 'String'
                     $mock | Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String'
                     $mock | Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $_ }
@@ -161,26 +195,26 @@ InModuleScope $script:moduleName {
 
             Mock -CommandName Get-CimAssociatedInstance -MockWith {
                 $mock = New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster'
-                    
+
                 $mock | Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server Agent ($($InputObject.PrivateProperties.InstanceName))" -TypeName 'String'
                 $mock | Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server Agent' -TypeName 'String'
                 $mock | Add-Member -MemberType NoteProperty -Name 'State' -Value (@{ $true = 3; $false = 2 }[($InputObject.PrivateProperties.InstanceName -eq 'STOPPEDAGENT')]) -TypeName 'Int32'
-                
+
                 return $mock
             } -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
 
             Mock -CommandName Invoke-CimMethod -MockWith {} -Verifiable -ParameterFilter { $MethodName -eq 'TakeOffline' }
 
-            Mock -CommandName Invoke-CimMethod -MockWith {} -Verifiable -ParameterFilter { $MethodName -eq 'BringOnline' } 
+            Mock -CommandName Invoke-CimMethod -MockWith {} -Verifiable -ParameterFilter { $MethodName -eq 'BringOnline' }
 
             It 'Should restart SQL Server and SQL Agent resources for a clustered default instance' {
                 { Restart-SqlService -SQLServer 'CLU01' } | Should Not Throw
-                
+
                 Assert-MockCalled -CommandName Connect-SQL -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Get-CimInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Get-CimAssociatedInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2 
+                Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2
             }
 
             It 'Should restart SQL Server and SQL Agent resources for a clustered named instance' {
@@ -190,7 +224,7 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Get-CimInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Get-CimAssociatedInstance -Scope It -Exactly -Times 1
                 Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'TakeOffline' } -Scope It -Exactly -Times 1
-                Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2 
+                Assert-MockCalled -CommandName Invoke-CimMethod -ParameterFilter { $MethodName -eq 'BringOnline' } -Scope It -Exactly -Times 2
             }
 
             It 'Should not try to restart a SQL Agent resource that is not online' {
@@ -205,13 +239,104 @@ InModuleScope $script:moduleName {
         }
     }
 
+    Describe 'Testing Connect-SQLAnalysis' {
+        BeforeEach {
+            Mock -CommandName New-Object `
+                -MockWith $mockNewObject_MicrosoftAnalysisServicesServer `
+                -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter `
+                -Verifiable
+        }
+
+        Context 'When connecting to the dafault instance using Windows Authentication' {
+            It 'Should not throw when connecting' {
+                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+
+                { Connect-SQLAnalysis } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+            }
+        }
+
+        Context 'When connecting to the named instance using Windows Authentication' {
+            It 'Should not throw when connecting' {
+                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
+
+                { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+            }
+        }
+
+        Context 'When connecting to the named instance using Windows Authentication impersonation' {
+            It 'Should not throw when connecting' {
+                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockSetupCredentialUserName;Password=$mockSetupCredentialPassword"
+
+                { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName -SetupCredential $mockSetupCredential } | Should -Not -Throw
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+            }
+        }
+
+        Context 'When connecting to the default instance using the correct service instance but does not return a correct Analysis Service object' {
+            It 'Should throw the correct error' {
+                $mockExpectedDataSource = ''
+
+                Mock -CommandName New-Object `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter `
+                    -Verifiable
+
+                $mockCorrectErrorMessage = 'Failed to connect to Analysis Services ''PC01''. InnerException: Did not get the expected Analysis Services server object.'
+                { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+            }
+        }
+
+        Context 'When connecting to the default instance using a Analysis Service instance that does not exist' {
+            It 'Should throw the correct error' {
+                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+
+                # Force the mock of Connect() method to throw 'Unable to connect.'
+                $mockThrowInvalidOperation = $true
+
+                $mockCorrectErrorMessage = 'Failed to connect to Analysis Services ''PC01''. InnerException: Exception calling "Connect" with "1" argument(s): "Unable to connect."'
+                { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+
+                # Setting it back to the default so it does not disturb other tests.
+                $mockThrowInvalidOperation = $false
+            }
+        }
+
+        # This test is to test the mock so that it throws correct when data source is not the expected data source
+        Context 'When connecting to the named instance using another data source then expected' {
+            It 'Should throw the correct error' {
+                $mockExpectedDataSource = "Force wrong datasource"
+
+                $mockCorrectErrorMessage = 'Failed to connect to Analysis Services ''DummyHost\TEST''. InnerException: Exception calling "Connect" with "1" argument(s): "Datasource was expected to be ''Force wrong datasource'', but was ''Data Source=DummyHost\TEST''."'
+                { Connect-SQLAnalysis -SQLServer 'DummyHost' -SQLInstanceName $mockInstanceName } | Should -Throw $mockCorrectErrorMessage
+
+                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
     Describe "Testing Get-SqlDatabasePermission" {
         $mockSqlServerObject = [pscustomobject]@{
             InstanceName = 'MSSQLSERVER'
             ComputerNamePhysicalNetBIOS = 'SQL01'
         }
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value {
             return @{
                 'AdventureWorks' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Database -ArgumentList @( $null, 'AdventureWorks') ) )
             } | Add-Member -MemberType ScriptMethod -Name EnumDatabasePermissions -Value {
@@ -221,12 +346,12 @@ InModuleScope $script:moduleName {
             } -PassThru -Force
         } -PassThru -Force
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value {
             return @{
                 'CONTOSO\SqlAdmin' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'CONTOSO\SqlAdmin') -Property @{ LoginType = 'WindowsUser'} ) )
             }
         } -PassThru -Force
-            
+
 
         Context 'When the specified database does not exist' {
             $testParameters = @{
@@ -235,7 +360,7 @@ InModuleScope $script:moduleName {
                 Database = 'UnknownDatabase'
                 PermissionState = 'Grant'
             }
-            
+
             It 'Should throw the correct error' {
                 { Get-SqlDatabasePermission @testParameters } | Should Throw "Database 'UnknownDatabase' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -248,7 +373,7 @@ InModuleScope $script:moduleName {
                 Database = 'AdventureWorks'
                 PermissionState = 'Grant'
             }
-            
+
             It 'Should throw the correct error' {
                 { Get-SqlDatabasePermission @testParameters } | Should Throw "Login 'CONTOSO\UnknownUser' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -265,10 +390,10 @@ InModuleScope $script:moduleName {
             It 'Should not return any permissions' {
                 [Microsoft.SqlServer.Management.Smo.Globals]::GenerateMockData = $false
 
-                $permission = Get-SqlDatabasePermission @testParameters 
+                $permission = Get-SqlDatabasePermission @testParameters
                 $permission | Should BeNullOrEmpty
             }
-            
+
         }
 
         Context 'When the specified database and login exist and the system is in desired state' {
@@ -284,7 +409,7 @@ InModuleScope $script:moduleName {
 
                 $permission = Get-SqlDatabasePermission @testParameters
                 $permission -contains 'Connect' | Should Be $true
-                $permission -contains 'Update' | Should Be $true 
+                $permission -contains 'Update' | Should Be $true
             }
         }
 
@@ -301,13 +426,13 @@ InModuleScope $script:moduleName {
                 }
             }
         }
-        
+
         Context 'When the specified database does not exist' {
             $testParameters = @{
                 SqlServerObject = $mockSqlServerObject
                 DatabaseName    = 'UnknownDatabase'
             }
-            
+
             It 'Should throw the correct error' {
                 { Get-SqlDatabaseRecoveryModel @testParameters } | Should Throw "Database 'UnknownDatabase' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -320,9 +445,9 @@ InModuleScope $script:moduleName {
             }
 
             It 'Should return the current RecoveryModel' {
-                $recoveryModel = Get-SqlDatabaseRecoveryModel @testParameters 
+                $recoveryModel = Get-SqlDatabaseRecoveryModel @testParameters
                 $recoveryModel | Should Be $testParameters.SqlServerObject.Databases.AdventureWorks.RecoveryModel
-            }            
+            }
         }
 
         Assert-VerifiableMocks
@@ -350,7 +475,7 @@ InModuleScope $script:moduleName {
                 DatabaseName    = 'UnknownDatabase'
                 RecoveryModel   = 'Simple'
             }
-            
+
             It 'Should throw the correct error' {
                 { Set-SqlDatabaseRecoveryModel @testParameters } | Should Throw "Database 'UnknownDatabase' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -366,7 +491,7 @@ InModuleScope $script:moduleName {
             It 'Should set the correct RecoveryModel without throwing an error' {
                 $mockExpectedRecoveryModelForAlterMethod = $testParameters.RecoveryModel
                 { Set-SqlDatabaseRecoveryModel @testParameters } | Should Not Throw
-            }            
+            }
         }
 
         Assert-VerifiableMocks
@@ -378,7 +503,7 @@ InModuleScope $script:moduleName {
             ComputerNamePhysicalNetBIOS = 'SQL01'
         }
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value {
             return @{
                 'AdventureWorks' = @(
                     (
@@ -398,12 +523,12 @@ InModuleScope $script:moduleName {
             } -PassThru -Force
         } -PassThru -Force
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value {
             return @{
                 'CONTOSO\SqlAdmin' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'CONTOSO\SqlAdmin') -Property @{ LoginType = 'WindowsUser'} ) )
             }
         } -PassThru -Force
-            
+
         Context 'When the specified database and login exist and the system is not in desired state' {
             $testParameters = @{
                 Sql             = $mockSqlServerObject
@@ -415,7 +540,7 @@ InModuleScope $script:moduleName {
 
             It 'Should add permissions to the specified database' {
                 Add-SqlDatabasePermission @testParameters
-            }            
+            }
         }
 
         Context 'When the specified database does not exist' {
@@ -426,7 +551,7 @@ InModuleScope $script:moduleName {
                 PermissionState = 'Grant'
                 Permissions     = @( 'Connect','Update' )
             }
-            
+
             It 'Should throw the correct error' {
                 { Add-SqlDatabasePermission @testParameters } | Should Throw "Database 'UnknownDatabase' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -440,7 +565,7 @@ InModuleScope $script:moduleName {
                 PermissionState = 'Grant'
                 Permissions     = @( 'Connect','Update' )
             }
-            
+
             It 'Should throw the correct error' {
                 { Add-SqlDatabasePermission @testParameters } | Should Throw "Login 'CONTOSO\UnknownUser' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -455,7 +580,7 @@ InModuleScope $script:moduleName {
             ComputerNamePhysicalNetBIOS = 'SQL01'
         }
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Databases -Value {
             return @{
                 'AdventureWorks' = @(
                     (
@@ -475,12 +600,12 @@ InModuleScope $script:moduleName {
             } -PassThru -Force
         } -PassThru -Force
 
-        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value { 
+        $mockSqlServerObject = $mockSqlServerObject | Add-Member -MemberType ScriptProperty -Name Logins -Value {
             return @{
                 'CONTOSO\SqlAdmin' = @( ( New-Object Microsoft.SqlServer.Management.Smo.Login -ArgumentList @( $null, 'CONTOSO\SqlAdmin') -Property @{ LoginType = 'WindowsUser'} ) )
             }
         } -PassThru -Force
-            
+
         Context 'When the specified database and login exist and the system is not in desired state' {
             $testParameters = @{
                 Sql             = $mockSqlServerObject
@@ -492,7 +617,7 @@ InModuleScope $script:moduleName {
 
             It 'Should remove permissions to the specified database' {
                 Remove-SqlDatabasePermission @testParameters
-            }            
+            }
         }
 
         Context 'When the specified database does not exist' {
@@ -503,7 +628,7 @@ InModuleScope $script:moduleName {
                 PermissionState = 'Grant'
                 Permissions     = @( 'Connect','Update' )
             }
-            
+
             It 'Should throw the correct error' {
                 { Remove-SqlDatabasePermission @testParameters } | Should Throw "Database 'UnknownDatabase' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -517,7 +642,7 @@ InModuleScope $script:moduleName {
                 PermissionState = 'Grant'
                 Permissions     = @( 'Connect','Update' )
             }
-            
+
             It 'Should throw the correct error' {
                 { Remove-SqlDatabasePermission @testParameters } | Should Throw "Login 'CONTOSO\UnknownUser' does not exist on SQL server 'SQL01\MSSQLSERVER'."
             }
@@ -525,7 +650,7 @@ InModuleScope $script:moduleName {
 
         Assert-VerifiableMocks
     }
-    
+
     Describe 'Testing Invoke-Query' {
         $mockExpectedQuery = ''
 
@@ -570,7 +695,7 @@ InModuleScope $script:moduleName {
                 )
             )
         }
-        
+
         BeforeEach {
             Mock -CommandName Connect-SQL -MockWith $mockConnectSql -ModuleName $script:DSCResourceName -Verifiable
         }
@@ -582,12 +707,12 @@ InModuleScope $script:moduleName {
             Database = 'master'
             Query = ''
         }
-        
+
         Context 'Execute a query with no results' {
             It 'Should execute the query silently' {
                 $queryParams.Query = "EXEC sp_configure 'show advanced option', '1'"
                 $mockExpectedQuery = $queryParams.Query.Clone()
-                
+
                 { Invoke-Query @queryParams } | Should Not Throw
 
                 Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -596,7 +721,7 @@ InModuleScope $script:moduleName {
 
             It 'Should throw the correct error, ExecuteNonQueryFailed, when executing the query fails' {
                 $queryParams.Query = 'BadQuery'
-                
+
                 { Invoke-Query @queryParams } | Should Throw 'ExecuteNonQueryFailed'
 
                 Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -608,7 +733,7 @@ InModuleScope $script:moduleName {
             It 'Should execute the query and return a result set' {
                 $queryParams.Query = 'SELECT name FROM sys.databases'
                 $mockExpectedQuery = $queryParams.Query.Clone()
-                
+
                 Invoke-Query @queryParams -WithResults | Should Not BeNullOrEmpty
 
                 Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -617,7 +742,7 @@ InModuleScope $script:moduleName {
 
             It 'Should throw the correct error, ExecuteQueryWithResultsFailed, when executing the query fails' {
                 $queryParams.Query = 'BadQuery'
-                
+
                 { Invoke-Query @queryParams -WithResults } | Should Throw 'ExecuteQueryWithResultsFailed'
 
                 Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -1,13 +1,13 @@
 ConvertFrom-StringData @'
-###PSLOC 
+###PSLOC
 # Common
 NoKeyFound = No Localization key found for ErrorType: '{0}'.
 AbsentNotImplemented = Ensure = Absent is not implemented!
 TestFailedAfterSet = Test-TargetResource returned false after calling set.
 RemoteConnectionFailed = Remote PowerShell connection to Server '{0}' failed.
-TODO = ToDo. Work not implemented at this time. 
+TODO = ToDo. Work not implemented at this time.
 UnexpectedErrorFromGet = Got unexpected result from Get-TargetResource. No change is made.
-FailedToImportSQLPSModule = Failed to import SQLPS module. 
+FailedToImportSQLPSModule = Failed to import SQLPS module.
 NotConnectedToInstance = Was unable to connect to the instance '{0}\\{1}'
 
 # SQLServer
@@ -77,6 +77,8 @@ RemoveAvailabilityGroupFailed = Failed to remove the availabilty group '{0}' fro
 # SQLServerHelper
 ExecuteQueryWithResultsFailed = Executing query with results failed on database '{0}'.
 ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.
+AnalysisServicesFailedToConnect = Failed to connect to Analysis Services '{0}'.
+AnalysisServicesNoServerObject = Did not get the expected Analysis Services server object.
 
 # Max degree of parallelism
 MaxDopSetError = Unexpected result when trying to configure the max degree of parallelism server configuration option.


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - Added a note to the README.md saying that it is not possible to add or remove features from a SQL Server failover cluster (issue #433).
  - Changed so that it reports false if the desired state is not correct (issue #432).
    - Added a test to make sure we always return false if a SQL Server failover cluster is missing features.
  - Helper function Connect-SQLAnalysis
    - Now has correct error handling, and throw does not used the unknown named parameter '-Message' (issue #436)
    - Added tests for Connect-SQLAnalysis
    - Changed to localized error messages.
    - Minor changes to error handling.
 
This Pull Request (PR) fixes the following issues:
Fixes #432 
Fixes #433 
Fixes #436 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/438)
<!-- Reviewable:end -->
