### PR TITLE
xSQLServerSetup: Adds better support for action 'Addnode'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@
   - xSQLServerDatabaseRole
     - 1-AddDatabaseRole.ps1
     - 2-RemoveDatabaseRole.ps1
-  - xSQLServerRole, add examples:
+  - xSQLServerRole
     - 3-AddMembersToServerRole.ps1
     - 4-MembersToIncludeInServerRole.ps1
     - 5-MembersToExcludeInServerRole.ps1
+  - xSQLServerSetup
+    - 1-InstallDefaultInstanceSingleServer.ps1
+    - 2-InstallNamedInstanceSingleServer.ps1
+    - 3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
 - Changes to xSQLServerDatabaseRole
   - Fixed code style, added updated parameter descriptions to schema.mof and README.md.
 - Changes to xSQLServer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
     - Added tests for Connect-SQLAnalysis
     - Changed to localized error messages.
     - Minor changes to error handling.
+  - This adds better support for Addnode (issue #369).
+  - Now it skips cluster validation för add node (issue #442).
+  - Now it ignores parameters that are not allowed for action Addnode (issue #441).
 - Added new resource
   - xSQLServerAlwaysOnAvailabilityGroupReplica
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     - 1-InstallDefaultInstanceSingleServer.ps1
     - 2-InstallNamedInstanceSingleServer.ps1
     - 3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+    - 4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
+    - 5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
 - Changes to xSQLServerDatabaseRole
   - Fixed code style, added updated parameter descriptions to schema.mof and README.md.
 - Changes to xSQLServer

--- a/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
@@ -1,0 +1,70 @@
+<#
+.EXAMPLE
+    This example shows how to install a default instance of SQL Server on a single server.
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35' {
+           Name = 'NET-Framework-Core'
+           Source = $node.WindowsSourceSxs
+           Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45' {
+           Name = 'NET-Framework-45-Core'
+           Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        xSQLServerSetup 'InstallDefaultInstance'
+        {
+            InstanceName = 'MSSQLSERVER'
+            Features = 'SQLENGINE,AS'
+            SQLCollation = 'SQL_Latin1_General_CP1_CI_AS'
+            SQLSvcAccount = $SqlServiceCredential
+            AgtSvcAccount = $SqlAgentServiceCredential
+            ASSvcAccount = $SqlServiceCredential
+            SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            SetupCredential = $SqlInstallCredential
+            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
+            InstanceDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\User"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\User"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Temp"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Temp"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Backup"
+            SourcePath = 'C:\InstallMedia\SQL2016RTM'
+            UpdateEnabled = 'False'
+            ForceReboot = $false
+
+            DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
@@ -12,19 +12,27 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlServiceCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer
@@ -34,7 +42,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
            Ensure = 'Present'
         }
 
@@ -56,15 +64,15 @@ Configuration Example
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
-            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
-            InstanceDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Backup"
+            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSQLDataDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLUserDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLUserDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLTempDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLTempDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data'
+            SQLBackupDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Backup'
             ASConfigDir = 'C:\MSOLAP\Config'
             ASDataDir = 'C:\MSOLAP\Data'
             ASLogDir = 'C:\MSOLAP\Log'

--- a/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
@@ -2,7 +2,7 @@
     .EXAMPLE
         This example shows how to install a default instance of SQL Server on a single server.
     .NOTES
-        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        SQL Server setup is run using the SYSTEM account. Even if SetupCredential is provided
         it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
@@ -34,7 +34,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = $node.WindowsSourceSxs
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
            Ensure = 'Present'
         }
 
@@ -44,6 +44,7 @@ Configuration Example
         }
         #endregion Install prerequisites for SQL Server
 
+        #region Install SQL Server
         xSQLServerSetup 'InstallDefaultInstance'
         {
             InstanceName = 'MSSQLSERVER'
@@ -53,21 +54,28 @@ Configuration Example
             AgtSvcAccount = $SqlAgentServiceCredential
             ASSvcAccount = $SqlServiceCredential
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
             InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
             InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
             InstanceDir = "C:\Program Files\Microsoft SQL Server"
             InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\User"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\User"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Temp"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Temp"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data\Backup"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Data"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Backup"
+            ASConfigDir = 'C:\MSOLAP\Config'
+            ASDataDir = 'C:\MSOLAP\Data'
+            ASLogDir = 'C:\MSOLAP\Log'
+            ASBackupDir = 'C:\MSOLAP\Backup'
+            ASTempDir = 'C:\MSOLAP\Temp'
             SourcePath = 'C:\InstallMedia\SQL2016RTM'
             UpdateEnabled = 'False'
             ForceReboot = $false
 
             DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
         }
+        #endregion Install SQL Server
     }
 }

--- a/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1
@@ -1,6 +1,9 @@
 <#
-.EXAMPLE
-    This example shows how to install a default instance of SQL Server on a single server.
+    .EXAMPLE
+        This example shows how to install a default instance of SQL Server on a single server.
+    .NOTES
+        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
 {
@@ -9,19 +12,19 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlInstallCredential,
+        [PsCredential] $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlServiceCredential,
+        [PsCredential] $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer

--- a/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
@@ -1,0 +1,71 @@
+<#
+.EXAMPLE
+    This example shows how to install a named instance of SQL Server on a single server.
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35' {
+           Name = 'NET-Framework-Core'
+           Source = $node.WindowsSourceSxs
+           Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45' {
+           Name = 'NET-Framework-45-Core'
+           Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        xSQLServerSetup 'InstallNamedInstance-INST2016'
+        {
+            InstanceName = 'INST2016'
+            Features = 'SQLENGINE,AS'
+            SQLCollation = 'SQL_Latin1_General_CP1_CI_AS'
+            SQLSvcAccount = $SqlServiceCredential
+            AgtSvcAccount = $SqlAgentServiceCredential
+            ASSvcAccount = $SqlServiceCredential
+            SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            SetupCredential = $SqlInstallCredential
+            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
+            InstanceDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Backup"
+            SourcePath = 'C:\InstallMedia\SQL2016RTM'
+            UpdateEnabled = 'False'
+            ForceReboot = $false
+            BrowserSvcStartupType = 'Automatic'
+
+            DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
@@ -12,19 +12,27 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlServiceCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer
@@ -34,7 +42,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
            Ensure = 'Present'
         }
 
@@ -56,15 +64,15 @@ Configuration Example
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
-            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
-            InstanceDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup"
+            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSQLDataDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLUserDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLUserDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLTempDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLTempDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLBackupDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup'
             ASConfigDir = 'C:\MSOLAP13.INST2016\Config'
             ASDataDir = 'C:\MSOLAP13.INST2016\Data'
             ASLogDir = 'C:\MSOLAP13.INST2016\Log'

--- a/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
@@ -1,6 +1,9 @@
 <#
-.EXAMPLE
-    This example shows how to install a named instance of SQL Server on a single server.
+    .EXAMPLE
+        This example shows how to install a named instance of SQL Server on a single server.
+    .NOTES
+        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
 {
@@ -9,19 +12,19 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlInstallCredential,
+        [PsCredential] $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlServiceCredential,
+        [PsCredential] $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer

--- a/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
+++ b/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1
@@ -2,7 +2,7 @@
     .EXAMPLE
         This example shows how to install a named instance of SQL Server on a single server.
     .NOTES
-        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        SQL Server setup is run using the SYSTEM account. Even if SetupCredential is provided
         it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
@@ -34,7 +34,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = $node.WindowsSourceSxs
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
            Ensure = 'Present'
         }
 
@@ -44,6 +44,7 @@ Configuration Example
         }
         #endregion Install prerequisites for SQL Server
 
+        #region Install SQL Server
         xSQLServerSetup 'InstallNamedInstance-INST2016'
         {
             InstanceName = 'INST2016'
@@ -53,16 +54,22 @@ Configuration Example
             AgtSvcAccount = $SqlAgentServiceCredential
             ASSvcAccount = $SqlServiceCredential
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
             InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
             InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
             InstanceDir = "C:\Program Files\Microsoft SQL Server"
             InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Backup"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup"
+            ASConfigDir = 'C:\MSOLAP13.INST2016\Config'
+            ASDataDir = 'C:\MSOLAP13.INST2016\Data'
+            ASLogDir = 'C:\MSOLAP13.INST2016\Log'
+            ASBackupDir = 'C:\MSOLAP13.INST2016\Backup'
+            ASTempDir = 'C:\MSOLAP13.INST2016\Temp'
             SourcePath = 'C:\InstallMedia\SQL2016RTM'
             UpdateEnabled = 'False'
             ForceReboot = $false
@@ -70,5 +77,6 @@ Configuration Example
 
             DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
         }
+        #endregion Install SQL Server
     }
 }

--- a/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+++ b/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
@@ -1,0 +1,74 @@
+<#
+.EXAMPLE
+    This example shows how to install a named instance of SQL Server on a single server, from an UNC path.
+.NOTES
+    For this to work the credentials assigned to SourceCredential must have read permission on the share and on the UNC path.
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35' {
+           Name = 'NET-Framework-Core'
+           Source = $node.WindowsSourceSxs
+           Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45' {
+           Name = 'NET-Framework-45-Core'
+           Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        xSQLServerSetup 'InstallNamedInstance-INST2016'
+        {
+            InstanceName = 'INST2016'
+            Features = 'SQLENGINE,AS'
+            SQLCollation = 'SQL_Latin1_General_CP1_CI_AS'
+            SQLSvcAccount = $SqlServiceCredential
+            AgtSvcAccount = $SqlAgentServiceCredential
+            ASSvcAccount = $SqlServiceCredential
+            SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            SetupCredential = $SqlInstallCredential
+            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
+            InstanceDir = "C:\Program Files\Microsoft SQL Server"
+            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Backup"
+            SourcePath = '\\fileserver.compant.local\images$\SQL2016RTM'
+            SourceCredential = $SqlInstallCredential
+            UpdateEnabled = 'False'
+            ForceReboot = $false
+            BrowserSvcStartupType = 'Automatic'
+
+            DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+++ b/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
@@ -2,9 +2,11 @@
     .EXAMPLE
         This example shows how to install a named instance of SQL Server on a single server, from an UNC path.
     .NOTES
-        For this to work the credentials assigned to SourceCredential must have read permission on the share and on the UNC path.
+        Assumes the credentials assigned to SourceCredential have read permission on the share and on the UNC path.
+        The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
+        that the SYSTEM account can access the media locally.
 
-        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        SQL Server setup is run using the SYSTEM account. Even if SetupCredential is provided
         it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
@@ -36,7 +38,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = $node.WindowsSourceSxs
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
            Ensure = 'Present'
         }
 
@@ -46,6 +48,7 @@ Configuration Example
         }
         #endregion Install prerequisites for SQL Server
 
+        #region Install SQL Server
         xSQLServerSetup 'InstallNamedInstance-INST2016'
         {
             InstanceName = 'INST2016'
@@ -55,16 +58,22 @@ Configuration Example
             AgtSvcAccount = $SqlAgentServiceCredential
             ASSvcAccount = $SqlServiceCredential
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
             InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
             InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
             InstanceDir = "C:\Program Files\Microsoft SQL Server"
             InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\User"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Temp"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data\Backup"
+            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
+            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup"
+            ASConfigDir = 'C:\MSOLAP13.INST2016\Config'
+            ASDataDir = 'C:\MSOLAP13.INST2016\Data'
+            ASLogDir = 'C:\MSOLAP13.INST2016\Log'
+            ASBackupDir = 'C:\MSOLAP13.INST2016\Backup'
+            ASTempDir = 'C:\MSOLAP13.INST2016\Temp'
             SourcePath = '\\fileserver.compant.local\images$\SQL2016RTM'
             SourceCredential = $SqlInstallCredential
             UpdateEnabled = 'False'
@@ -73,5 +82,6 @@ Configuration Example
 
             DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
         }
+        #endregion Install SQL Server
     }
 }

--- a/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+++ b/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
@@ -16,19 +16,27 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlServiceCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer
@@ -38,7 +46,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
            Ensure = 'Present'
         }
 
@@ -60,15 +68,15 @@ Configuration Example
             SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
             SetupCredential = $SqlInstallCredential
-            InstallSharedDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSharedWOWDir = "C:\Program Files (x86)\Microsoft SQL Server"
-            InstanceDir = "C:\Program Files\Microsoft SQL Server"
-            InstallSQLDataDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLUserDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLTempDBDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLTempDBLogDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data"
-            SQLBackupDir = "C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup"
+            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSQLDataDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLUserDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLUserDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLTempDBDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLTempDBLogDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Data'
+            SQLBackupDir = 'C:\Program Files\Microsoft SQL Server\MSSQL13.INST2016\MSSQL\Backup'
             ASConfigDir = 'C:\MSOLAP13.INST2016\Config'
             ASDataDir = 'C:\MSOLAP13.INST2016\Data'
             ASLogDir = 'C:\MSOLAP13.INST2016\Log'

--- a/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
+++ b/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1
@@ -1,8 +1,11 @@
 <#
-.EXAMPLE
-    This example shows how to install a named instance of SQL Server on a single server, from an UNC path.
-.NOTES
-    For this to work the credentials assigned to SourceCredential must have read permission on the share and on the UNC path.
+    .EXAMPLE
+        This example shows how to install a named instance of SQL Server on a single server, from an UNC path.
+    .NOTES
+        For this to work the credentials assigned to SourceCredential must have read permission on the share and on the UNC path.
+
+        SQL Server setup.exe is run using the SYSTEM account. Even if SetupCredential is provided
+        it is not used to install SQL Server at this time (see issue #139).
 #>
 Configuration Example
 {
@@ -11,19 +14,19 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlInstallCredential,
+        [PsCredential] $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAdministratorCredential = $SqlInstallCredential,
+        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlServiceCredential,
+        [PsCredential] $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential]$SqlAgentServiceCredential = $SqlServiceCredential
+        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer

--- a/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
+++ b/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
@@ -1,0 +1,116 @@
+<#
+    .EXAMPLE
+        This example shows how to install the first node in a SQL Server failover cluster.
+    .NOTES
+        This example assumes that a Failover Cluster is already present with a Cluster Name Object (CNO), IP-address.
+        This example also assumes that that all necessary shared disks is present, and formatted with the correct
+        drive letter, to accomdate the paths used during SQL Server setup. Minimum is one shared disk.
+        This example also assumes that the Cluster Name Object (CNO) has the permission to manage Computer Objects in
+        the Organizational Unit (OU) where the CNO Computer Object resides in Active Directory. This is neccessary
+        so that SQL Server setup can create a Virtual Computer Object (VCO) for the cluster group
+        (Windows Server 2012 R2 and earlier) or cluster role (Windows Server 2016 and later). Also so that the
+        Virtual Computer Object (VCO) can be removed when the Failover CLuster instance is uninstalled.
+
+        See the DSC resources xFailoverCluster, xStorage and iSCSIDsc for information how to setup a failover cluster
+        with DSC.
+
+        The resource is run using the SYSTEM account, but the setup is run using impersonation, with the credentials in
+        SetupCredential, when Action is 'InstallFailoverCluster'.
+
+        Assumes the credentials assigned to SourceCredential have read permission on the share and on the UNC path.
+        The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
+        that the impersonated credentials in SetupCredential can access the media locally.
+
+        Resource (Setup) cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
+        also means that PsDscRunAsCredential can not be used to access media on the UNC share at this time.
+
+        There is currently a bug that prevents the resource to logon to the instance if the current node is not the
+        active node. This is beacuse the resource tries to logon using the SYSTEM account, instead of the credentials
+        in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
+        issue #444).
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35' {
+           Name = 'NET-Framework-Core'
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45' {
+           Name = 'NET-Framework-45-Core'
+           Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        #region Install SQL Server Failover Cluster
+        xSQLServerSetup 'InstallNamedInstanceNode1-INST2016'
+        {
+            Action = 'InstallFailoverCluster'
+            ForceReboot = $false
+            UpdateEnabled = 'False'
+            SourcePath = '\\fileserver.compant.local\images$\SQL2016RTM'
+            SourceCredential = $SqlInstallCredential
+            SetupCredential = $SqlInstallCredential
+
+            InstanceName = 'INST2016'
+            Features = 'SQLENGINE,AS'
+
+            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir = 'C:\Program Files\Microsoft SQL Server'
+
+            SQLCollation = 'Finnish_Swedish_CI_AS'
+            SQLSvcAccount = $SqlServiceCredential
+            AgtSvcAccount = $SqlAgentServiceCredential
+            SQLSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+            ASSvcAccount = $SqlServiceCredential
+            ASSysAdminAccounts = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+
+            # Drive D: must be a shared disk.
+            InstallSQLDataDir = 'D:\MSSQL\Data'
+            SQLUserDBDir = 'D:\MSSQL\Data'
+            SQLUserDBLogDir = 'D:\MSSQL\Log'
+            SQLTempDBDir = 'D:\MSSQL\Temp'
+            SQLTempDBLogDir = 'D:\MSSQL\Temp'
+            SQLBackupDir = 'D:\MSSQL\Backup'
+            ASConfigDir = 'D:\AS\Config'
+            ASDataDir = 'D:\AS\Data'
+            ASLogDir = 'D:\AS\Log'
+            ASBackupDir = 'D:\AS\Backup'
+            ASTempDir = 'D:\AS\Temp'
+
+            FailoverClusterNetworkName = 'TESTCLU01A'
+            FailoverClusterIPAddress = '192.168.0.46'
+            FailoverClusterGroupName = 'TESTCLU01A'
+
+            DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
+        }
+        #region Install SQL Server Failover Cluster
+    }
+}

--- a/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
+++ b/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
@@ -21,11 +21,11 @@
         The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
         that the impersonated credentials in SetupCredential can access the media locally.
 
-        Resource (Setup) cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
-        also means that PsDscRunAsCredential can not be used to access media on the UNC share at this time.
+        Setup cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
+        also means that at this time PsDscRunAsCredential can not be used to access media on the UNC share.
 
         There is currently a bug that prevents the resource to logon to the instance if the current node is not the
-        active node. This is beacuse the resource tries to logon using the SYSTEM account, instead of the credentials
+        active node. This is beacuse the resource tries to logon using the SYSTEM account instead of the credentials
         in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
         issue #444).
 #>
@@ -36,19 +36,27 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlServiceCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer
@@ -58,7 +66,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
            Ensure = 'Present'
         }
 

--- a/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
+++ b/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
@@ -1,0 +1,90 @@
+<#
+    .EXAMPLE
+        This example shows how to add a node to an existing SQL Server failover cluster.
+    .NOTES
+        This example assumes that a Failover Cluster is already present with the first SQL Server Failover Cluster
+        node already installed.
+        This example also assumes that that the same shared disks on the first node is also present on this second
+        node.
+
+        See the example 4-InstallNamedInstanceInFailoverClusterFirstNode.ps1 for information how to setup the first
+        SQL Server Failover Cluster node.
+
+        The resource is run using the SYSTEM account, but the setup is run using impersonation, with the credentials in
+        SetupCredential, when Action is 'Addnode'.
+
+        Assumes the credentials assigned to SourceCredential have read permission on the share and on the UNC path.
+        The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
+        that the impersonated credentials in SetupCredential can access the media locally.
+
+        Resource (Setup) cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
+        also means that PsDscRunAsCredential can not be used to access media on the UNC share at this time.
+
+        There is currently a bug that prevents the resource to logon to the instance if the current node is not the
+        active node. This is beacuse the resource tries to logon using the SYSTEM account, instead of the credentials
+        in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
+        issue #444).
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullorEmpty()]
+        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35' {
+           Name = 'NET-Framework-Core'
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45' {
+           Name = 'NET-Framework-45-Core'
+           Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        #region Install SQL Server Failover Cluster
+        xSQLServerSetup 'InstallNamedInstanceNode2-INST2016'
+        {
+            Action = 'AddNode'
+            ForceReboot = $false
+            UpdateEnabled = 'False'
+            SourcePath = '\\fileserver.compant.local\images$\SQL2016RTM'
+            SourceCredential = $SqlInstallCredential
+            SetupCredential = $SqlInstallCredential
+
+            InstanceName = 'INST2016'
+            Features = 'SQLENGINE,AS'
+
+            SQLSvcAccount = $SqlServiceCredential
+            AgtSvcAccount = $SqlAgentServiceCredential
+            ASSvcAccount = $SqlServiceCredential
+
+            FailoverClusterNetworkName = 'TESTCLU01A'
+
+            DependsOn = '[WindowsFeature]NetFramework35','[WindowsFeature]NetFramework45'
+        }
+        #region Install SQL Server Failover Cluster
+    }
+}

--- a/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
+++ b/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
@@ -17,11 +17,11 @@
         The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
         that the impersonated credentials in SetupCredential can access the media locally.
 
-        Resource (Setup) cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
-        also means that PsDscRunAsCredential can not be used to access media on the UNC share at this time.
+        Setup cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
+        also means that at this time PsDscRunAsCredential can not be used to access media on the UNC share.
 
         There is currently a bug that prevents the resource to logon to the instance if the current node is not the
-        active node. This is beacuse the resource tries to logon using the SYSTEM account, instead of the credentials
+        active node. This is beacuse the resource tries to logon using the SYSTEM account instead of the credentials
         in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
         issue #444).
 #>
@@ -32,19 +32,27 @@ Configuration Example
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlInstallCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAdministratorCredential = $SqlInstallCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAdministratorCredential = $SqlInstallCredential,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlServiceCredential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlServiceCredential,
 
         [Parameter()]
         [ValidateNotNullorEmpty()]
-        [PsCredential] $SqlAgentServiceCredential = $SqlServiceCredential
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SqlAgentServiceCredential = $SqlServiceCredential
     )
 
     Import-DscResource -ModuleName xSQLServer
@@ -54,7 +62,7 @@ Configuration Example
         #region Install prerequisites for SQL Server
         WindowsFeature 'NetFramework35' {
            Name = 'NET-Framework-Core'
-           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes Everyone has read permission
+           Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
            Ensure = 'Present'
         }
 

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,23 @@ Installs SQL Server on the target node.
 * [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1)
 * [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1)
 
+#### Known issues
+
+All issues are not listed here, see [here for all issues](https://github.com/PowerShell/xSQLServer/issues).
+This is known issues that severly impact the use of the resource.
+
+##### Failover Cluster Setup
+
+Setup cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
+also means that at this time PsDscRunAsCredential can not be used to access media on the UNC share.
+
+There is currently a bug that prevents the resource to logon to the instance if the current node is not the
+active node. This is beacuse the resource tries to logon using the SYSTEM account instead of the credentials
+in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
+issue #444).
+
+These issues are also documented in the example files [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1) and [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1)
+
 ### xWaitforAvailabilityGroup
 
 No description.

--- a/README.md
+++ b/README.md
@@ -1017,7 +1017,7 @@ active node. This is beacuse the resource tries to logon using the SYSTEM accoun
 in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see
 issue #444).
 
-These issues are also documented in the example files [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1) and [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1)
+These issues are also documented in the example files [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1) and [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1).
 
 ### xWaitforAvailabilityGroup
 

--- a/README.md
+++ b/README.md
@@ -996,7 +996,9 @@ Installs SQL Server on the target node.
 
 #### Examples
 
-None.
+* [Install a default instance on a single server](/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1)
+* [Install a named instance on a single server](/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1)
+* [Install a named instance on a single server from an UNC path using SourceCredential](/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1)
 
 ### xWaitforAvailabilityGroup
 

--- a/README.md
+++ b/README.md
@@ -999,6 +999,8 @@ Installs SQL Server on the target node.
 * [Install a default instance on a single server](/Examples/Resources/xSQLServerSetup/1-InstallDefaultInstanceSingleServer.ps1)
 * [Install a named instance on a single server](/Examples/Resources/xSQLServerSetup/2-InstallNamedInstanceSingleServer.ps1)
 * [Install a named instance on a single server from an UNC path using SourceCredential](/Examples/Resources/xSQLServerSetup/3-InstallNamedInstanceSingleServerFromUncPathUsingSourceCredential.ps1)
+* [Install a named instance as the first node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1)
+* [Install a named instance as the second node in SQL Server Failover Cluster](/Examples/Resources/xSQLServerSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1)
 
 ### xWaitforAvailabilityGroup
 


### PR DESCRIPTION
- Changes to xSQLServerSetup
  - This adds better support for Addnode (issue #369).
  - Now it skips cluster validation för add node (issue #442).
  - Now it ignores parameters that are not allowed for action Addnode (issue #441).
  - Added examples for installing single server instances.  
  - Added examples for installing a Failover Cluster.

This Pull Request (PR) fixes the following issues:
Fixes #369 (partly, issues are submitted for known bugs)
Fixes #441 
Fixes #442 

- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/445)
<!-- Reviewable:end -->
