### PR TITLE
BREAKING CHANGE: xSQLServerEndpoint: Refactored this resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
   - xSQLServerConfiguration
     - 1-ConfigureTwoInstancesOnTheSameServerToEnableClr.ps1
     - 2-ConfigureInstanceToEnablePriorityBoost.ps1
+  - xSQLServerEndpoint
+    - 1-CreateEndpointWithDefaultValues.ps1
+    - 2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+    - 3-RemoveEndpoint.ps1
 - Changes to xSQLServerDatabaseRole
   - Fixed code style, added updated parameter descriptions to schema.mof and README.md.
 - Changes to xSQLServer
@@ -98,6 +102,7 @@
   - Parameter Ensure now defaults to 'Present'.
   - Resource now supports changing IP address and changing port.
   - Added unit tests (issue #289)
+  - Added examples.
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
   - Parameter Port now has a default value of 5022.
   - Parameter Ensure now defaults to 'Present'.
   - Resource now supports changing IP address and changing port.
+  - Added unit tests (issue #289)
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@
   - Refactored tests so they use less code.
 - Changes to README.md
   - Adding deprecated tag to xSQLServerFailoverClusterSetup, xSQLAOGroupEnsure and xSQLAOGroupJoin in README.md so it it more clear that these resources has been replaced by xSQLServerSetup, xSQLServerAlwaysOnAvailabilityGroup and xSQLServerAlwaysOnAvailabilityGroupReplica respectively.
+- Changes to xSQLServerEndpoint
+  - BREAKING CHANGE: Now SQLInstanceName is mandatory, and is a key, so SQLInstanceName has no longer a default value (issue #279).
+  - BREAKING CHANGE: Parameter AutorizedUser has been removed (issue #466, issue #275 and issue #80). Connect permissons can be set using the resource xSQLServerEndpointPermission.
+  - Optional parameter IpAddress has been added. Default is to listen on any valid IP-address. (issue #232)
+  - Parameter Port now has a default value of 5022.
+  - Parameter Ensure now defaults to 'Present'.
+  - Resource now supports changing IP address and changing port.
+- Changes to xSQLServerEndpointPermission
+  - Added description to the README.md
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,6 @@
   - Parameter Port now has a default value of 5022.
   - Parameter Ensure now defaults to 'Present'.
   - Resource now supports changing IP address and changing port.
-- Changes to xSQLServerEndpointPermission
-  - Added description to the README.md
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
@@ -1,12 +1,6 @@
-$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
-Write-Verbose -Message "CurrentPath: $currentPath"
-
-# Load Common Code
-Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
-
-# DSC resource to manage SQL Endpoint
-
-# NOTE: This resource requires WMF5 and PsDscRunAsCredential
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+                               -ChildPath 'xSQLServerHelper.psm1') `
+                               -Force
 
 function Get-TargetResource
 {
@@ -14,104 +8,149 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $EndPointName,
+        $EndpointName,
 
-        [ValidateSet("Present","Absent")]
-        [System.String]
-        $Ensure,
-
-        [System.UInt32]
-        $Port,
-
-        [System.String]
-        $AuthorizedUser,
-
+        [Parameter()]
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName = "MSSQLSERVER"
+        $SQLInstanceName
     )
-     
-    $vConfigured = Test-TargetResource -EndPointName $EndPointName -Ensure $Ensure -Port $Port -AuthorizedUser $AuthorizedUser
-    if(!$SQL)
+
+    $getTargetResourceReturnValues = @{
+        SQLServer = $SQLServer
+        SQLInstanceName = $SQLInstanceName
+        Ensure = 'Absent'
+        EndpointName = ''
+        Port = ''
+        IpAddress = ''
+    }
+
+    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    if ($sqlServerObject)
     {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+        Write-Verbose -Message ('Connected to {0}\{1}' -f $SQLServer, $SQLInstanceName)
+
+        $endpointObject = $sqlServerObject.Endpoints[$EndpointName]
+        if ($endpointObject.Name -eq $EndpointName)
+        {
+            if ($sqlServerObject.Endpoints[$EndPointName].EndpointType -ne 'DatabaseMirroring')
+            {
+                throw New-TerminatingError -ErrorType EndpointFoundButWrongType `
+                                            -FormatArgs @($EndpointName) `
+                                            -ErrorCategory InvalidOperation
+            }
+
+            $getTargetResourceReturnValues.Ensure = 'Present'
+            $getTargetResourceReturnValues.EndpointName = $endpointObject.Name
+            $getTargetResourceReturnValues.Port = $endpointObject.Protocol.Tcp.ListenerPort
+            $getTargetResourceReturnValues.IpAddress = $endpointObject.Protocol.Tcp.ListenerIPAddress
+        }
     }
-    
-    $returnValue = @{
-    EndPointName = $EndPointName
-    Ensure = $vConfigured
-    Port = $sql.Endpoints[$EndPointName].Protocol.Tcp.ListenerPort
-    AuthorizedUser = $sql.Endpoints[$EndPointName].EnumObjectPermissions().grantee
+    else
+    {
+        throw New-TerminatingError -ErrorType NotConnectedToInstance `
+                                    -FormatArgs @($SQLServer,$SQLInstanceName) `
+                                    -ErrorCategory InvalidOperation
     }
 
-    $returnValue
+    return $getTargetResourceReturnValues
 }
-
 
 function Set-TargetResource
 {
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $EndPointName,
+        $EndpointName,
 
-        [ValidateSet("Present","Absent")]
+        [Parameter()]
+        [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
-        [System.UInt32]
-        $Port,
+        [Parameter()]
+        [System.UInt16]
+        $Port = 5022,
 
-        [System.String]
-        $AuthorizedUser,
-
+        [Parameter()]
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName = "MSSQLSERVER"
+        $SQLInstanceName,
+
+        [Parameter()]
+        [System.String]
+        $IpAddress = '0.0.0.0'
     )
 
-    if(!$SQL)
-    {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    }
-Write-Verbose "Connected to Server"
+    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
 
-    if($Ensure -eq "Present")
+    $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    if ($sqlServerObject)
     {
-        Write-Verbose "Check to see login $AuthorizedUser exist on the server"
-
-        if(!$SQL.Logins.Contains($AuthorizedUser))
+        if ($Ensure -eq 'Present' -and $getTargetResourceResult.Ensure -eq 'Absent')
         {
-            throw New-TerminatingError -ErrorType NoAuthorizedUser -FormatArgs @($AuthorizedUser,$SQLServer,$SQLInstanceName) -ErrorCategory InvalidResult
+            Write-Verbose -Message ('Creating endpoint {0}.' -f $EndpointName)
+
+            $endpointObject = New-Object -typename Microsoft.SqlServer.Management.Smo.Endpoint -ArgumentList $sqlServerObject, $EndpointName
+            $endpointObject.EndpointType = [Microsoft.SqlServer.Management.Smo.EndpointType]::DatabaseMirroring
+            $endpointObject.ProtocolType = [Microsoft.SqlServer.Management.Smo.ProtocolType]::Tcp
+            $endpointObject.Protocol.Tcp.ListenerPort = $Port
+            $endpointObject.Protocol.Tcp.ListenerIPAddress = $IpAddress
+            $endpointObject.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::All
+            $endpointObject.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::Required
+            $endpointObject.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::Aes
+            $endpointObject.Create()
+            $endpointObject.Start()
         }
-        $Endpoint = New-Object -typename Microsoft.SqlServer.Management.Smo.Endpoint -ArgumentList $Sql,$EndpointName
-        $Endpoint.EndpointType = [Microsoft.SqlServer.Management.Smo.EndpointType]::DatabaseMirroring
-        $Endpoint.ProtocolType = [Microsoft.SqlServer.Management.Smo.ProtocolType]::Tcp
-        $Endpoint.Protocol.Tcp.ListenerPort = $Port
-        $Endpoint.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::All
-        $Endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::Required
-        $Endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::Aes 
-        $Endpoint.Create()
-        $Endpoint.Start()
-        $ConnectPerm = New-Object -TypeName Microsoft.SqlServer.Management.SMO.ObjectPermissionSet
-        $ConnectPerm.Connect= $true
-        $Endpoint.Grant($ConnectPerm,$AuthorizedUser)
+        elseif ($Ensure -eq 'Present' -and $getTargetResourceResult.Ensure -eq 'Present')
+        {
+            # The endpoint already exist, verifying supported endpoint properties so they are in desired state.
+            $endpointObject = $sqlServerObject.Endpoints[$EndpointName]
+            if ($endpointObject)
+            {
+                if ($endpointObject.Protocol.Tcp.ListenerIPAddress -ne $IpAddress)
+                {
+                    Write-Verbose -Message ('Updating endpoint {0} IP address to {1}.' -f $EndpointName, $IpAddress)
+                    $endpointObject.Protocol.Tcp.ListenerIPAddress = $IpAddress
+                }
+
+                if ($endpointObject.Protocol.Tcp.ListenerPort -ne $Port)
+                {
+                    Write-Verbose -Message ('Updating endpoint {0} port to {1}.' -f $EndpointName, $Port)
+                    $endpointObject.Protocol.Tcp.ListenerPort = $Port
+                }
+
+                $endpointObject.Alter()
+            }
+        }
+        elseif ($Ensure -eq 'Absent' -and $getTargetResourceResult.Ensure -eq 'Present')
+        {
+            Write-Verbose -Message ('Dropping endpoint {0}.' -f $EndpointName)
+
+            $endpointObject = $sqlServerObject.Endpoints[$EndpointName]
+            if ($endpointObject)
+            {
+                $endpointObject.Drop()
+            }
+        }
     }
-    elseif($Ensure -eq "Absent")
+    else
     {
-        Write-Verbose "Drop $EndPointName"
-        $SQL.Endpoints[$EndPointName].Drop()
+        throw New-TerminatingError -ErrorType NotConnectedToInstance `
+                                    -FormatArgs @($SQLServer,$SQLInstanceName) `
+                                    -ErrorCategory InvalidOperation
     }
 }
-
 
 function Test-TargetResource
 {
@@ -119,45 +158,53 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $EndPointName,
+        $EndpointName,
 
-        [ValidateSet("Present","Absent")]
+        [Parameter()]
+        [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
-        [System.UInt32]
-        $Port,
+        [Parameter()]
+        [System.UInt16]
+        $Port = 5022,
 
-        [System.String]
-        $AuthorizedUser,
-
+        [Parameter()]
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
-        $SQLInstanceName = "MSSQLSERVER"
+        $SQLInstanceName,
+
+        [Parameter()]
+        [System.String]
+        $IpAddress = '0.0.0.0'
     )
 
-    if(!$SQL)
+    $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
+    if( $getTargetResourceResult.Ensure -eq $Ensure )
     {
-        $SQL = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    }
-    
-    $result = [System.Boolean]
+        $result = $true
 
-
-    if(($sql.Endpoints[$EndPointName].Name -eq $EndPointName)-and($ensure -eq "Present") )
-    {
-        $Result = $true
+        if ($getTargetResourceResult.Ensure -eq 'Present' `
+            -and (
+                $getTargetResourceResult.Port -ne $Port `
+                -or $getTargetResourceResult.IpAddress -ne $IpAddress
+                )
+            )
+        {
+            $result = $false
+        }
     }
     else
-    {$result = $false}
+    {
+        $result = $false
+    }
 
-    $result
+    return $result
 }
 
-
 Export-ModuleMember -Function *-TargetResource
-

--- a/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
@@ -1,7 +1,19 @@
 Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
+<#
+    .SYNOPSIS
+        Returns the current state of the endpoint.
 
+    .PARAMETER EndpointName
+        The name of the endpoint.
+
+    .PARAMETER SQLServer
+        The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+
+    .PARAMETER SQLInstanceName
+        The name of the SQL instance to be configured.
+#>
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -68,6 +80,28 @@ function Get-TargetResource
     return $getTargetResourceReturnValues
 }
 
+<#
+    .SYNOPSIS
+        Create, changes or drops an endpoint.
+
+    .PARAMETER EndpointName
+        The name of the endpoint.
+
+    .PARAMETER Ensure
+        If the endpoint should be present or absent. Default values is 'Present'.
+
+    .PARAMETER Port
+        The network port the endpoint is listening on. Default value is 5022.
+
+    .PARAMETER SQLServer
+        The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+
+    .PARAMETER SQLInstanceName
+        The name of the SQL instance to be configured.
+
+    .PARAMETER IpAddress
+        The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -167,6 +201,28 @@ function Set-TargetResource
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests if the principal (login) has the desired permissions.
+
+    .PARAMETER EndpointName
+        The name of the endpoint.
+
+    .PARAMETER Ensure
+        If the endpoint should be present or absent. Default values is 'Present'.
+
+    .PARAMETER Port
+        The network port the endpoint is listening on. Default value is 5022.
+
+    .PARAMETER SQLServer
+        The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+
+    .PARAMETER SQLInstanceName
+        The name of the SQL instance to be configured.
+
+    .PARAMETER IpAddress
+        The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
+#>
 function Test-TargetResource
 {
     [CmdletBinding()]

--- a/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.psm1
@@ -256,7 +256,7 @@ function Test-TargetResource
     )
 
     $getTargetResourceResult = Get-TargetResource -EndpointName $EndpointName -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    if( $getTargetResourceResult.Ensure -eq $Ensure )
+    if ($getTargetResourceResult.Ensure -eq $Ensure)
     {
         $result = $true
 

--- a/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.schema.mof
+++ b/DSCResources/MSFT_xSQLServerEndpoint/MSFT_xSQLServerEndpoint.schema.mof
@@ -1,12 +1,10 @@
-
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerEndpoint")]
 class MSFT_xSQLServerEndpoint : OMI_BaseResource
 {
-    [Key] String EndPointName;
-    [Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Write] Uint32 Port;
-    [Write] String AuthorizedUser;
-    [Write] String SQLServer;
-    [Write] String SQLInstanceName;
+    [Key, Description("The name of the endpoint.")] String EndpointName;
+    [Write, Description("If the endpoint should be present or absent. Default values is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The network port the endpoint is listening on. Default value is 5022.")] Uint16 Port;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
+    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.")] String IpAddress;
 };
-

--- a/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroup/1-CreateAvailabilityGroup.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroup/1-CreateAvailabilityGroup.ps1
@@ -57,7 +57,6 @@ Configuration Example
             EndPointName = 'HADR'
             Ensure = 'Present'
             Port = 5022
-            AuthorizedUser = 'sa'
             SQLServer = $Node.NodeName
             SQLInstanceName = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -63,7 +63,6 @@ Configuration Example
             EndPointName = 'HADR'
             Ensure = 'Present'
             Port = 5022
-            AuthorizedUser = 'sa'
             SQLServer = $Node.NodeName
             SQLInstanceName = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/2-RemoveAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/2-RemoveAvailabilityGroupReplica.ps1
@@ -63,7 +63,6 @@ Configuration Example
             EndPointName = 'HADR'
             Ensure = 'Present'
             Port = 5022
-            AuthorizedUser = 'sa'
             SQLServer = $Node.NodeName
             SQLInstanceName = $Node.SQLInstanceName
             PsDscRunAsCredential = $SysAdminAccount

--- a/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
@@ -1,6 +1,6 @@
 ﻿<#
     .EXAMPLE
-        This example will add a Database Mirror endpoint using the default values to two instances.
+        This example will add a Database Mirror endpoint, to two instances, using the default values.
 
 #>
 Configuration Example

--- a/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
@@ -1,0 +1,36 @@
+﻿<#
+    .EXAMPLE
+        This example will add a Database Mirror endpoint using the default values to two instances.
+
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        xSQLServerEndpoint SQLConfigureEndpoint
+        {
+            EndpointName = 'HADR'
+            SQLInstanceName = 'INST1'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        xSQLServerEndpoint SQLConfigureEndpoint
+        {
+            EndpointName = 'HADR'
+            SQLInstanceName = 'INST2'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+   }
+}

--- a/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/1-CreateEndpointWithDefaultValues.ps1
@@ -17,7 +17,7 @@ Configuration Example
 
     node localhost
     {
-        xSQLServerEndpoint SQLConfigureEndpoint
+        xSQLServerEndpoint SQLConfigureEndpoint-Instance1
         {
             EndpointName = 'HADR'
             SQLInstanceName = 'INST1'
@@ -25,7 +25,7 @@ Configuration Example
             PsDscRunAsCredential = $SysAdminAccount
         }
 
-        xSQLServerEndpoint SQLConfigureEndpoint
+        xSQLServerEndpoint SQLConfigureEndpoint-Instances2
         {
             EndpointName = 'HADR'
             SQLInstanceName = 'INST2'

--- a/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
@@ -1,6 +1,6 @@
 ﻿<#
     .EXAMPLE
-        This example will add a Database Mirror endpoint with specifc listener port and listener IP address.
+        This example will add a Database Mirror endpoint with a specific listener port and a specific listener IP address.
 #>
 Configuration Example
 {

--- a/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
@@ -1,7 +1,6 @@
 ﻿<#
     .EXAMPLE
         This example will add a Database Mirror endpoint with specifc listener port and listener IP address.
-
 #>
 Configuration Example
 {

--- a/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/2-CreateEndpointWithSpecificPortAndIPAddress.ps1
@@ -1,0 +1,34 @@
+﻿<#
+    .EXAMPLE
+        This example will add a Database Mirror endpoint with specifc listener port and listener IP address.
+
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        xSQLServerEndpoint SQLConfigureEndpoint
+        {
+            Ensure = 'Present'
+
+            EndpointName = 'HADR'
+            Port = 9001
+            IpAddress = '192.168.0.20'
+
+            SQLServer = 'server1.company.local'
+            SQLInstanceName = 'INST1'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+   }
+}

--- a/Examples/Resources/xSQLServerEndpoint/3-RemoveEndpoint.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/3-RemoveEndpoint.ps1
@@ -1,0 +1,39 @@
+﻿<#
+    .EXAMPLE
+        This example will remove an Database Mirror endpoint from two instances.
+
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        xSQLServerEndpoint SQLConfigureEndpoint
+        {
+            Ensure = 'Absent'
+
+            EndpointName = 'HADR'
+            SQLInstanceName = 'INST1'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        xSQLServerEndpoint SQLConfigureEndpoint
+        {
+            Ensure = 'Absent'
+
+            EndpointName = 'HADR'
+            SQLInstanceName = 'INST2'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+   }

--- a/Examples/Resources/xSQLServerEndpoint/3-RemoveEndpoint.ps1
+++ b/Examples/Resources/xSQLServerEndpoint/3-RemoveEndpoint.ps1
@@ -17,7 +17,7 @@ Configuration Example
 
     node localhost
     {
-        xSQLServerEndpoint SQLConfigureEndpoint
+        xSQLServerEndpoint SQLConfigureEndpoint-Instance1
         {
             Ensure = 'Absent'
 
@@ -27,7 +27,7 @@ Configuration Example
             PsDscRunAsCredential = $SysAdminAccount
         }
 
-        xSQLServerEndpoint SQLConfigureEndpoint
+        xSQLServerEndpoint SQLConfigureEndpoint-Instance2
         {
             Ensure = 'Absent'
 
@@ -36,4 +36,5 @@ Configuration Example
 
             PsDscRunAsCredential = $SysAdminAccount
         }
-   }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ This resource is used to create an endpoint. Currently it only supports creating
 * **[Uint16] Port** _(Write)_: The network port the endpoint is listening on. Default value is 5022.
 * **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 * **[String] SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
-* **[String] IpAddress** _(Write)_: The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.
+* **[String] IpAddress** _(Write)_: The network IP address the endpoint is listening on. Defaults to '0.0.0.0' which means listen on any valid IP address.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -452,9 +452,9 @@ Read more about database role in this article [CREATE ROLE (Transact-SQL)](https
 
 This resource is used to create an endpoint. Currently it only supports creating a database mirror endpoint which can be used by, for example, AlwaysOn.
 
->Note: The endpoint will be started after creation, but will not be enforced. Please use xSQLServerEndpointState to make sure the endpoint remains in started state.
-
->Note: To set connect permission to the endpoint, please use the resource xSQLServerEndpointPermission.
+>Note:
+>The endpoint will be started after creation, but will not be enforced. Please use [**xSQLServerEndpointState**](#xsqlserverendpointstate) to make sure the endpoint remains in started state.
+>To set connect permission to the endpoint, please use the resource [**xSQLServerEndpointPermission**](#xsqlserverendpointpermission).
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ None.
 
 ### xSQLServerEndpointPermission
 
-This resource is used to give connect permission to an endpoint for a user (login)
+This resource is used to give connect permission to an endpoint for a user (login).
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -454,6 +454,8 @@ This resource is used to create an endpoint. Currently it only supports creating
 
 >Note: The endpoint will be started after creation, but will not be enforced. Please use xSQLServerEndpointState to make sure the endpoint remains in started state.
 
+>Note: To set connect permission to the endpoint, please use the resource xSQLServerEndpointPermission.
+
 #### Requirements
 
 * Target machine must be running Windows Server 2008 R2 or later.
@@ -478,7 +480,7 @@ None.
 
 ### xSQLServerEndpointPermission
 
-This resource is used to give connect permission to an endpoint for a user (login).
+No description.
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,9 @@ Read more about database role in this article [CREATE ROLE (Transact-SQL)](https
 
 ### xSQLServerEndpoint
 
-No description.
+This resource is used to create an endpoint. Currently it only supports creating a database mirror endpoint which can be used by, for example, AlwaysOn.
+
+>Note: The endpoint will be started after creation, but will not be enforced. Please use xSQLServerEndpointState to make sure the endpoint remains in started state.
 
 #### Requirements
 
@@ -463,12 +465,12 @@ No description.
 
 #### Parameters
 
-* **[String] EndPointName** _(Key)_: Name for endpoint to be created on SQL Server
-* **[String] Ensure** _(Write)_: An enumerated value that describes if endpoint is to be present or absent on SQL Server. { Present | Absent }.
-* **[Uint32] Port** _(Write)_: Port Endpoint should listen on
-* **[String] AuthorizedUser** _(Write)_:  User who should have connect ability to endpoint
-* **[String] SQLServer** _(Write)_: The SQL Server for the database
-* **[String] SQLInstance** _(Write)_: The SQL instance for the database
+* **[String] EndpointName** _(Key)_: The name of the endpoint.
+* **[String] Ensure** _(Write)_: If the endpoint should be present or absent. Default values is 'Present'. { *Present* | Absent }.
+* **[Uint16] Port** _(Write)_: The network port the endpoint is listening on. Default value is 5022.
+* **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+* **[String] SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **[String] IpAddress** _(Write)_: The network IP address the endpoint is listening on. Default the endpoint will listen on any valid IP address.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ This resource is used to create an endpoint. Currently it only supports creating
 
 #### Security Requirements
 
-* The built-in parameter `PsDscRunAsCredential` must be set to the credentials of an account with the permission to enumerate logins, create the endpoint, and alter the permission on an endpoint.
+* The built-in parameter PsDscRunAsCredential must be set to the credentials of an account with the permission to create and alter endpoints.
 
 #### Parameters
 
@@ -480,7 +480,7 @@ None.
 
 ### xSQLServerEndpointPermission
 
-No description.
+This resource is used to give connect permission to an endpoint for a user (login)
 
 #### Requirements
 

--- a/Tests/Unit/MSFT_xSQLServerEndpoint.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpoint.Tests.ps1
@@ -1,0 +1,312 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerEndpoint'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup {
+    # Loading mocked classes
+    #Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $mockNodeName = 'localhost'
+        $mockInstanceName = 'DEFAULT'
+        $mockPrincipal = 'COMPANY\SqlServiceAcct'
+        $mockOtherPrincipal = 'COMPANY\OtherAcct'
+        $mockEndpointName = 'DefaultEndpointMirror'
+
+        $script:mockMethodGrantRan = $false
+        $script:mockMethodRevokeRan = $false
+
+        $mockConnectSql = {
+            return New-Object Object |
+                Add-Member ScriptProperty Endpoints {
+                    return @(
+                        @{
+                            # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                            'DefaultEndpointMirror' = New-Object Object |
+                                                        Add-Member NoteProperty Name $mockEndpointName -PassThru |
+                                                        Add-Member ScriptMethod EnumObjectPermissions {
+                                                            param($permissionSet)
+                                                            return @(
+                                                                (New-Object Object |
+                                                                    Add-Member NoteProperty Grantee $mockDynamicPrincipal -PassThru |
+                                                                    Add-Member NoteProperty PermissionState 'Grant' -PassThru
+                                                                )
+                                                            )
+                                                        } -PassThru |
+                                                        Add-Member ScriptMethod Grant {
+                                                            param(
+                                                                $permissionSet,
+                                                                $mockPrincipal
+                                                            )
+
+                                                            $script:mockMethodGrantRan = $true
+                                                        } -PassThru |
+                                                        Add-Member ScriptMethod Revoke {
+                                                            param(
+                                                                $permissionSet,
+                                                                $mockPrincipal
+                                                            )
+
+                                                            $script:mockMethodRevokeRan = $true
+                                                        } -PassThru -Force
+                        }
+                    )
+                } -PassThru -Force
+        }
+
+        $defaultParameters = @{
+            InstanceName = $mockInstanceName
+            NodeName = $mockNodeName
+            Name = $mockEndpointName
+            Principal = $mockPrincipal
+        }
+
+        Describe 'MSFT_xSQLServerEndpointPermission\Get-TargetResource' -Tag 'Get' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+            }
+
+            $mockDynamicPrincipal = $mockOtherPrincipal
+
+            Context 'When the system is not in the desired state' {
+                It 'Should return the desired state as absent' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should Be 'Absent'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.mockNodeName | Should Be $testParameters.mockNodeName
+                    $result.mockInstanceName | Should Be $testParameters.mockInstanceName
+                    $result.Name | Should Be $testParameters.Name
+                    $result.mockPrincipal | Should Be $testParameters.mockPrincipal
+                }
+
+                It 'Should not return any permissions' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Permission | Should Be ''
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    $result = Get-TargetResource @testParameters
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            $mockDynamicPrincipal = $mockPrincipal
+
+            Context 'When the system is in the desired state' {
+                It 'Should return the desired state as present' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should Be 'Present'
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.mockNodeName | Should Be $testParameters.mockNodeName
+                    $result.mockInstanceName | Should Be $testParameters.mockInstanceName
+                    $result.Name | Should Be $testParameters.Name
+                    $result.mockPrincipal | Should Be $testParameters.mockPrincipal
+                }
+
+                It 'Should return the permissions passed as parameter' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Permission | Should Be 'CONNECT'
+                }
+
+                It 'Should call the mock function Connect-SQL' {
+                    $result = Get-TargetResource @testParameters
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'MSFT_xSQLServerEndpointPermission\Test-TargetResource' -Tag 'Test' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                $mockDynamicPrincipal = $mockOtherPrincipal
+
+                It 'Should return that desired state is absent when wanted desired state is to be Present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        Permission = 'CONNECT'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                $mockDynamicPrincipal = $mockPrincipal
+
+                It 'Should return that desired state is absent when wanted desired state is to be Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                        Permission = 'CONNECT'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                $mockDynamicPrincipal = $mockPrincipal
+
+                It 'Should return that desired state is present when wanted desired state is to be Present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        Permission = 'CONNECT'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                $mockDynamicPrincipal = $mockOtherPrincipal
+
+                It 'Should return that desired state is present when wanted desired state is to be Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                        Permission = 'CONNECT'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'MSFT_xSQLServerEndpointPermission\Set-TargetResource' -Tag 'Set' {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                $mockDynamicPrincipal = $mockOtherPrincipal
+                $script:mockMethodGrantRan = $false
+                $script:mockMethodRevokeRan = $false
+
+                It 'Should call the the method Grant when desired state is to be Present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        Permission = 'CONNECT'
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+                    $script:mockMethodGrantRan | Should Be $true
+                    $script:mockMethodRevokeRan | Should Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope It
+                }
+
+                $mockDynamicPrincipal = $mockPrincipal
+                $script:mockMethodGrantRan = $false
+                $script:mockMethodRevokeRan = $false
+
+                It 'Should call the the method Revoke when desired state is to be Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                        Permission = 'CONNECT'
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+                    $script:mockMethodGrantRan | Should Be $false
+                    $script:mockMethodRevokeRan | Should Be $true
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope It
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                $mockDynamicPrincipal = $mockPrincipal
+                $script:mockMethodGrantRan = $false
+                $script:mockMethodRevokeRan = $false
+
+                It 'Should not call Grant() or Revoke() method when desired state is already Present' {
+                    $testParameters += @{
+                        Ensure = 'Present'
+                        Permission = 'CONNECT'
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+                    $script:mockMethodGrantRan | Should Be $false
+                    $script:mockMethodRevokeRan | Should Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                $mockDynamicPrincipal = $mockOtherPrincipal
+                $script:mockMethodGrantRan = $false
+                $script:mockMethodRevokeRan = $false
+
+                It 'Should not call Grant() or Revoke() method when desired state is already Absent' {
+                    $testParameters += @{
+                        Ensure = 'Absent'
+                        Permission = 'CONNECT'
+                    }
+
+                    { Set-TargetResource @testParameters } | Should Not Throw
+                    $script:mockMethodGrantRan | Should Be $false
+                    $script:mockMethodRevokeRan | Should Be $false
+
+                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -18,10 +18,10 @@ namespace Microsoft.SqlServer.Management.Smo
         IsHashed = 1,
         MustChange = 2
     }
-    
+
     // TypeName: Microsoft.SqlServer.Management.Smo.LoginType
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLServerLogin
     public enum LoginType
     {
@@ -32,11 +32,11 @@ namespace Microsoft.SqlServer.Management.Smo
         SqlLogin = 2,
         WindowsGroup = 1,
         WindowsUser = 0,
-        Unknown = -1    // Added for verification (mock) purposes, to verify that a login type is passed  
+        Unknown = -1    // Added for verification (mock) purposes, to verify that a login type is passed
     }
-    
+
     // TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityReplicaFailoverMode
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLAOGroupEnsure.Tests
     public enum AvailabilityReplicaFailoverMode
     {
@@ -46,13 +46,69 @@ namespace Microsoft.SqlServer.Management.Smo
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityReplicaAvailabilityMode
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLAOGroupEnsure.Tests
     public enum AvailabilityReplicaAvailabilityMode
     {
         AsynchronousCommit,
         SynchronousCommit,
         Unknown
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.EndpointType
+    // Used by:
+    //  xSQLServerEndpoint
+    public enum EndpointType
+    {
+        DatabaseMirroring,
+        ServiceBroker,
+        Soap,
+        TSql
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.ProtocolType
+    // Used by:
+    //  xSQLServerEndpoint
+    public enum ProtocolType
+    {
+        Http,
+        NamedPipes,
+        SharedMemory,
+        Tcp,
+        Via
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.ServerMirroringRole
+    // Used by:
+    //  xSQLServerEndpoint
+    public enum ServerMirroringRole
+    {
+        All,
+        None,
+        Partner,
+        Witness
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.EndpointEncryption
+    // Used by:
+    //  xSQLServerEndpoint
+    public enum EndpointEncryption
+    {
+        Disabled,
+        Required,
+        Supported
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm
+    // Used by:
+    //  xSQLServerEndpoint
+    public enum EndpointEncryptionAlgorithm
+    {
+        Aes,
+        AesRC4,
+        None,
+        RC4,
+        RC4Aes
     }
 
     #endregion Public Enums
@@ -67,41 +123,41 @@ namespace Microsoft.SqlServer.Management.Smo
 
     // Typename: Microsoft.SqlServer.Management.Smo.ObjectPermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
-    // Used by: 
+    // Used by:
     //  xSQLServerEndpointPermission.Tests.ps1
-    public class ObjectPermissionSet 
+    public class ObjectPermissionSet
     {
         public ObjectPermissionSet(){}
 
         public ObjectPermissionSet(
             bool connect )
         {
-            this.Connect = connect; 
-        } 
-    
+            this.Connect = connect;
+        }
+
         public bool Connect = false;
     }
-    
+
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
-    // Used by: 
+    // Used by:
     //  xSQLServerPermission.Tests.ps1
-    public class ServerPermissionSet 
+    public class ServerPermissionSet
     {
         public ServerPermissionSet(){}
 
         public ServerPermissionSet(
-            bool alterAnyAvailabilityGroup, 
+            bool alterAnyAvailabilityGroup,
             bool alterAnyEndPoint,
-            bool connectSql,  
+            bool connectSql,
             bool viewServerState )
         {
-            this.AlterAnyAvailabilityGroup = alterAnyAvailabilityGroup; 
+            this.AlterAnyAvailabilityGroup = alterAnyAvailabilityGroup;
             this.AlterAnyEndPoint = alterAnyEndPoint;
             this.ConnectSql = connectSql;
             this.ViewServerState = viewServerState;
-        } 
-    
+        }
+
         public bool AlterAnyAvailabilityGroup = false;
         public bool AlterAnyEndPoint = false;
         public bool ConnectSql = false;
@@ -110,9 +166,9 @@ namespace Microsoft.SqlServer.Management.Smo
 
     // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionInfo
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionInfo
-    // Used by: 
+    // Used by:
     //  xSQLServerPermission.Tests.ps1
-    public class ServerPermissionInfo 
+    public class ServerPermissionInfo
     {
         public ServerPermissionInfo()
         {
@@ -120,39 +176,39 @@ namespace Microsoft.SqlServer.Management.Smo
             this.PermissionType = permissionSet;
         }
 
-        public ServerPermissionInfo( 
+        public ServerPermissionInfo(
             Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet )
         {
             this.PermissionType = permissionSet;
         }
-        
+
         public Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] PermissionType;
         public string PermissionState = "Grant";
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.DatabasePermissionSet
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
-    // Used by: 
+    // Used by:
     //  xSQLServerDatabasePermission.Tests.ps1
-    public class DatabasePermissionSet 
+    public class DatabasePermissionSet
     {
         public DatabasePermissionSet(){}
 
         public DatabasePermissionSet( bool connect, bool update )
         {
-            this.Connect = connect; 
+            this.Connect = connect;
             this.Update = update;
-        } 
-    
+        }
+
         public bool Connect = false;
         public bool Update = false;
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo
     // BaseType: Microsoft.SqlServer.Management.Smo.PermissionInfo
-    // Used by: 
+    // Used by:
     //  xSQLServerDatabasePermission.Tests.ps1
-    public class DatabasePermissionInfo 
+    public class DatabasePermissionInfo
     {
         public DatabasePermissionInfo()
         {
@@ -164,18 +220,18 @@ namespace Microsoft.SqlServer.Management.Smo
         {
             this.PermissionType = permissionSet;
         }
-        
+
         public Microsoft.SqlServer.Management.Smo.DatabasePermissionSet[] PermissionType;
         public string PermissionState = "Grant";
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.Server
     // BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
-    // Used by: 
+    // Used by:
     //  xSQLServerPermission
     //  MSFT_xSQLServerLogin
-    public class Server 
-    { 
+    public class Server
+    {
         public string MockGranteeName;
 
         public string Name;
@@ -185,14 +241,14 @@ namespace Microsoft.SqlServer.Management.Smo
         public bool IsClustered = false;
         public bool IsHadrEnabled = false;
 
-        public Server(){} 
+        public Server(){}
 
-        public Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] EnumServerPermissions( string principal, Microsoft.SqlServer.Management.Smo.ServerPermissionSet permissionSetQuery ) 
-        { 
+        public Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] EnumServerPermissions( string principal, Microsoft.SqlServer.Management.Smo.ServerPermissionSet permissionSetQuery )
+        {
             List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo> listOfServerPermissionInfo = new List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo>();
-            
+
             if( Globals.GenerateMockData ) {
-                Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = { 
+                Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = {
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( true, false, false, false ),
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, true, false, false ),
                     new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, false, true, false ),
@@ -210,7 +266,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Grant( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
         {
-            if( granteeName != this.MockGranteeName ) 
+            if( granteeName != this.MockGranteeName )
             {
                 string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
                 throw new System.ArgumentException(errorMessage, "granteeName");
@@ -219,7 +275,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Revoke( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
         {
-            if( granteeName != this.MockGranteeName ) 
+            if( granteeName != this.MockGranteeName )
             {
                 string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
                 throw new System.ArgumentException(errorMessage, "granteeName");
@@ -229,9 +285,9 @@ namespace Microsoft.SqlServer.Management.Smo
 
     // TypeName: Microsoft.SqlServer.Management.Smo.Login
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLServerLogin
-    public class Login 
+    public class Login
     {
         private bool _mockPasswordPassed = false;
 
@@ -248,12 +304,12 @@ namespace Microsoft.SqlServer.Management.Smo
         {
             this.Name = name;
         }
-        
+
         public Login( Object server, string name )
         {
             this.Name = name;
         }
-        
+
         public void Alter()
         {
             if( !( String.IsNullOrEmpty(this.MockName) ) )
@@ -272,15 +328,15 @@ namespace Microsoft.SqlServer.Management.Smo
                 }
             }
         }
-        
+
         public void ChangePassword( SecureString secureString )
         {
             IntPtr valuePtr = IntPtr.Zero;
             try
             {
-                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);            
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
                 if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
-                {                    
+                {
                     throw new FailedOperationException (
                         "FailedOperationException",
                         new SmoException (
@@ -308,7 +364,7 @@ namespace Microsoft.SqlServer.Management.Smo
                 Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
             }
         }
-        
+
         public void Create()
         {
             if( this.LoginType == LoginType.Unknown ) {
@@ -350,7 +406,7 @@ namespace Microsoft.SqlServer.Management.Smo
             {
                 valuePtr = Marshal.SecureStringToGlobalAllocUnicode(password);
                 if ( Marshal.PtrToStringUni(valuePtr) == "pw" )
-                {                    
+                {
                     throw new FailedOperationException (
                         "FailedOperationException",
                         new SmoException (
@@ -373,9 +429,9 @@ namespace Microsoft.SqlServer.Management.Smo
                     throw new Exception ();
                 }
                 else
-                {                    
+                {
                     _mockPasswordPassed = true;
-                    
+
                     this.Create();
                 }
             }
@@ -404,28 +460,28 @@ namespace Microsoft.SqlServer.Management.Smo
             }
         }
     }
-	
+
 	// TypeName: Microsoft.SqlServer.Management.Smo.ServerRole
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLServerRole
-    public class ServerRole 
+    public class ServerRole
     {
         public ServerRole( Server server, string name ) {
             this.Name = name;
-        } 
+        }
 
         public ServerRole( Object server, string name ) {
             this.Name = name;
-        } 
-            
+        }
+
         public string Name;
     }
 
 
 	// TypeName: Microsoft.SqlServer.Management.Smo.Database
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
-    // Used by: 
+    // Used by:
     //  MSFT_xSQLServerDatabase
     //  MSFT_xSQLServerDatabasePermission
 	public class Database
@@ -434,28 +490,28 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public Database( Server server, string name ) {
             this.Name = name;
-        } 
+        }
 
         public Database( Object server, string name ) {
             this.Name = name;
-        } 
-            
+        }
+
         public string Name;
-		
+
 		public void Create()
         {
         }
-		
+
 		public void Drop()
         {
         }
-		
-        public Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo[] EnumDatabasePermissions( string granteeName ) 
-        { 
+
+        public Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo[] EnumDatabasePermissions( string granteeName )
+        {
             List<Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo> listOfDatabasePermissionInfo = new List<Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo>();
-            
+
             if( Globals.GenerateMockData ) {
-                Microsoft.SqlServer.Management.Smo.DatabasePermissionSet[] permissionSet = { 
+                Microsoft.SqlServer.Management.Smo.DatabasePermissionSet[] permissionSet = {
                     new Microsoft.SqlServer.Management.Smo.DatabasePermissionSet( true, false ),
                     new Microsoft.SqlServer.Management.Smo.DatabasePermissionSet( false, true )
                 };
@@ -472,7 +528,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Grant( Microsoft.SqlServer.Management.Smo.DatabasePermissionSet permission, string granteeName )
         {
-            if( granteeName != this.MockGranteeName ) 
+            if( granteeName != this.MockGranteeName )
             {
                 string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
                 throw new System.ArgumentException(errorMessage, "granteeName");
@@ -481,7 +537,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Deny( Microsoft.SqlServer.Management.Smo.DatabasePermissionSet permission, string granteeName )
         {
-            if( granteeName != this.MockGranteeName ) 
+            if( granteeName != this.MockGranteeName )
             {
                 string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
                 throw new System.ArgumentException(errorMessage, "granteeName");
@@ -491,14 +547,14 @@ namespace Microsoft.SqlServer.Management.Smo
 
     // TypeName: Microsoft.SqlServer.Management.Smo.User
     // BaseType: Microsoft.SqlServer.Management.Smo.ScriptNameObjectBase
-    // Used by: 
+    // Used by:
     //  xSQLServerDatabaseRole.Tests.ps1
-    public class User 
+    public class User
     {
         public User( Server server, string name )
         {
             this.Name = name;
-        } 
+        }
 
         public User( Object server, string name )
         {
@@ -518,7 +574,7 @@ namespace Microsoft.SqlServer.Management.Smo
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.SqlServerManagementException
-    // BaseType: System.Exception 
+    // BaseType: System.Exception
     // Used by:
     //  xSqlServerLogin.Tests.ps1
     public class SqlServerManagementException : Exception
@@ -531,7 +587,7 @@ namespace Microsoft.SqlServer.Management.Smo
     }
 
     // TypeName: Microsoft.SqlServer.Management.Smo.SmoException
-    // BaseType: Microsoft.SqlServer.Management.Smo.SqlServerManagementException  
+    // BaseType: Microsoft.SqlServer.Management.Smo.SqlServerManagementException
     // Used by:
     //  xSqlServerLogin.Tests.ps1
     public class SmoException : SqlServerManagementException
@@ -539,7 +595,7 @@ namespace Microsoft.SqlServer.Management.Smo
         public SmoException () : base () {}
 
         public SmoException (string message) : base (message) {}
-        
+
         public SmoException (string message, SqlServerManagementException inner) : base (message, inner) {}
     }
 
@@ -550,9 +606,9 @@ namespace Microsoft.SqlServer.Management.Smo
     public class FailedOperationException : SmoException
     {
         public FailedOperationException () : base () {}
-        
+
         public FailedOperationException (string message) : base (message) {}
-        
+
         public FailedOperationException (string message, SmoException inner) : base (message, inner) {}
     }
 
@@ -585,7 +641,7 @@ namespace Microsoft.SqlServer.Management.Smo
             }
         }
     }
-    
+
     // TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityReplica
     // BaseType: Microsoft.SqlServer.Management.Smo.NamedSmoObject
     // Used by:
@@ -607,7 +663,7 @@ namespace Microsoft.SqlServer.Management.Smo
         public string Name;
         public string ReadOnlyRoutingConnectionUrl;
         public string[] ReadOnlyRoutingList;
-        
+
         public void Alter()
         {
             if ( this.Name == "AlterFailed" )

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -35,6 +35,7 @@ AvailabilityGroupListenerDHCPChangeError = IP-address configuration mismatch. Ex
 # Endpoint
 EndpointNotFound = Endpoint '{0}' does not exist
 EndpointErrorVerifyExist = Unexpected result when trying to verify existence of endpoint '{0}'.
+EndpointFoundButWrongType = Endpoint '{0}' does exist, but it is not of type 'DatabaseMirroring'.
 
 # Permission
 PermissionGetError = Unexpected result when trying to get permissions for '{0}'.


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerEndpoint
  - BREAKING CHANGE: Now SQLInstanceName is mandatory, and is a key, so SQLInstanceName has no longer a default value (issue #279).
  - BREAKING CHANGE: Parameter AutorizedUser has been removed (issue #466, issue #275 and issue #80). Connect permissons can be set using the resource xSQLServerEndpointPermission.
  - Optional parameter IpAddress has been added. Default is to listen on any valid IP-address. (issue #232)
  - Parameter Port now has a default value of 5022.
  - Parameter Ensure now defaults to 'Present'.
  - Resource now supports changing IP address and changing port.
  - Added unit tests (issue #289)
  - Added examples.

This resource is dependent on that PR #485 is merged before this one, so there is not a problem setting permissions.

**This Pull Request (PR) fixes the following issues:**
Fixes #466 
Fixes #289  
Fixes #279 
Fixes #275 
Fixes #232 
Fixes #80 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/495)
<!-- Reviewable:end -->
