### PR TITLE
xSQLServerAlwaysOnAvailabilityGroup: Fixed permissions checking loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
   - xSQLServerAlwaysOnAvailabilityGroupReplica
 - Changes to xSQLServerDatabaseRecoveryModel
   - Fixed code style, removed SQLServerDatabaseRecoveryModel functions from xSQLServerHelper.
+- Changes to xSQLServerAlwaysOnAvailabilityGroup
+  - Fixed the permissions check loop so that it exits the loop after the function determines the required permissions are in place.
+
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Fixed the permissions check loop so that it exits the loop after the function determines the required permissions are in place.
 
-
 ## 6.0.0.0
 
 - Changes to xSQLServerConfiguration

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -259,7 +259,7 @@ function Set-TargetResource
 
             foreach ( $loginName in @( $clusterServiceName, $ntAuthoritySystemName ) )
             {
-                if ( $serverObject.Logins[$loginName] -and -not $clusterPermissionsPresent )
+                if ( $serverObject.Logins[$loginName] )
                 {
                     $testLoginEffectivePermissionsParams = @{
                         SQLServer = $SQLServer
@@ -270,7 +270,12 @@ function Set-TargetResource
                     
                     $clusterPermissionsPresent = Test-LoginEffectivePermissions @testLoginEffectivePermissionsParams
                     
-                    if ( -not $clusterPermissionsPresent )
+                    if ( $clusterPermissionsPresent )
+                    {
+                        # Exit the loop when the script verifies the required cluster permissions are present
+                        break
+                    }
+                    else
                     {
                         switch ( $loginName )
                         {


### PR DESCRIPTION
**Pull Request (PR) description**
Exit the permissions check loop when the script verifies the required cluster permissions are present.

**This Pull Request (PR) fixes the following issues:**
Fixes xSQLServerAlwaysOnAvailabilityGroup: Reports wrongly that 'NT AUTHORITY\SYSTEM' is missing even if it is not #467 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/470)
<!-- Reviewable:end -->
