### PR TITLE
xSQLServer: Raised the codecov target to 70%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,9 +14,8 @@ coverage:
   status:
     project:
       default:
-        # Set the overall project code coverage requirement to 68
-        # This should be 70
-        target: 68
+        # Set the overall project code coverage requirement to 70%
+        target: 70
     patch:
       default:
         # Set the pull request requirement to not regress overall coverage by more than 5%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     - 2-RemoveDatabaseRole.ps1
 - Changes to xSQLServerDatabaseRole
   - Fixed code style, added updated parameter descriptions to schema.mof and README.md.
+- Changes to xSQLServer
+  - Raised the CodeCov target to 70% which is the minimum and required target for HQRM resource.
 
 ## 6.0.0.0
 


### PR DESCRIPTION
Raised the CodeCov target to 70% which is the minimum and required target for HQRM resource.

_We limited it until we reache 70% so that it would no fail on the PR's. But now we have reached that target! Many thanks to @luigilink for going back and fixing already present test to get more coverage!_ 👍 😃   

This Pull Request (PR) fixes the following issues:
n/a

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/439)
<!-- Reviewable:end -->
