### PR TITLE
xSQLServerAvailabilityGroupListener: Removed the dependency of SQLPS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Changes to xSQLServerAvailabilityGroupListener
   - Removed the dependency of SQLPS provider (issue #460).
   - Cleaned up code.
-  - Cleaned up tests somewhat.
+  - Added test for more coverage.
   - Fixed PSSA rule warnings (issue #255).
   - Parameter Ensure now defaults to 'Present' (issue #450).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@
   - Removed the dependency of SQLPS provider (issue #460).
   - Cleaned up code.
   - Cleaned up tests somewhat.
-  - Fixed PSSA rule warnings (issue #255)
+  - Fixed PSSA rule warnings (issue #255).
+  - Parameter Ensure now defaults to 'Present' (issue #450).
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
   - Removed the dependency of SQLPS provider (issue #460).
   - Cleaned up code.
   - Cleaned up tests somewhat.
+  - Fixed PSSA rule warnings (issue #255)
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
   - Fixed code style, removed SQLServerDatabaseRecoveryModel functions from xSQLServerHelper.
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Fixed the permissions check loop so that it exits the loop after the function determines the required permissions are in place.
+- Changes to xSQLServerAvailabilityGroupListener
+  - Removed the dependency of SQLPS provider (issue #460).
+  - Cleaned up code.
+  - Cleaned up tests somewhat.
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -136,7 +136,7 @@ function Set-TargetResource
 
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -393,7 +393,7 @@ function Test-TargetResource
 
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -118,7 +118,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -209,7 +209,7 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
                 }
             }
             else
@@ -233,7 +233,7 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
                 }
             }
         }
@@ -329,12 +329,8 @@ function Set-TargetResource
                 }
                 else
                 {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
                 }
-            }
-            else
-            {
-                throw New-TerminatingError -ErrorType AvailabilityGroupListenerNotFound -ErrorCategory ObjectNotFound
             }
         }
     }
@@ -491,7 +487,7 @@ function Get-SQLAlwaysOnAvailabilityGroupListener
     }
     else
     {
-        throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+        throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -FormatArgs @($AvailabilityGroup,$InstanceName) -ErrorCategory ObjectNotFound
     }
 
     return $availabilityGroupListener

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -25,7 +25,7 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = 'MSSQLSERVER',
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -123,7 +123,7 @@ function Set-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = 'MSSQLSERVER',
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -380,7 +380,7 @@ function Test-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = 'MSSQLSERVER',
+        $InstanceName,
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -202,7 +202,7 @@ function Set-TargetResource
                     }
                     else
                     {
-                        New-VerboseMessage -Message "Listener using DHCP with server default subnet"
+                        New-VerboseMessage -Message 'Listener using DHCP with server default subnet'
                     }
 
                     New-SqlAvailabilityGroupListener @newListenerParams -ErrorAction Stop | Out-Null
@@ -248,7 +248,7 @@ function Set-TargetResource
             {
                 if (-not $DHCP -and $availabilityGroupListenerState.IpAddress.Count -lt $IpAddress.Count) # Only able to add a new IP-address, not change existing ones.
                 {
-                    New-VerboseMessage -Message "Found at least one new IP-address."
+                    New-VerboseMessage -Message 'Found at least one new IP-address.'
                     $ipAddressEqual = $false
                 }
                 else
@@ -279,11 +279,11 @@ function Set-TargetResource
                     {
                         if ($availabilityGroupListenerState.Port -ne $Port -or -not $ipAddressEqual)
                         {
-                            New-VerboseMessage -Message "Listener differ in configuration."
+                            New-VerboseMessage -Message 'Listener differ in configuration.'
 
                             if ($availabilityGroupListenerState.Port -ne $Port)
                             {
-                                New-VerboseMessage -Message "Changing port configuration"
+                                New-VerboseMessage -Message 'Changing port configuration'
 
                                 $setListenerParams = @{
                                     InputObject = $availabilityGroupListenerObject
@@ -295,7 +295,7 @@ function Set-TargetResource
 
                             if (-not $ipAddressEqual)
                             {
-                                New-VerboseMessage -Message "Adding IP-address(es)"
+                                New-VerboseMessage -Message 'Adding IP-address(es)'
 
                                 $InstanceName = Get-SQLPSInstanceName -InstanceName $InstanceName
 
@@ -319,7 +319,7 @@ function Set-TargetResource
                         }
                         else
                         {
-                            New-VerboseMessage -Message "Listener configuration is already correct."
+                            New-VerboseMessage -Message 'Listener configuration is already correct.'
                         }
                     }
                     else

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -1,8 +1,22 @@
-﻿$ErrorActionPreference = "Stop"
+﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+                               -ChildPath 'xSQLServerHelper.psm1') `
+                               -Force
+<#
+    .SYNOPSIS
+        Returns the current state of the Availabilty Group listener.
 
-$script:currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -ErrorAction Stop
+    .PARAMETER InstanceName
+        The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
 
+    .PARAMETER NodeName
+        The host name or FQDN of the primary replica.
+
+    .PARAMETER Name
+        The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).
+
+    .PARAMETER AvailabilityGroup
+        The name of the availability group to which the availability group listener is or will be connected.
+#>
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -11,7 +25,7 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = "DEFAULT",
+        $InstanceName = 'MSSQLSERVER',
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -27,37 +41,42 @@ function Get-TargetResource
         $AvailabilityGroup
     )
 
-    try {
-        $listener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -NodeName $NodeName -InstanceName $InstanceName
-        
-        if( $null -ne $listener ) {
-            New-VerboseMessage -Message "Listener $Name already exist"
+    try
+    {
+        $availabilityGroupListener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -NodeName $NodeName -InstanceName $InstanceName
 
-            $ensure = "Present"
-            
-            $port = [uint16]( $listener | Select-Object -ExpandProperty PortNumber )
+        if ($null -ne $availabilityGroupListener)
+        {
+            New-VerboseMessage -Message "Listener $Name exist."
 
-            $presentIpAddress = $listener.AvailabilityGroupListenerIPAddresses
+            $ensure = 'Present'
+            $port = [uint16]( $availabilityGroupListener | Select-Object -ExpandProperty PortNumber )
 
+            $presentIpAddress = $availabilityGroupListener.AvailabilityGroupListenerIPAddresses
             $dhcp = [bool]( $presentIpAddress | Select-Object -First 1 -ExpandProperty IsDHCP )
 
             $ipAddress = @()
-            foreach( $currentIpAddress in $presentIpAddress ) {
+            foreach ($currentIpAddress in $presentIpAddress)
+            {
                 $ipAddress += "$($currentIpAddress.IPAddress)/$($currentIpAddress.SubnetMask)"
-            } 
-        } else {
+            }
+        }
+        else
+        {
             New-VerboseMessage -Message "Listener $Name does not exist"
 
-            $ensure = "Absent"
+            $ensure = 'Absent'
             $port = 0
             $dhcp = $false
             $ipAddress = $null
         }
-    } catch {
+    }
+    catch
+    {
         throw New-TerminatingError -ErrorType AvailabilityGroupListenerNotFound -FormatArgs @($Name) -ErrorCategory ObjectNotFound -InnerException $_.Exception
     }
 
-    $returnValue = @{
+    return @{
         InstanceName = [System.String] $InstanceName
         NodeName = [System.String] $NodeName
         Name = [System.String] $Name
@@ -67,10 +86,36 @@ function Get-TargetResource
         Port = [System.UInt16] $port
         DHCP = [System.Boolean] $dhcp
     }
-
-    return $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Creates the Availability Group listener.
+
+    .PARAMETER InstanceName
+        The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
+
+    .PARAMETER NodeName
+        The host name or FQDN of the primary replica.
+
+    .PARAMETER Name
+        The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).
+
+    .PARAMETER Ensure
+        If the availability group listener should be present or absent.
+
+    .PARAMETER AvailabilityGroup
+        The name of the availability group to which the availability group listener is or will be connected.
+
+    .PARAMETER IpAddress
+        The IP address used for the availability group listener, in the format 192.168.10.45/255.255.252.0. If using DCHP, set to the first IP-address of the DHCP subnet, in the format 192.168.8.1/255.255.252.0. Must be valid in the cluster-allowed IP range.
+
+    .PARAMETER Port
+        The port used for the availability group listener.
+
+    .PARAMETER DHCP
+        If DHCP should be used for the availability group listener instead of static IP address.
+#>
 function Set-TargetResource
 {
     [CmdletBinding(SupportsShouldProcess)]
@@ -78,7 +123,7 @@ function Set-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = "DEFAULT",
+        $InstanceName = 'MSSQLSERVER',
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -89,7 +134,7 @@ function Set-TargetResource
         [System.String]
         $Name,
 
-        [ValidateSet("Present","Absent")]
+        [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure,
 
@@ -106,123 +151,227 @@ function Set-TargetResource
         [System.Boolean]
         $DHCP
     )
-   
+
     $parameters = @{
         InstanceName = [System.String] $InstanceName
         NodeName = [System.String] $NodeName
         Name = [System.String] $Name
         AvailabilityGroup = [System.String] $AvailabilityGroup
     }
-    
-    $listenerState = Get-TargetResource @parameters 
-    if( $null -ne $listenerState ) {
-        if( $Ensure -ne "" -and $listenerState.Ensure -ne $Ensure ) {
-            $InstanceName = Get-SQLPSInstanceName -InstanceName $InstanceName
-            
-            if( $Ensure -eq "Present") {
-                if( ( $PSCmdlet.ShouldProcess( $Name, "Create listener on $AvailabilityGroup" ) ) ) {
+
+    $availabilityGroupListenerState = Get-TargetResource @parameters
+    if ($null -ne $availabilityGroupListenerState)
+    {
+        if ($Ensure -ne '' -and $availabilityGroupListenerState.Ensure -ne $Ensure)
+        {
+            if ($Ensure -eq 'Present')
+            {
+                New-VerboseMessage -Message "Create listener on $AvailabilityGroup"
+
+                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+
+                $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
+                if ($availabilityGroupObject)
+                {
                     $newListenerParams = @{
                         Name = $Name
-                        Path = "SQLSERVER:\SQL\$NodeName\$InstanceName\AvailabilityGroups\$AvailabilityGroup"
+                        InputObject = $availabilityGroupObject
                     }
 
-                    if( $Port ) {
+                    if ($Port)
+                    {
                         New-VerboseMessage -Message "Listener port set to $Port"
                         $newListenerParams += @{
                             Port = $Port
                         }
                     }
 
-                    if( $DHCP -and $IpAddress.Count -gt 0 ) {
+                    if ($DHCP -and $IpAddress.Count -gt 0)
+                    {
                         New-VerboseMessage -Message "Listener set to DHCP with subnet $IpAddress"
                         $newListenerParams += @{
                             DhcpSubnet = [string]$IpAddress
                         }
-                    } elseif ( -not $DHCP -and $IpAddress.Count -gt 0 ) {
+                    }
+                    elseif (-not $DHCP -and $IpAddress.Count -gt 0)
+                    {
                         New-VerboseMessage -Message "Listener set to static IP-address(es); $($IpAddress -join ', ')"
                         $newListenerParams += @{
                             StaticIp = $IpAddress
                         }
-                    } else {
+                    }
+                    else
+                    {
                         New-VerboseMessage -Message "Listener using DHCP with server default subnet"
                     }
-                                        
-                    New-SqlAvailabilityGroupListener @newListenerParams -Verbose:$False | Out-Null   # Suppressing Verbose because it prints the entire T-SQL statement otherwise
+
+                    New-SqlAvailabilityGroupListener @newListenerParams -ErrorAction Stop | Out-Null
                 }
-            } else {
-                if( ( $PSCmdlet.ShouldProcess( $Name, "Remove listener from $AvailabilityGroup" ) ) ) {
-                    Remove-Item "SQLSERVER:\SQL\$NodeName\$InstanceName\AvailabilityGroups\$AvailabilityGroup\AvailabilityGroupListeners\$Name"
+                else
+                {
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
                 }
             }
-        } else {
-            if( $Ensure -ne "" ) { New-VerboseMessage -Message "State is already $Ensure" }
-            
-            if( $listenerState.Ensure -eq "Present") {
-                if( -not $DHCP -and $listenerState.IpAddress.Count -lt $IpAddress.Count ) { # Only able to add a new IP-address, not change existing ones.
+            else
+            {
+                New-VerboseMessage -Message "Remove listener from $AvailabilityGroup"
+
+                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
+
+                $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
+                if ($availabilityGroupObject)
+                {
+                    $availabilityGroupListenerObject = $availabilityGroupObject.AvailabilityGroupListeners[$Name]
+                    if ($availabilityGroupListenerObject)
+                    {
+                        $availabilityGroupListenerObject.Drop()
+                    }
+                    else
+                    {
+                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerNotFound -ErrorCategory ObjectNotFound
+                    }
+                }
+                else
+                {
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+                }
+            }
+        }
+        else
+        {
+            if ($Ensure -ne '')
+            {
+                New-VerboseMessage -Message "State is already $Ensure"
+            }
+
+            if ($availabilityGroupListenerState.Ensure -eq 'Present')
+            {
+                if (-not $DHCP -and $availabilityGroupListenerState.IpAddress.Count -lt $IpAddress.Count) # Only able to add a new IP-address, not change existing ones.
+                {
                     New-VerboseMessage -Message "Found at least one new IP-address."
-                    $ipAddressEqual = $False
-                } else {
+                    $ipAddressEqual = $false
+                }
+                else
+                {
                     # No new IP-address
-                    if( $null -eq $IpAddress -or -not ( Compare-Object -ReferenceObject $IpAddress -DifferenceObject $listenerState.IpAddress ) ) { 
-                       $ipAddressEqual = $True
-                    } else {
-                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerIPChangeError -FormatArgs @($($IpAddress -join ', '),$($listenerState.IpAddress -join ', ')) -ErrorCategory InvalidOperation
+                    if ($null -eq $IpAddress -or -not ( Compare-Object -ReferenceObject $IpAddress -DifferenceObject $availabilityGroupListenerState.IpAddress))
+                    {
+                       $ipAddressEqual = $true
+                    }
+                    else
+                    {
+                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerIPChangeError -FormatArgs @($($IpAddress -join ', '),$($availabilityGroupListenerState.IpAddress -join ', ')) -ErrorCategory InvalidOperation
                     }
                 }
 
-                if( $($PSBoundParameters.ContainsKey('DHCP')) -and $listenerState.DHCP -ne $DHCP ) {
-                    throw New-TerminatingError -ErrorType AvailabilityGroupListenerDHCPChangeError -FormatArgs @( $DHCP, $($listenerState.DHCP) ) -ErrorCategory InvalidOperation
+                if ($($PSBoundParameters.ContainsKey('DHCP')) -and $availabilityGroupListenerState.DHCP -ne $DHCP)
+                {
+                    throw New-TerminatingError -ErrorType AvailabilityGroupListenerDHCPChangeError -FormatArgs @( $DHCP, $($availabilityGroupListenerState.DHCP) ) -ErrorCategory InvalidOperation
                 }
-                
-                if( $listenerState.Port -ne $Port -or -not $ipAddressEqual ) {
-                    New-VerboseMessage -Message "Listener differ in configuration."
 
-                    if( $listenerState.Port -ne $Port ) {
-                        if( ( $PSCmdlet.ShouldProcess( $Name, "Changing port configuration" ) ) ) {
-                            $InstanceName = Get-SQLPSInstanceName -InstanceName $InstanceName
-                            
-                            $setListenerParams = @{
-                                Path = "SQLSERVER:\SQL\$NodeName\$InstanceName\AvailabilityGroups\$AvailabilityGroup\AvailabilityGroupListeners\$Name"
-                                Port = $Port
-                            }
+                $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
 
-                            Set-SqlAvailabilityGroupListener @setListenerParams -Verbose:$False | Out-Null # Suppressing Verbose because it prints the entire T-SQL statement otherwise
-                        }
-                    }
+                $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
+                if ($availabilityGroupObject)
+                {
+                    $availabilityGroupListenerObject = $availabilityGroupObject.AvailabilityGroupListeners[$Name]
+                    if ($availabilityGroupListenerObject)
+                    {
+                        if ($availabilityGroupListenerState.Port -ne $Port -or -not $ipAddressEqual)
+                        {
+                            New-VerboseMessage -Message "Listener differ in configuration."
 
-                    if( -not $ipAddressEqual ) {
-                        if( ( $PSCmdlet.ShouldProcess( $Name, "Adding IP-address(es)" ) ) ) {
-                            $InstanceName = Get-SQLPSInstanceName -InstanceName $InstanceName
-                            
-                            $newIpAddress = @()
-                            
-                            foreach( $currentIpAddress in $IpAddress ) {
-                                if( -not ( $listenerState.IpAddress -contains $currentIpAddress ) ) {
-                                    $newIpAddress += $currentIpAddress
+                            if ($availabilityGroupListenerState.Port -ne $Port)
+                            {
+                                New-VerboseMessage -Message "Changing port configuration"
+
+                                $setListenerParams = @{
+                                    InputObject = $availabilityGroupListenerObject
+                                    Port = $Port
                                 }
-                            }
-                            
-                            $setListenerParams = @{
-                                Path = "SQLSERVER:\SQL\$NodeName\$InstanceName\AvailabilityGroups\$AvailabilityGroup\AvailabilityGroupListeners\$Name"
-                                StaticIp = $newIpAddress
+
+                                Set-SqlAvailabilityGroupListener @setListenerParams -ErrorAction Stop | Out-Null
                             }
 
-                            Add-SqlAvailabilityGroupListenerStaticIp @setListenerParams -Verbose:$False | Out-Null # Suppressing Verbose because it prints the entire T-SQL statement otherwise
+                            if (-not $ipAddressEqual)
+                            {
+                                New-VerboseMessage -Message "Adding IP-address(es)"
+
+                                $InstanceName = Get-SQLPSInstanceName -InstanceName $InstanceName
+
+                                $newIpAddress = @()
+
+                                foreach ($currentIpAddress in $IpAddress)
+                                {
+                                    if (-not ( $availabilityGroupListenerState.IpAddress -contains $currentIpAddress))
+                                    {
+                                        $newIpAddress += $currentIpAddress
+                                    }
+                                }
+
+                                $setListenerParams = @{
+                                    InputObject = $availabilityGroupListenerObject
+                                    StaticIp = $newIpAddress
+                                }
+
+                                Add-SqlAvailabilityGroupListenerStaticIp @setListenerParams -ErrorAction Stop | Out-Null
+                            }
+                        }
+                        else
+                        {
+                            New-VerboseMessage -Message "Listener configuration is already correct."
                         }
                     }
-
-                } else {
-                    New-VerboseMessage -Message "Listener configuration is already correct."
+                    else
+                    {
+                        throw New-TerminatingError -ErrorType AvailabilityGroupListenerNotFound -ErrorCategory ObjectNotFound
+                    }
                 }
-            } else {
+                else
+                {
+                    throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+                }
+            }
+            else
+            {
                 throw New-TerminatingError -ErrorType AvailabilityGroupListenerNotFound -ErrorCategory ObjectNotFound
             }
         }
-    } else {
+    }
+    else
+    {
         throw New-TerminatingError -ErrorType UnexpectedErrorFromGet -ErrorCategory InvalidResult
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests if the the Availability Group listener is in desired state.
+
+    .PARAMETER InstanceName
+        The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
+
+    .PARAMETER NodeName
+        The host name or FQDN of the primary replica.
+
+    .PARAMETER Name
+        The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).
+
+    .PARAMETER Ensure
+        If the availability group listener should be present or absent.
+
+    .PARAMETER AvailabilityGroup
+        The name of the availability group to which the availability group listener is or will be connected.
+
+    .PARAMETER IpAddress
+        The IP address used for the availability group listener, in the format 192.168.10.45/255.255.252.0. If using DCHP, set to the first IP-address of the DHCP subnet, in the format 192.168.8.1/255.255.252.0. Must be valid in the cluster-allowed IP range.
+
+    .PARAMETER Port
+        The port used for the availability group listener.
+
+    .PARAMETER DHCP
+        If DHCP should be used for the availability group listener instead of static IP address.
+#>
 function Test-TargetResource
 {
     [CmdletBinding()]
@@ -231,7 +380,7 @@ function Test-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $InstanceName = "DEFAULT",
+        $InstanceName = 'MSSQLSERVER',
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -242,7 +391,7 @@ function Test-TargetResource
         [System.String]
         $Name,
 
-        [ValidateSet("Present","Absent")]
+        [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure,
 
@@ -266,34 +415,42 @@ function Test-TargetResource
         Name = [System.String] $Name
         AvailabilityGroup = [System.String] $AvailabilityGroup
     }
-    
+
     New-VerboseMessage -Message "Testing state of listener $Name"
-    
-    $listenerState = Get-TargetResource @parameters 
-    if( $null -ne $listenerState ) {
-        if( $null -eq $IpAddress -or ($null -ne $listenerState.IpAddress -and -not ( Compare-Object -ReferenceObject $IpAddress -DifferenceObject $listenerState.IpAddress ) ) ) { 
+
+    $availabilityGroupListenerState = Get-TargetResource @parameters
+    if ($null -ne $availabilityGroupListenerState)
+    {
+        if ($null -eq $IpAddress -or ($null -ne $availabilityGroupListenerState.IpAddress -and -not ( Compare-Object -ReferenceObject $IpAddress -DifferenceObject $availabilityGroupListenerState.IpAddress)))
+        {
             $ipAddressEqual = $true
-        } else {
+        }
+        else
+        {
             $ipAddressEqual = $false
         }
-        
-        [System.Boolean] $result = $false
-        if( $listenerState.Ensure -eq $Ensure)  {
-            if( $Ensure -eq 'Absent' ) {
-                $result = $true
-            }
-        }
 
-        if( -not $($PSBoundParameters.ContainsKey('Ensure')) -or $Ensure -eq "Present" ) { 
-            if( ( $Port -eq "" -or $listenerState.Port -eq $Port) -and 
-                $ipAddressEqual -and 
-                ( -not $($PSBoundParameters.ContainsKey('DHCP')) -or $listenerState.DHCP -eq $DHCP ) ) 
+        [System.Boolean] $result = $false
+        if ($availabilityGroupListenerState.Ensure -eq $Ensure)
+        {
+            if ($Ensure -eq 'Absent')
             {
                 $result = $true
             }
         }
 
-    } else {
+        if (-not $($PSBoundParameters.ContainsKey('Ensure')) -or $Ensure -eq 'Present')
+        {
+            if (($Port -eq "" -or $availabilityGroupListenerState.Port -eq $Port) -and
+                $ipAddressEqual -and
+                (-not $($PSBoundParameters.ContainsKey('DHCP')) -or $availabilityGroupListenerState.DHCP -eq $DHCP))
+            {
+                $result = $true
+            }
+        }
+    }
+    else
+    {
         throw New-TerminatingError -ErrorType UnexpectedErrorFromGet -ErrorCategory InvalidResult
     }
 
@@ -320,23 +477,24 @@ function Get-SQLAlwaysOnAvailabilityGroupListener
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $NodeName 
+        $NodeName
     )
 
-    $instance = Get-SQLPSInstance -InstanceName $InstanceName -NodeName $NodeName
-    $Path = "$($instance.PSPath)\AvailabilityGroups\$AvailabilityGroup\AvailabilityGroupListeners"
+    Write-Debug "Connecting to availability group $Name as $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
 
-    Write-Debug "Connecting to $Path as $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
-    
-    [String[]] $presentListener = Get-ChildItem $Path
-    if( $presentListener.Count -ne 0 -and $presentListener.Contains("[$Name]") ) {
-        Write-Debug "Connecting to availability group $Name as $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
-        $listener = Get-Item "$Path\$Name"
-    } else {
-        $listener = $null
-    }    
+    $sqlServerObject = Connect-SQL -SQLServer $NodeName -SQLInstanceName $InstanceName
 
-    return $listener
+    $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
+    if ($availabilityGroupObject)
+    {
+        $availabilityGroupListener = $availabilityGroupObject.AvailabilityGroupListeners[$Name]
+    }
+    else
+    {
+        throw New-TerminatingError -ErrorType AvailabilityGroupNotFound -ErrorCategory ObjectNotFound
+    }
+
+    return $availabilityGroupListener
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerAvailabilityGroupListener")]
 class MSFT_xSQLServerAvailabilityGroupListener : OMI_BaseResource
 {
-    [Key, Description("The SQL Server instance name of the primary replica.")] String InstanceName;
+    [Key, Description("The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.")] String InstanceName;
     [Required, Description("The host name or FQDN of the primary replica.")] String NodeName;
     [Required, Description("The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).")] String Name;
     [Write, Description("If the availability group listener should be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
@@ -5,7 +5,7 @@ class MSFT_xSQLServerAvailabilityGroupListener : OMI_BaseResource
     [Key, Description("The SQL Server instance name of the primary replica.")] String InstanceName;
     [Required, Description("The host name or FQDN of the primary replica.")] String NodeName;
     [Required, Description("The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).")] String Name;
-    [Write, Description("If the availability group listener should be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("If the availability group listener should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The name of the availability group to which the availability group listener is or will be connected.")] String AvailabilityGroup;
     [Write, Description("The IP address used for the availability group listener, in the format 192.168.10.45/255.255.252.0. If using DCHP, set to the first IP-address of the DHCP subnet, in the format 192.168.8.1/255.255.252.0. Must be valid in the cluster-allowed IP range.")] String IpAddress[];
     [Write, Description("The port used for the availability group listener")] UInt16 Port;

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerAvailabilityGroupListener")]
 class MSFT_xSQLServerAvailabilityGroupListener : OMI_BaseResource
 {
-    [Key, Description("The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.")] String InstanceName;
+    [Key, Description("The SQL Server instance name of the primary replica.")] String InstanceName;
     [Required, Description("The host name or FQDN of the primary replica.")] String NodeName;
     [Required, Description("The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).")] String Name;
     [Write, Description("If the availability group listener should be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ No description.
 
 #### Parameters
 
-* **[String] InstanceName** _(Key)_: The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
+* **[String] InstanceName** _(Key)_: The SQL Server instance name of the primary replica.
 * **[String] AvailabilityGroup** _(Key)_: The name of the availability group to which the availability group listener is or will be connected.
 * **[String] NodeName** _(Write)_: The host name or FQDN of the primary replica.
 * **[String] Ensure** _(Write)_: If the availability group listener should be present or absent. { Present | Absent }.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ No description.
 
 #### Parameters
 
-* **[String] InstanceName** _(Key)_: The SQL Server instance name of the primary replica.
+* **[String] InstanceName** _(Key)_: The SQL Server instance name of the primary replica. Default value is 'MSSQLSERVER'.
 * **[String] AvailabilityGroup** _(Key)_: The name of the availability group to which the availability group listener is or will be connected.
 * **[String] NodeName** _(Write)_: The host name or FQDN of the primary replica.
 * **[String] Ensure** _(Write)_: If the availability group listener should be present or absent. { Present | Absent }.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ No description.
 * **[String] InstanceName** _(Key)_: The SQL Server instance name of the primary replica.
 * **[String] AvailabilityGroup** _(Key)_: The name of the availability group to which the availability group listener is or will be connected.
 * **[String] NodeName** _(Write)_: The host name or FQDN of the primary replica.
-* **[String] Ensure** _(Write)_: If the availability group listener should be present or absent. { Present | Absent }.
+* **[String] Ensure** _(Write)_: If the availability group listener should be present or absent. Default value is 'Present'. { *Present* | Absent }.
 * **[String] Name** _(Write)_: The name of the availability group listener, max 15 characters. This name will be used as the Virtual Computer Object (VCO).
 * **[String[]] IpAddress** _(Write)_: The IP address used for the availability group listener, in the format 192.168.10.45/255.255.252.0. If using DCHP, set to the first IP-address of the DHCP subnet, in the format 192.168.8.1/255.255.252.0. Must be valid in the cluster-allowed IP range.
 * **[Uint16] Port** _(Write)_: The port used for the availability group listener.

--- a/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -3,10 +3,10 @@ $script:DSCResourceName    = 'MSFT_xSQLServerAvailabilityGroupListener'
 
 #region HEADER
 
-# Unit Test Template Version: 1.1.0
-[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
@@ -16,669 +16,673 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 #endregion HEADER
+
+function Invoke-TestSetup {
+    # Loading stub cmdlets
+    Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
 
 # Begin Testing
 try
 {
-    #region Pester Test Initialization
-
-    # Loading mocked classes
-    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
-
-    # Loading stub cmdlets
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
-
-    # Static parameter values
-    $nodeName = 'localhost'
-    $instanceName = 'DEFAULT'
-    $availabilityGroup = 'AG01'
-    $listnerName = 'AGListner'
-    
-    $defaultParameters = @{
-        InstanceName = $instanceName
-        NodeName = $nodeName 
-        Name = $listnerName
-        AvailabilityGroup = $availabilityGroup
-    }
-
-    #endregion Pester Test Initialization
-
-    Describe "$($script:DSCResourceName)\Get-TargetResource" {
-        Context 'When the system is not in the desired state' {
-            $testParameters = $defaultParameters
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the desired state as absent' {
-                $result.Ensure | Should Be 'Absent'
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-            }
-
-            It 'Should not return any IP addresses' {
-                $result.IpAddress | Should Be $null
-            }
-
-            It 'Should not return port' {
-                $result.Port | Should Be 0
-            }
-
-            It 'Should return that DHCP is not used' {
-                $result.DHCP | Should Be $false
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-
-        Context 'When the system is in the desired state, without DHCP' {
-            $testParameters = $defaultParameters
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the desired state as present' {
-                $result.Ensure | Should Be 'Present'
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-            }
-
-            It 'Should return correct IP address' {
-                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
-            }
-
-            It 'Should return correct port' {
-                $result.Port | Should Be 5030
-            }
-
-            It 'Should return that DHCP is not used' {
-                $result.DHCP | Should Be $false
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-
-        Context 'When the system is in the desired state, with DHCP' {
-            $testParameters = $defaultParameters
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5031 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the desired state as present' {
-                $result.Ensure | Should Be 'Present'
-            }
-
-            It 'Should return the same values as passed as parameters' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-                $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
-            }
-
-            It 'Should return correct IP address' {
-                $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
-            }
-
-            It 'Should return correct port' {
-                $result.Port | Should Be 5031
-            }
-
-            It 'Should return that DHCP is used' {
-                $result.DHCP | Should Be $true
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-
-        Assert-VerifiableMocks
-    }
-
-    Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        Context 'When the system is not in the desired state (for static IP)' {
-            It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Absent'
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is absent when IP address is different' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is absent when DHCP is absent but should be present' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $true
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is absent when DHCP is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    DHCP = $true
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses { 
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is absent when port is different' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-        }
-
-        Context 'When the system is not in the desired state (for DHCP)' {
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is absent when DHCP is present but should be absent' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.100/255.255.255.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is absent when IP address is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is absent when port is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Port = 5030
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-        }
-
-        Context 'When the system is in the desired state (for static IP)' {
-            It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Absent'
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is present when IP address is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is present when port is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Port = 5030
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-        }
-
-        Context 'When the system is in the desired state (for DHCP)' {
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $true -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $true
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-
-            It 'Should return that desired state is present when DHCP is the only set parameter' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    DHCP = $true
-                }            
-
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-            }
-        }
-
-        Assert-VerifiableMocks
-    }
-
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-        Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-        Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-        Context 'When the system is not in the desired state' {
-            It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-                Set-TargetResource @testParameters | Out-Null
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should throw when trying to change an existing IP address' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '10.0.0.1/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                { Set-TargetResource @testParameters } | Should Throw
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should throw when trying to change from static IP to DHCP' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $true
-                }            
-
-                { Set-TargetResource @testParameters } | Should Throw
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Set-TargetResource @testParameters | Out-Null
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-                return New-Object Object | 
-                    Add-Member NoteProperty PortNumber 5555 -PassThru | 
-                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
-                        return @(
-                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                Add-Member NoteProperty IsDHCP $false -PassThru | 
-                                Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
-                                Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
-                            )
-                        )
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '192.168.10.45/255.255.252.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Set-TargetResource @testParameters | Out-Null
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-        }
-
-        Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
-            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
-            return New-Object Object | 
-                Add-Member NoteProperty PortNumber 5030 -PassThru | 
-                Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        # Static parameter values
+        $mockNodeName = 'localhost'
+        $mockInstanceName = 'MSSQLSERVER'
+        $mockAvailabilityGroup = 'AG01'
+        $mockListenerName = 'AGListner'
+        $mockPortNumber = 5031
+        $mockIsDhcp = $true
+
+        $mockConnectSql = {
+            return New-Object Object |
+                Add-Member ScriptProperty AvailabilityGroups {
                     return @(
-                        # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
-                        (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                            Add-Member NoteProperty IsDHCP $false -PassThru | 
-                            Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
-                            Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
-                        )
+                        @{
+                            $mockAvailabilityGroup = New-Object Object |
+                                Add-Member ScriptProperty AvailabilityGroupListeners {
+                                    @(
+                                        @{
+                                            $mockListenerName = New-Object Object |
+                                                Add-Member NoteProperty PortNumber $mockPortNumber -PassThru |
+                                                Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                                                    return @(
+                                                        # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                                        (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                                            Add-Member NoteProperty IsDHCP $mockIsDhcp -PassThru |
+                                                            Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                                            Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                                        )
+                                                    )
+                                                } -PassThru -Force
+                                        }
+                                    )
+                                } -PassThru -Force
+                        }
                     )
-                } -PassThru -Force 
-        } -ModuleName $script:DSCResourceName -Verifiable
-
-        Context 'When the system is in the desired state' {
-            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    Ensure = 'Present'
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                    DHCP = $false
-                }            
-
-                Set-TargetResource @testParameters | Out-Null
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    IpAddress = '192.168.0.1/255.255.255.0'
-                    Port = 5030
-                }            
-
-                Set-TargetResource @testParameters | Out-Null
-
-                Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It 
-                Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-                Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
+                } -PassThru -Force
         }
 
-        Assert-VerifiableMocks
+        $defaultParameters = @{
+            InstanceName = $mockInstanceName
+            NodeName = $mockNodeName
+            Name = $mockListenerName
+            AvailabilityGroup = $mockAvailabilityGroup
+        }
+
+        #endregion Pester Test Initialization
+
+        Describe 'xSQLServerAvailabilityGroupListener\Get-TargetResource' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
+
+                It 'Should return the desired state as absent' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should Be 'Absent'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.NodeName | Should Be $testParameters.NodeName
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                    $result.Name | Should Be $testParameters.Name
+                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+                }
+
+                It 'Should not return any IP addresses' {
+                    $result = Get-TargetResource @testParameters
+                    $result.IpAddress | Should Be $null
+                }
+
+                It 'Should not return port' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Port | Should Be 0
+                }
+
+                It 'Should return that DHCP is not used' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DHCP | Should Be $false
+                }
+
+                It 'Should call the mock function Get-SQLAlwaysOnAvailabilityGroupListener' {
+                    $result = Get-TargetResource @testParameters
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state, without DHCP' {
+                It 'Should return the desired state as present' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should Be 'Present'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.NodeName | Should Be $testParameters.NodeName
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                    $result.Name | Should Be $testParameters.Name
+                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+                }
+
+                It 'Should return correct IP address' {
+                    $result = Get-TargetResource @testParameters
+                    $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+                }
+
+                It 'Should return correct port' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Port | Should Be $mockPortNumber
+                }
+
+                It 'Should return that DHCP is not used' {
+                    $mockIsDhcp = $false
+
+                    $result = Get-TargetResource @testParameters
+                    $result.DHCP | Should Be $false
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    $result = Get-TargetResource @testParameters
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state, with DHCP' {
+                It 'Should return the desired state as present' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should Be 'Present'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.NodeName | Should Be $testParameters.NodeName
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                    $result.Name | Should Be $testParameters.Name
+                    $result.AvailabilityGroup | Should Be $testParameters.AvailabilityGroup
+                }
+
+                It 'Should return correct IP address' {
+                    $result = Get-TargetResource @testParameters
+                    $result.IpAddress | Should Be '192.168.0.1/255.255.255.0'
+                }
+
+                It 'Should return correct port' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Port | Should Be $mockPortNumber
+                }
+
+                It 'Should return that DHCP is used' {
+                    $mockIsDhcp = $true
+
+                    $result = Get-TargetResource @testParameters
+                    $result.DHCP | Should Be $true
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    $result = Get-TargetResource @testParameters
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'xSQLServerAvailabilityGroupListener\Test-TargetResource' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+            }
+
+            Context 'When the system is not in the desired state (for static IP)' {
+                It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5030 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is absent when IP address is different' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is absent when DHCP is absent but should be present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $true
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is absent when DHCP is the only set parameter' {
+                    $testParameters += @{
+                        DHCP = $true
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5555 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is absent when port is different' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state (for DHCP)' {
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5030 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is absent when DHCP is present but should be absent' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.100/255.255.255.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is absent when IP address is the only set parameter' {
+                    $testParameters += @{
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5555 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is absent when port is the only set parameter' {
+                    $testParameters += @{
+                        Port = 5030
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state (for static IP)' {
+                It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5030 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is present when IP address is the only set parameter' {
+                    $testParameters += @{
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is present when port is the only set parameter' {
+                    $testParameters += @{
+                        Port = 5030
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state (for DHCP)' {
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5030 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $true -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $true
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return that desired state is present when DHCP is the only set parameter' {
+                    $testParameters += @{
+                        DHCP = $true
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'xSQLServerAvailabilityGroupListener\Set-TargetResource' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable -Scope It
+                Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -Verifiable
+                Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -Verifiable
+                Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5030 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should throw when trying to change an existing IP address' {
+                    $testParameters += @{
+                        IpAddress = '10.0.0.1/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+
+                It 'Should throw when trying to change from static IP to DHCP' {
+                    $testParameters += @{
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $true
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+
+                It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
+                    $testParameters += @{
+                        IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 1 -Scope It
+                }
+
+                Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                    return New-Object Object |
+                        Add-Member NoteProperty PortNumber 5555 -PassThru |
+                        Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                            return @(
+                                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                                (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member NoteProperty IsDHCP $false -PassThru |
+                                    Add-Member NoteProperty IPAddress '192.168.10.45' -PassThru |
+                                    Add-Member NoteProperty SubnetMask '255.255.252.0' -PassThru
+                                )
+                            )
+                        } -PassThru -Force
+                } -Verifiable
+
+                It 'Should call the cmdlet Set-SqlAvailabilityGroupListener when port is not in desired state' {
+                    $testParameters += @{
+                        IpAddress = '192.168.10.45/255.255.252.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {
+                # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener
+                return New-Object Object |
+                    Add-Member NoteProperty PortNumber 5030 -PassThru |
+                    Add-Member ScriptProperty AvailabilityGroupListenerIPAddresses {
+                        return @(
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                Add-Member NoteProperty IsDHCP $false -PassThru |
+                                Add-Member NoteProperty IPAddress '192.168.0.1' -PassThru |
+                                Add-Member NoteProperty SubnetMask '255.255.255.0' -PassThru
+                            )
+                        )
+                    } -PassThru -Force
+            } -Verifiable
+
+            Context 'When the system is in the desired state' {
+                It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                        DHCP = $false
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+
+                It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
+                    $testParameters += @{
+                        IpAddress = '192.168.0.1/255.255.255.0'
+                        Port = 5030
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+
+                    Assert-MockCalled Get-SQLAlwaysOnAvailabilityGroupListener -Exactly -Times 1 -Scope It
+                    Assert-MockCalled New-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Set-SqlAvailabilityGroupListener -Exactly -Times 0 -Scope It
+                    Assert-MockCalled Add-SqlAvailabilityGroupListenerStaticIp -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
     }
 }
 finally
 {
-    #region FOOTER
-
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
-
-    #endregion
+    Invoke-TestCleanup
 }

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -11,6 +11,7 @@ FailedToImportSQLPSModule = Failed to import SQLPS module.
 NotConnectedToInstance = Was unable to connect to the instance '{0}\\{1}'
 AlterAvailabilityGroupFailed = Failed to alter the availability group '{0}'.
 HadrNotEnabled = HADR is not enabled.
+AvailabilityGroupNotFound = Unable to locate the availability group '{0}' on the instance '{1}'.
 
 # SQLServer
 NoDatabase = Database '{0}' does not exist on SQL server '{1}\\{2}'.
@@ -75,7 +76,6 @@ InstanceNotPrimaryReplica = The instance '{0}' is not the primary replica for th
 RemoveAvailabilityGroupFailed = Failed to remove the availabilty group '{0}' from the '{1}' instance.
 
 # AlwaysOnAvailabilityGroupReplica
-AvailabilityGroupNotFound = Unable to locate the availability group '{0}' on the instance '{1}'.
 JoinAvailabilityGroupFailed = Failed to join the availability group replica '{0}'.
 RemoveAvailabilityGroupReplicaFailed = Failed to remove the availability group replica '{0}' with the error '{1}'.
 ReplicaNotFound = Unable to find the availability group replica '{0}' on the instance '{1}'.


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerAvailabilityGroupListener
  - Removed the dependency of SQLPS provider (issue #460).
  - Cleaned up code.
  - Cleaned up tests somewhat.
  - Fixed PSSA rule warnings (issue #255).
  - Parameter Ensure now defaults to 'Present' (issue #450).

**This Pull Request (PR) fixes the following issues:**
Fixes #460
Fixes #255 
Fixes #450 
Fixes #233 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/469)
<!-- Reviewable:end -->
