### PR TITLE
xSQLServerFirewall: Now works on two or more instances on the same server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
   - Added test for more coverage.
   - Fixed PSSA rule warnings (issue #255).
   - Parameter Ensure now defaults to 'Present' (issue #450).
+- Changes to xSQLServerFirewall
+  - Now it will correctly create rules when the resource is used for two or more instances on the same server (issue #461).
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerFirewall/MSFT_xSQLServerFirewall.psm1
+++ b/DSCResources/MSFT_xSQLServerFirewall/MSFT_xSQLServerFirewall.psm1
@@ -82,7 +82,7 @@ function Get-TargetResource
     $integrationServiceName = 'MsDtsServer{0}0' -f $sqlVersion
     $browserServiceName = 'SQLBrowser'
 
-    $ensure = 'Absent'
+    $ensure = 'Present'
     $featuresInstalled = ''
 
     $services = Get-Service
@@ -111,7 +111,6 @@ function Get-TargetResource
                     if (Test-IsFirewallRuleInDesiredState @databaseEngineFirewallRuleParameters)
                     {
                         $databaseEngineFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -131,7 +130,6 @@ function Get-TargetResource
                     if (Test-IsFirewallRuleInDesiredState @browserFirewallRuleParameters)
                     {
                         $browserFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -176,7 +174,6 @@ function Get-TargetResource
                         -and (Test-IsFirewallRuleInDesiredState @reportingServicesSslFirewallRuleParameters))
                     {
                         $reportingServicesFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -204,7 +201,6 @@ function Get-TargetResource
                     if (Test-IsFirewallRuleInDesiredState @analysisServicesFirewallRuleParameters)
                     {
                         $analysisServicesFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -224,7 +220,6 @@ function Get-TargetResource
                     if (Test-IsFirewallRuleInDesiredState @browserFirewallRuleParameters)
                     {
                         $browserFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -267,7 +262,6 @@ function Get-TargetResource
                         -and (Test-IsFirewallRuleInDesiredState @integrationServicesFirewallRulePortParameters))
                     {
                         $integrationServicesFirewall = $true
-                        $ensure = 'Present'
                     }
                     else
                     {
@@ -277,6 +271,17 @@ function Get-TargetResource
             }
         }
     }
+
+    if (
+        ($Features -match 'SQLENGINE' -and -not ($databaseEngineFirewall -and $browserFirewall)) `
+        -or ($Features -match 'RS' -and -not $reportingServicesFirewall) `
+        -or ($Features -match 'AS' -and -not ($analysisServicesFirewall -and $browserFirewall)) `
+        -or ($Features -match 'IS' -and -not $integrationServicesFirewall)
+    )
+    {
+        $ensure = 'Absent'
+    }
+
 
     $featuresInstalled = $featuresInstalled.Trim(',')
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerFirewall
  - Now it will correctly create rules when the resource is used for two or more instances on the same server (issue #461).

**This Pull Request (PR) fixes the following issues:**
Fixes #461 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/479)
<!-- Reviewable:end -->
