### PR TITLE
xSQLServerEndpointState: Removed dependency of SQLPS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@
   - Resource now supports changing IP address and changing port.
   - Added unit tests (issue #289)
   - Added examples.
+- Changes to xSQLServerEndpointState
+  - Cleaned up code, removed `SupportsShouldProcess` and fixed PSSA rules warnings (issue #258 and issue #230).
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,12 @@
   - Added unit tests (issue #289)
   - Added examples.
 - Changes to xSQLServerEndpointState
-  - Cleaned up code, removed `SupportsShouldProcess` and fixed PSSA rules warnings (issue #258 and issue #230).
-  - Now the defult value for the parameter `State` is 'Started'.
+  - Cleaned up code, removed SupportsShouldProcess and fixed PSSA rules warnings (issue #258 and issue #230).
+  - Now the defult value for the parameter State is 'Started'.
   - Updated README.md with a description for the resources and revised the parameter descriptions.
   - Removed dependency of SQLPS provider (issue #481).
+  - The parameter NodeName is no longer mandatory and has now the default value of $env:COMPUTERNAME.
+  - The parameter Name is now a key so it is now possible to change the state on more than one endpoint on the same instance. _Note: The resource still only supports Database Mirror endpoints at this time._
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@
   - Added examples.
 - Changes to xSQLServerEndpointState
   - Cleaned up code, removed `SupportsShouldProcess` and fixed PSSA rules warnings (issue #258 and issue #230).
+  - Now the defult value for the parameter `State` is 'Started'.
+  - Updated README.md with a description for the resources and revised the parameter descriptions.
+  - Removed dependency of SQLPS provider (issue #481).
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.psm1
@@ -24,9 +24,9 @@ function Get-TargetResource
         [System.String]
         $InstanceName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
-        $NodeName,
+        $NodeName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -87,9 +87,9 @@ function Set-TargetResource
         [System.String]
         $InstanceName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
-        $NodeName,
+        $NodeName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -162,9 +162,9 @@ function Test-TargetResource
         [System.String]
         $InstanceName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
-        $NodeName,
+        $NodeName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
+++ b/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerEndpointState")]
 class MSFT_xSQLServerEndpointState : OMI_BaseResource
 {
-    [Key, Description(The name of the SQL instance to be configured.")] String InstanceName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Required, Description("The host name of the SQL Server to be configured.")] String NodeName;
     [Required, Description("The name of the endpoint.")] String Name;
     [Write, Description("The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'."), ValueMap{"Started","Stopped","Disabled"}, Values{"Started","Stopped","Disabled"}] String State;

--- a/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
+++ b/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
@@ -1,10 +1,8 @@
-
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerEndpointState")]
 class MSFT_xSQLServerEndpointState : OMI_BaseResource
 {
-    [Key, Description("The SQL Server instance name.")] String InstanceName;
-    [Required, Description("The host name or FQDN.")] String NodeName;
+    [Key, Description(The name of the SQL instance to be configured.")] String InstanceName;
+    [Required, Description("The host name of the SQL Server to be configured.")] String NodeName;
     [Required, Description("The name of the endpoint.")] String Name;
-    [Write, Description("The state of the endpoint. Valid states are Started, Stopped or Disabled."), ValueMap{"Started","Stopped","Disabled"}, Values{"Started","Stopped","Disabled"}] String State;
+    [Write, Description("The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'."), ValueMap{"Started","Stopped","Disabled"}, Values{"Started","Stopped","Disabled"}] String State;
 };
-

--- a/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
+++ b/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_xSQLServerEndpointState : OMI_BaseResource
 {
     [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
-    [Required, Description("The host name of the SQL Server to be configured.")] String NodeName;
-    [Required, Description("The name of the endpoint.")] String Name;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String NodeName;
+    [Key, Description("The name of the endpoint.")] String Name;
     [Write, Description("The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'."), ValueMap{"Started","Stopped","Disabled"}, Values{"Started","Stopped","Disabled"}] String State;
 };

--- a/Examples/Resources/xSQLServerEndpointState/1-MakeSureEndpointIsStarted.ps1
+++ b/Examples/Resources/xSQLServerEndpointState/1-MakeSureEndpointIsStarted.ps1
@@ -1,6 +1,15 @@
 ﻿<#
     .EXAMPLE
-        This example will make sure that the endpoint DefaultMirrorEndpoint is in started state, if not it will start the endpoint.
+        This example will make sure that the endpoint DefaultMirrorEndpoint is in started state in the default instance, if not it will start the endpoint.
+
+    .EXAMPLE
+        This example will make sure that the endpoint HADR is in started state in the default instance, if not it will start the endpoint.
+
+    .EXAMPLE
+        This example will make sure that the endpoint DefaultMirrorEndpoint is in started state in the named instance INSTANCE1, if not it will start the endpoint.
+
+    .NOTES
+        There is three different scenarios in this example to validate the schema during unit testing.
 #>
 Configuration Example
 {
@@ -16,11 +25,33 @@ Configuration Example
 
     node localhost
     {
-        # Start the endpoint
-        xSQLServerEndpointState StartEndpoint
+        # Start the DefaultMirrorEndpoint in the default instance
+        xSQLServerEndpointState StartEndpoint1
         {
             NodeName = 'SQLNODE01.company.local'
             InstanceName = 'MSSQLSERVER'
+            Name = 'DefaultMirrorEndpoint'
+            State = 'Started'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        # Start the HADR in the default instance
+        xSQLServerEndpointState StartEndpoint2
+        {
+            NodeName = 'SQLNODE01.company.local'
+            InstanceName = 'MSSQLSERVER'
+            Name = 'HADR'
+            State = 'Started'
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        # Start the DefaultMirrorEndpoint in the named instance INSTANCE1
+        xSQLServerEndpointState StartEndpoint3
+        {
+            NodeName = 'SQLNODE01.company.local'
+            InstanceName = 'INSTANCE1'
             Name = 'DefaultMirrorEndpoint'
             State = 'Started'
 

--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ This resource is used to set the state of an endpoint.
 #### Parameters
 
 * **[String] InstanceName** _(Key)_: The name of the SQL instance to be configured.
-* **[String] NodeName** _(Required)_: The host name of the SQL Server to be configured.
-* **[String] Name** _(Required)_: The name of the endpoint.
+* **[String] NodeName** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+* **[String] Name** _(Key)_: The name of the endpoint.
 * **[String] State** _(Write)_: The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'. { *Started* | Stopped | Disabled }.
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -505,7 +505,9 @@ This resource is used to give connect permission to an endpoint for a user (logi
 
 ### xSQLServerEndpointState
 
-No description.
+This resource is used to set the state of an endpoint.
+
+>Note: Currently this resource can only be used with Database Mirror endpoints.
 
 #### Requirements
 
@@ -515,10 +517,10 @@ No description.
 
 #### Parameters
 
-* **[String] InstanceName** _(Key)_: The SQL Server instance name.
-* **[String] NodeName** _(Required)_: The host name or FQDN.
+* **[String] InstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **[String] NodeName** _(Required)_: The host name of the SQL Server to be configured.
 * **[String] Name** _(Required)_: The name of the endpoint.
-* **[String] State** _(Write)_: The state of the endpoint. Valid states are Started, Stopped or Disabled. { Started | Stopped | Disabled }.
+* **[String] State** _(Write)_: The state of the endpoint. Valid states are Started, Stopped or Disabled. Default value is 'Started'. { *Started* | Stopped | Disabled }.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
@@ -258,26 +258,6 @@ try
             Assert-VerifiableMocks
         }
 
-        Write-Verbose -Message '' -Verbose
-        Write-Verbose -Message 'Available modules:' -Verbose
-        Get-Module -ListAvailable | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
-
-        Write-Verbose -Message '' -Verbose
-        Write-Verbose -Message 'Loaded modules:' -Verbose
-        Get-Module | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
-
-        Write-Verbose -Message '' -Verbose
-        Write-Verbose -Message 'Commands from SQLPSStub:' -Verbose
-        Get-Command -Module SQLPSStub -Name Set-Sql* | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
-
-        Write-Verbose -Message '' -Verbose
-        Describe 'Testing SQLPSStub Set-SqlHADREndpoint stub cmdlet' {
-            It 'Should throw correct errot' {
-                { Set-SqlHADREndpoint } | Should Throw 'StubNotImplemented'
-            }
-        }
-        Write-Verbose -Message '' -Verbose
-
         Describe 'MSFT_xSQLServerEndpointState\Set-TargetResource' -Tag Set {
             BeforeEach {
                 $testParameters = $defaultParameters.Clone()

--- a/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
@@ -22,7 +22,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 function Invoke-TestSetup {
     # Loading stub cmdlets
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+    Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
 }
 
 function Invoke-TestCleanup {
@@ -70,7 +70,7 @@ try
 
         Describe 'MSFT_xSQLServerEndpointState\Get-TargetResource' -Tag Get {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -182,7 +182,7 @@ try
 
         Describe 'MSFT_xSQLServerEndpointState\Test-TargetResource' -Tag Test {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -192,9 +192,7 @@ try
 
                 Context 'When desired state should be Started, but the current state is Stopped' {
                     It 'Should return that desired state as absent' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStarted
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStarted)
 
                         $result = Test-TargetResource @testParameters
                         $result | Should Be $false
@@ -207,9 +205,7 @@ try
 
                 Context 'When desired state should be Stopped, but the current state is Started' {
                     It 'Should return that desired state as absent' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStopped
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStopped)
 
                         $result = Test-TargetResource @testParameters
                         $result | Should Be $false
@@ -224,9 +220,7 @@ try
 
                 Context 'When desired state should be Started, and the current state is Started' {
                     It 'Should return that desired state as absent' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStarted
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStarted)
 
                         $result = Test-TargetResource @testParameters
                         $result | Should Be $true
@@ -239,9 +233,7 @@ try
 
                 Context 'When desired state should be Stopped, and the current state is Stopped' {
                     It 'Should return that desired state as absent' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStopped
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStopped)
 
                         $result = Test-TargetResource @testParameters
                         $result | Should Be $true
@@ -251,7 +243,7 @@ try
                 }
 
                 Context 'When Get-TargetResource returns nothing' {
-                    It 'Should thor the correct error message' {
+                    It 'Should throw the correct error message' {
                         Mock -CommandName Get-TargetResource -MockWith {
                             return $null
                         } -Verifiable
@@ -266,9 +258,29 @@ try
             Assert-VerifiableMocks
         }
 
+        Write-Verbose -Message '' -Verbose
+        Write-Verbose -Message 'Available modules:' -Verbose
+        Get-Module -ListAvailable | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
+
+        Write-Verbose -Message '' -Verbose
+        Write-Verbose -Message 'Loaded modules:' -Verbose
+        Get-Module | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
+
+        Write-Verbose -Message '' -Verbose
+        Write-Verbose -Message 'Commands from SQLPSStub:' -Verbose
+        Get-Command -Module SQLPSStub -Name Set-Sql* | ForEach-Object { Write-Verbose -Message $_.Name -Verbose }
+
+        Write-Verbose -Message '' -Verbose
+        Describe 'Testing SQLPSStub Set-SqlHADREndpoint stub cmdlet' {
+            It 'Should throw correct errot' {
+                { Set-SqlHADREndpoint } | Should Throw 'StubNotImplemented'
+            }
+        }
+        Write-Verbose -Message '' -Verbose
+
         Describe 'MSFT_xSQLServerEndpointState\Set-TargetResource' -Tag Set {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
                 Mock Set-SqlHADREndpoint -Verifiable
@@ -279,9 +291,7 @@ try
 
                 Context 'When desired state should be Started, but the current state is Stopped' {
                     It 'Should call the mock function Set-SqlHADREndpoint to set the state to Started' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStarted
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStarted)
 
                         Set-TargetResource @testParameters
 
@@ -293,9 +303,7 @@ try
 
                 Context 'When desired state should be Stopped, but the current state is Started' {
                     It 'Should call the mock function Set-SqlHADREndpoint to set the state to Stopped' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStopped
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStopped)
 
                         Set-TargetResource @testParameters
 
@@ -309,9 +317,7 @@ try
 
                 Context 'When desired state should be Started, and the current state is Started' {
                     It 'Should not call the mock function Set-SqlHADREndpoint' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStarted
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStarted)
 
                         Set-TargetResource @testParameters
 
@@ -323,9 +329,7 @@ try
 
                 Context 'When desired state should be Stopped, and the current state is Stopped' {
                     It 'Should not call the mock function Set-SqlHADREndpoint' {
-                        $testParameters += @{
-                            State = $mockEndpointStateStopped
-                        }
+                        $testParameters.Add('State', $mockEndpointStateStopped)
 
                         Set-TargetResource @testParameters
 

--- a/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
@@ -1,10 +1,10 @@
 $script:DSCModuleName      = 'xSQLServer'
-$script:DSCResourceName    = 'MSFT_xSQLServerEndPointState'
+$script:DSCResourceName    = 'MSFT_xSQLServerEndpointState'
 
 #region HEADER
 
-# Unit Test Template Version: 1.1.0
-[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
@@ -16,355 +16,341 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 #endregion HEADER
+
+function Invoke-TestSetup {
+    # Loading stub cmdlets
+    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
 
 # Begin Testing
 try
 {
-    #region Pester Test Initialization
+    Invoke-TestSetup
 
-    # Loading stub cmdlets
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SQLPSStub.psm1') -Force
+    InModuleScope $script:DSCResourceName {
+        $mockNodeName = 'localhost'
+        $mockInstanceName = 'SQL2016'
+        $mockEndpointName = 'DefaultEndpointMirror'
+        $mockEndpointStateStarted = 'Started'
+        $mockEndpointStateStopped = 'Stopped'
 
-    $nodeName = 'localhost'
-    $instanceName = 'DEFAULT'
-    $endpointName = 'DefaultEndpointMirror'
+        $mockOtherEndpointName = 'OtherEndpoint'
 
-    $defaultParameters = @{
-        InstanceName = $instanceName
-        NodeName = $nodeName
-        Name = $endpointName
-    }
+        $mockDynamicEndpointName = $mockEndpointName
+        $mockDynamicEndpointState = $mockEndpointStateStarted
 
-    #endregion Pester Test Initialization
-
-    Describe "$($script:DSCResourceName)\Get-TargetResource" {
-        $testParameters = $defaultParameters
-
-        Context 'When the system is not in the desired state' {
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            $result = Get-TargetResource @testParameters
-
-            It 'Should not return the same value as expected state Started' {
-                $result.State | Should Not Be 'Started'
-                $result.State | Should Be 'Stopped'
-            }
-
-            It 'Should return the same values as passed as parameters when expected state is Started' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Started' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-            }
-            
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-    
-            $result = Get-TargetResource @testParameters
-
-            It 'Should not return the same value as expected state Stopped' {
-                $result.State | Should Not Be 'Stopped'
-                $result.State | Should Be 'Started'
-            }
-
-            It 'Should return the same values as passed as parameters when expected state is Stopped' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when expected state is Stopped' {
-                Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
-    
-        Context 'When the system is in the desired state' {
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the same value as expected state Started' {
-                $result.State | Should Not Be 'Stopped'
-                $result.State | Should Be 'Started'
-            }
-
-            It 'Should return the same values as passed as parameters when expected state is Started' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Get-SQLPSInstance when expected state is Started' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            $result = Get-TargetResource @testParameters
-
-            It 'Should return the same value as expected state Stopped' {
-                $result.State | Should Not Be 'Started'
-                $result.State | Should Be 'Stopped'
-            }
-
-            It 'Should return the same values as passed as parameters when expected state is Stopped' {
-                $result.NodeName | Should Be $testParameters.NodeName
-                $result.InstanceName | Should Be $testParameters.InstanceName
-                $result.Name | Should Be $testParameters.Name
-            }
-
-            It 'Should call the mock function Get-SQLPSInstance when expected state is Stopped' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
-            }
+        $mockConnectSql = {
+            return New-Object Object |
+                Add-Member -MemberType ScriptProperty -Name 'Endpoints' {
+                    return @(
+                        @{
+                            # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
+                            $mockDynamicEndpointName = New-Object Object |
+                                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDynamicEndpointName -PassThru |
+                                                        Add-Member -MemberType NoteProperty -Name 'EndpointState' -Value $mockDynamicEndpointState -PassThru -Force
+                        }
+                    )
+                } -PassThru -Force
         }
 
-        Assert-VerifiableMocks
-    }
-    
-    Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        Context 'When the system is not in the desired state' {
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
+        $defaultParameters = @{
+            InstanceName = $mockInstanceName
+            NodeName = $mockNodeName
+            Name = $mockEndpointName
+        }
 
-            It 'Should return that desired state as absent when desired state is Started' {
+        #endregion Pester Test Initialization
+
+        Describe 'MSFT_xSQLServerEndpointState\Get-TargetResource' -Tag Get {
+            BeforeEach {
                 $testParameters = $defaultParameters
-                $testParameters += @{
-                    State = 'Started' 
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+            }
+
+            $mockDynamicEndpointName = $mockEndpointName
+
+            Context 'When the system is not in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStopped
+
+                Context 'When desired state should be Started, but the current state is Stopped' {
+                    It 'Should not return the state as Started' {
+                        $result = Get-TargetResource @testParameters
+                        $result.State | Should Not Be $mockEndpointStateStarted
+                    }
+
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.NodeName | Should Be $testParameters.NodeName
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        $result.Name | Should Be $testParameters.Name
+                    }
+
+                    It 'Should call the mock function Connect-SQL' {
+                        $result = Get-TargetResource @testParameters
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
                 }
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-            }
+                $mockDynamicEndpointState = $mockEndpointStateStarted
 
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
+                Context 'When desired state should be Stopped, but the current state is Started' {
+                    It 'Should not return the state as Stopped' {
+                        $result = Get-TargetResource @testParameters
+                        $result.State | Should Not Be $mockEndpointStateStopped
+                    }
 
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.NodeName | Should Be $testParameters.NodeName
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        $result.Name | Should Be $testParameters.Name
+                    }
 
-            It 'Should return that desired state as absent when desired state is Stopped' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    State = 'Stopped' 
+                    It 'Should call the mock function Connect-SQL' {
+                        $result = Get-TargetResource @testParameters
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
                 }
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $false
-            }
+                $mockDynamicEndpointName = $mockOtherEndpointName
 
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is absent' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
-            }
-        }
+                Context 'When endpoint is missing' {
+                    It 'Should throw the correct error message' {
+                        { Get-TargetResource @testParameters } | Should Throw 'Unexpected result when trying to verify existence of endpoint 'DefaultEndpointMirror'. InnerException: Endpoint 'DefaultEndpointMirror' does not exist'
 
-        Context 'When the system is in the desired state' {
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should return that desired state as present when desired state is Started' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    State = 'Started' 
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
                 }
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                $mockDynamicEndpointName = $mockEndpointName
             }
 
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Started is present' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context 
-            }
+            Context 'When the system is in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStarted
 
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
+                Context 'When desired state is Started' {
+                    It 'Should return the state as Started' {
+                        $result = Get-TargetResource @testParameters
+                        $result.State | Should Be $mockEndpointStateStarted
+                    }
 
-            It 'Should return that desired state as present when desired state is Stopped' {
-                $testParameters = $defaultParameters
-                $testParameters += @{
-                    State = 'Stopped' 
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.NodeName | Should Be $testParameters.NodeName
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        $result.Name | Should Be $testParameters.Name
+                    }
+
+                    It 'Should call the mock function Connect-SQL' {
+                        $result = Get-TargetResource @testParameters
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
                 }
 
-                $result = Test-TargetResource @testParameters
-                $result | Should Be $true
+                $mockDynamicEndpointState = $mockEndpointStateStopped
+
+                Context 'When desired state is Stopped' {
+                    It 'Should return the state as Stopped' {
+                        $result = Get-TargetResource @testParameters
+                        $result.State | Should Be $mockEndpointStateStopped
+                    }
+
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.NodeName | Should Be $testParameters.NodeName
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        $result.Name | Should Be $testParameters.Name
+                    }
+
+                    It 'Should call the mock function Connect-SQL' {
+                        $result = Get-TargetResource @testParameters
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
             }
 
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state of Stopped is present' {
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope Context 
-            }
+            Assert-VerifiableMocks
         }
 
-        Assert-VerifiableMocks
-    }
+        Describe 'MSFT_xSQLServerEndpointState\Test-TargetResource' -Tag Test {
+            BeforeEach {
+                $testParameters = $defaultParameters
 
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock Set-SqlHADREndpoint -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
-
-        Context 'When the system is not in the desired state' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                State = 'Stopped' 
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
 
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-                    Add-Member ScriptProperty Protocol {
-                        return New-Object Object |
-                            Add-Member ScriptProperty Tcp {
-                                return New-Object Object |
-                                        Add-Member ScriptProperty ListenerIPAddress {
-                                            return New-Object Object |
-                                                    Add-Member NoteProperty IPAddressToString '10.0.0.1' -PassThru
-                                        } -PassThru
-                            } -PassThru
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
+            Context 'When the system is not in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStopped
 
-            It 'Should not throw an error when desired state is not equal to Stopped' {
-                { Set-TargetResource @testParameters } | Should Not Throw
+                Context 'When desired state should be Started, but the current state is Stopped' {
+                    It 'Should return that desired state as absent' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStarted
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                $mockDynamicEndpointState = $mockEndpointStateStarted
+
+                Context 'When desired state should be Stopped, but the current state is Started' {
+                    It 'Should return that desired state as absent' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStopped
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
             }
 
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Stopped' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
+            Context 'When the system is in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStarted
+
+                Context 'When desired state should be Started, and the current state is Started' {
+                    It 'Should return that desired state as absent' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStarted
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                $mockDynamicEndpointState = $mockEndpointStateStopped
+
+                Context 'When desired state should be Stopped, and the current state is Stopped' {
+                    It 'Should return that desired state as absent' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStopped
+                        }
+
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When Get-TargetResource returns nothing' {
+                    It 'Should thor the correct error message' {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return $null
+                        } -Verifiable
+
+                        { Test-TargetResource @testParameters } | Should Throw 'Got unexpected result from Get-TargetResource. No change is made.'
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 0 -Scope It
+                    }
+                }
             }
 
-            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Stopped' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                State = 'Started' 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru | # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-                    Add-Member ScriptProperty Protocol {
-                        return New-Object Object |
-                            Add-Member ScriptProperty Tcp {
-                                return New-Object Object |
-                                        Add-Member ScriptProperty ListenerIPAddress {
-                                            return New-Object Object |
-                                                    Add-Member NoteProperty IPAddressToString '10.0.0.1' -PassThru
-                                        } -PassThru
-                            } -PassThru
-                    } -PassThru -Force 
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should not throw an error when desired state is not equal to Started' {
-                { Set-TargetResource @testParameters } | Should Not Throw
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is not equal to Started' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 2 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should call the mock function Set-SqlHADREndpoint when desired state is not equal to Started' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            } 
-       }
-
-        Context 'When the system is in the desired state' {
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                State = 'Stopped' 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Stopped' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should not throw an error when desired state is equal to Stopped' {
-                { Set-TargetResource @testParameters } | Should Not Throw
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Stopped' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Stopped' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            $testParameters = $defaultParameters
-            $testParameters += @{
-                State = 'Started' 
-            }
-
-            Mock -CommandName Get-SQLAlwaysOnEndpoint -MockWith {
-                # TypeName: Microsoft.SqlServer.Management.Smo.Endpoint
-                return New-Object Object |            
-                    Add-Member NoteProperty EndpointState 'Started' -PassThru -Force # TypeName: Microsoft.SqlServer.Management.Smo.EndpointState
-            } -ModuleName $script:DSCResourceName -Verifiable
-
-            It 'Should not throw an error when desired state is equal to Started' {
-                { Set-TargetResource @testParameters } | Should Not Throw
-            }
-
-            It 'Should call the mock function Get-SQLAlwaysOnEndpoint when desired state is equal to Started' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Get-SQLAlwaysOnEndpoint -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope It
-            }
-
-            It 'Should not call the mock function Set-SqlHADREndpoint when desired state is equal to Started' {
-                 Set-TargetResource @testParameters
-                 Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope It
-            } 
+            Assert-VerifiableMocks
         }
 
-        Assert-VerifiableMocks
+        Describe 'MSFT_xSQLServerEndpointState\Set-TargetResource' -Tag Set {
+            BeforeEach {
+                $testParameters = $defaultParameters
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
+                Mock Set-SqlHADREndpoint -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStopped
+
+                Context 'When desired state should be Started, but the current state is Stopped' {
+                    It 'Should call the mock function Set-SqlHADREndpoint to set the state to Started' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStarted
+                        }
+
+                        Set-TargetResource @testParameters
+
+                        Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                $mockDynamicEndpointState = $mockEndpointStateStarted
+
+                Context 'When desired state should be Stopped, but the current state is Started' {
+                    It 'Should call the mock function Set-SqlHADREndpoint to set the state to Stopped' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStopped
+                        }
+
+                        Set-TargetResource @testParameters
+
+                        Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                $mockDynamicEndpointState = $mockEndpointStateStarted
+
+                Context 'When desired state should be Started, and the current state is Started' {
+                    It 'Should not call the mock function Set-SqlHADREndpoint' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStarted
+                        }
+
+                        Set-TargetResource @testParameters
+
+                        Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -Scope It
+                    }
+                }
+
+                $mockDynamicEndpointState = $mockEndpointStateStopped
+
+                Context 'When desired state should be Stopped, and the current state is Stopped' {
+                    It 'Should not call the mock function Set-SqlHADREndpoint' {
+                        $testParameters += @{
+                            State = $mockEndpointStateStopped
+                        }
+
+                        Set-TargetResource @testParameters
+
+                        Assert-MockCalled Set-SqlHADREndpoint -Exactly -Times 0 -Scope It
+                    }
+                }
+
+                Context 'When Get-TargetResource returns nothing' {
+                    It 'Should thor the correct error message' {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return $null
+                        } -Verifiable
+
+                        { Set-TargetResource @testParameters } | Should Throw 'Got unexpected result from Get-TargetResource. No change is made.'
+
+                        Assert-MockCalled Connect-SQL -Exactly -Times 0 -Scope It
+                    }
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
     }
 }
 finally
 {
-    #region FOOTER
-
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
-
-    #endregion
+    Invoke-TestCleanup
 }

--- a/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
@@ -334,7 +334,7 @@ try
                 }
 
                 Context 'When Get-TargetResource returns nothing' {
-                    It 'Should thor the correct error message' {
+                    It 'Should throw the correct error message' {
                         Mock -CommandName Get-TargetResource -MockWith {
                             return $null
                         } -Verifiable

--- a/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointState.Tests.ps1
@@ -36,7 +36,7 @@ try
 
     InModuleScope $script:DSCResourceName {
         $mockNodeName = 'localhost'
-        $mockInstanceName = 'SQL2016'
+        $mockInstanceName = 'INSTANCE1'
         $mockEndpointName = 'DefaultEndpointMirror'
         $mockEndpointStateStarted = 'Started'
         $mockEndpointStateStopped = 'Stopped'


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerEndpointState
  - Cleaned up code, removed `SupportsShouldProcess` and fixed PSSA rules warnings (issue #258 and issue #230).
  - Now the defult value for the parameter `State` is 'Started'.
  - Updated README.md with a description for the resources and revised the parameter descriptions.
  - Removed dependency of SQLPS provider (issue #481).

**This Pull Request (PR) fixes the following issues:**
Fixes #481 
Fixes #258 
Fixes #230 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/497)
<!-- Reviewable:end -->
