### PR TITLE
xWaitForAvailabilityGroup:  Added tests and fixed some issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).
   - Cleaned up code and fixed PSSA rules warnings (issue #268).
   - Added unit tests (issue #297).
+  - Added descriptive text to README.md that the account that runs the resource must have permission to run the cmdlet Get-ClusterGroup (issue #307).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Changes to xWaitForAvailabilityGroup
   - Updated README.md with a description for the resources and revised the parameter descriptions.
   - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).
+  - Cleaned up code and fixed PSSA rules warnings (issue #268).
+  - Added unit tests (issue #297).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,6 @@
   - BREAKING CHANGE: Changed helper function Import-SQLPSModule to support SqlServer module (issue #91). The SqlServer module is the preferred module so if it is found it will be used, and if not found an attempt will be done to load SQLPS module instead.
 - Changes to xSQLServerScript
   - Updated tests for this resource, because they failed when Import-SQLPSModule was updated.
-  - Removing helper function Get-SQLAlwaysOnEndpoint becuase there is no resource using it any longer.
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Added unit tests (issue #297).
   - Added descriptive text to README.md that the account that runs the resource must have permission to run the cmdlet Get-ClusterGroup (issue #307).
   - Added read-only parameter GroupExist which will return $true if the cluster role/group exist, otherwise it returns $false (issue #510).
+  - Added examples.
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Cleaned up code and fixed PSSA rules warnings (issue #268).
   - Added unit tests (issue #297).
   - Added descriptive text to README.md that the account that runs the resource must have permission to run the cmdlet Get-ClusterGroup (issue #307).
+  - Added read-only parameter GroupExist which will return $true if the cluster role/group exist, otherwise it returns $false (issue #510).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changes to xWaitForAvailabilityGroup
+  - Updated README.md with a description for the resources and revised the parameter descriptions.
+  - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).
+
 ## 7.0.0.0
 
 - Examples
@@ -117,6 +121,7 @@
   - BREAKING CHANGE: Changed helper function Import-SQLPSModule to support SqlServer module (issue #91). The SqlServer module is the preferred module so if it is found it will be used, and if not found an attempt will be done to load SQLPS module instead.
 - Changes to xSQLServerScript
   - Updated tests for this resource, because they failed when Import-SQLPSModule was updated.
+  - Removing helper function Get-SQLAlwaysOnEndpoint becuase there is no resource using it any longer.
 
 ## 6.0.0.0
 

--- a/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.psm1
@@ -4,6 +4,20 @@ Write-Verbose -Message "CurrentPath: $currentPath"
 # Load Common Code
 Import-Module $currentPath\..\..\xSQLServerHelper.psm1 -Verbose:$false -ErrorAction Stop
 
+<#
+    .SYNOPSIS
+        Returns the cluster role/group that is waiting to be created,
+        along with the time and number of times to wait.
+
+    .PARAMETER Name
+        Name of the cluster role/group to look for (normally the same as the Availability Group name).
+
+    .PARAMETER RetryIntervalSec
+        The interval, in seconds, to check for the presence of the cluster role/group. Default values is 20 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.
+#>
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -13,9 +27,9 @@ function Get-TargetResource
         [parameter(Mandatory = $true)]
         [System.String]
         $Name,
-        
-        [UInt64] $RetryIntervalSec = 10,
-        [UInt32] $RetryCount = 50
+
+        [UInt64] $RetryIntervalSec = 20,
+        [UInt32] $RetryCount = 30
     )
 
     @{
@@ -25,7 +39,19 @@ function Get-TargetResource
     }
 }
 
+<#
+    .SYNOPSIS
+        Waits for a cluster role/group to be created
 
+    .PARAMETER Name
+        Name of the cluster role/group to look for (normally the same as the Availability Group name).
+
+    .PARAMETER RetryIntervalSec
+        The interval, in seconds, to check for the presence of the cluster role/group. Default values is 20 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -36,14 +62,14 @@ function Set-TargetResource
         $Name,
 
         [System.UInt64]
-        $RetryIntervalSec =20,
+        $RetryIntervalSec = 20,
 
         [System.UInt32]
-        $RetryCount = 6
+        $RetryCount = 30
     )
 
     $AGFound = $false
-    New-VerboseMessage -Message "Checking for Availaibilty Group $Name ..."
+    New-VerboseMessage -Message "Checking for Availaibilty Group $Name. Will try for a total of $($RetryIntervalSec*$RetryCount) seconds."
 
     for ($count = 0; $count -lt $RetryCount; $count++)
     {
@@ -58,13 +84,13 @@ function Set-TargetResource
                 Start-Sleep -Seconds $RetryIntervalSec
                 break;
             }
-            
+
         }
         catch
         {
              New-VerboseMessage -Message "Availability Group $Name not found. Will retry again after $RetryIntervalSec sec"
         }
-            
+
         New-VerboseMessage -Message "Availability Group $Name not found. Will retry again after $RetryIntervalSec sec"
         Start-Sleep -Seconds $RetryIntervalSec
     }
@@ -78,7 +104,19 @@ function Set-TargetResource
 
 }
 
+<#
+    .SYNOPSIS
+        Tests if the cluster role/group has been created.
 
+    .PARAMETER Name
+        Name of the cluster role/group to look for (normally the same as the Availability Group name).
+
+    .PARAMETER RetryIntervalSec
+        The interval, in seconds, to check for the presence of the cluster role/group. Default values is 20 seconds.
+
+    .PARAMETER RetryCount
+        Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.
+#>
 function Test-TargetResource
 {
     [CmdletBinding()]
@@ -90,10 +128,10 @@ function Test-TargetResource
         $Name,
 
         [System.UInt64]
-        $RetryIntervalSec = 10,
+        $RetryIntervalSec = 20,
 
         [System.UInt32]
-        $RetryCount = 50
+        $RetryCount = 30
     )
 
     New-VerboseMessage -Message "Checking for Availability Group $Name ..."

--- a/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.psm1
@@ -1,3 +1,7 @@
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+                               -ChildPath 'xSQLServerHelper.psm1') `
+                               -Force
+
 <#
     .SYNOPSIS
         Returns the cluster role/group that is waiting to be created,

--- a/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
@@ -1,9 +1,7 @@
-
 [ClassVersion("1.0.0.0"), FriendlyName("xWaitForAvailabilityGroup")]
 class MSFT_xWaitForAvailabilityGroup : OMI_BaseResource
 {
-    [Key, Description("Availability Group Name")] String Name;
-    [Write, Description("Interval to check for Availability Group")] Uint64 RetryIntervalSec;
-    [Write, Description("Maximum number of retries to check Availabilty group creation")] Uint32 RetryCount;
+    [Key, Description("Name of the cluster role/group to look for (normally the same as the Availability Group name).")] String Name;
+    [Write, Description("The interval, in seconds, to check for the presence of the cluster role/group. Default values is 20 seconds.")] Uint64 RetryIntervalSec;
+    [Write, Description("Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.")] Uint32 RetryCount;
 };
-

--- a/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
@@ -2,6 +2,6 @@
 class MSFT_xWaitForAvailabilityGroup : OMI_BaseResource
 {
     [Key, Description("Name of the cluster role/group to look for (normally the same as the Availability Group name).")] String Name;
-    [Write, Description("The interval, in seconds, to check for the presence of the cluster role/group. Default values is 20 seconds.")] Uint64 RetryIntervalSec;
+    [Write, Description("The interval, in seconds, to check for the presence of the cluster role/group. Default value is 20 seconds. When the cluster role/group has been found the resource will wait for this amount of time once more before returning.")] Uint64 RetryIntervalSec;
     [Write, Description("Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.")] Uint32 RetryCount;
 };

--- a/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xWaitForAvailabilityGroup/MSFT_xWaitForAvailabilityGroup.schema.mof
@@ -4,4 +4,5 @@ class MSFT_xWaitForAvailabilityGroup : OMI_BaseResource
     [Key, Description("Name of the cluster role/group to look for (normally the same as the Availability Group name).")] String Name;
     [Write, Description("The interval, in seconds, to check for the presence of the cluster role/group. Default value is 20 seconds. When the cluster role/group has been found the resource will wait for this amount of time once more before returning.")] Uint64 RetryIntervalSec;
     [Write, Description("Maximum number of retries until the resource will timeout and throw an error. Default values is 30 times.")] Uint32 RetryCount;
+    [Read, Description("Returns $true if the cluster role/group exist, otherwise it returns $false. Used by Get-TargetResource.")] Boolean GroupExist;
 };

--- a/Examples/Resources/xWaitForAvailabilityGroup/1-WaitForASingleClusterGroup.ps1
+++ b/Examples/Resources/xWaitForAvailabilityGroup/1-WaitForASingleClusterGroup.ps1
@@ -1,0 +1,28 @@
+﻿<#
+    .EXAMPLE
+        This example will wait for the cluster role/group 'AGTest1'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest1
+        {
+            Name = 'AGTest1'
+            RetryIntervalSec = 20
+            RetryCount = 30
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+    }
+}

--- a/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
+++ b/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
@@ -18,7 +18,16 @@ Configuration Example
     {
         xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest1
         {
-            Name = @('AGTest1','AGTest2')
+            Name = 'AGTest1'
+            RetryIntervalSec = 20
+            RetryCount = 30
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+
+        xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest1
+        {
+            Name = 'AGTest2'
             RetryIntervalSec = 20
             RetryCount = 30
 

--- a/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
+++ b/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
@@ -1,0 +1,28 @@
+﻿<#
+    .EXAMPLE
+        This example will wait for both the cluster roles/groups 'AGTest1' and 'AGTest2'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSQLServer
+
+    node localhost
+    {
+        xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest1
+        {
+            Name = @('AGTest1','AGTest2')
+            RetryIntervalSec = 20
+            RetryCount = 30
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+    }
+}

--- a/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
+++ b/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1
@@ -25,7 +25,7 @@ Configuration Example
             PsDscRunAsCredential = $SysAdminAccount
         }
 
-        xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest1
+        xWaitForAvailabilityGroup SQLConfigureAG-WaitAGTest2
         {
             Name = 'AGTest2'
             RetryIntervalSec = 20

--- a/README.md
+++ b/README.md
@@ -1064,4 +1064,5 @@ This resource will wait for a cluster role/group to be created. This is used to 
 
 #### Examples
 
-None.
+* [Wait for a cluster role/group to be available](/Examples/Resources/xWaitForAvailabilityGroup/1-WaitForASingleClusterGroup.ps1)
+* [Wait for multiple cluster roles/groups to be available](/Examples/Resources/xWaitForAvailabilityGroup/2-WaitForMultipleClusterGroups.ps1)

--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ These issues are also documented in the example files [Install a named instance 
 
 This resource will wait for a cluster role/group to be created. This is used to wait for an Availability Group to create the cluster role/group in the cluster.
 
->Note: This only looks for the cluster role/group to be created and will immediately return when it does. There is currently no check to validate that the Availability Group was successfully created or that it has finished creating the Availability Group.
+>Note: This only evaluates if the cluster role/group has been created and when it found it will wait for RetryIntervalSec a last time before returning. There is currently no check to validate that the Availability Group was successfully created or that it has finished creating the Availability Group.
 
 #### Requirements
 
@@ -1051,7 +1051,7 @@ This resource will wait for a cluster role/group to be created. This is used to 
 #### Parameters
 
 * **[String] Name** _(Key)_: Name of the cluster role/group to look for (normally the same as the Availability Group name).
-* **[Uint64] RetryIntervalSec** _(Write)_: The interval, in seconds, to check for the presence of the cluster role/group. Default value is 20 seconds.
+* **[Uint64] RetryIntervalSec** _(Write)_: The interval, in seconds, to check for the presence of the cluster role/group. Default value is 20 seconds. When the cluster role/group has been found the resource will wait for this amount of time once more before returning.
 * **[Uint32] RetryCount** _(Write)_: Maximum number of retries until the resource will timeout and throw an error. Default value is 30 times.
 
 #### Read-Only Properties from Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,7 @@ This resource will wait for a cluster role/group to be created. This is used to 
 
 #### Read-Only Properties from Get-TargetResource
 
-None.
+* **[Boolean] GroupExist** _(Read)_: Returns $true if the cluster role/group exist, otherwise it returns $false. Used by Get-TargetResource.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -1038,18 +1038,21 @@ These issues are also documented in the example files [Install a named instance 
 
 ### xWaitforAvailabilityGroup
 
-No description.
+This resource will wait for a cluster role/group to be created. This is used to wait for an Availability Group to create the cluster role/group in the cluster.
+
+>Note: This only looks for the cluster role/group to be created and will immediately return when it does. There is currently no check to validate that the Availability Group was successfully created or that it has finished creating the Availability Group.
 
 #### Requirements
 
 * Target machine must be running Windows Server 2008 R2 or later.
 * Target machine must be running SQL Server Database Engine 2012 or later.
+* Target machine must have access to the Failover Cluster PowerShell module.
 
 #### Parameters
 
-* **[String] Name** _(Key)_: Name for availability group
-* **[Uint64] RetryIntervalSec** _(Write)_: Interval to check for availability group
-* **[Uint32] RetryCount** _(Write)_: Maximum number of retries to check availability group creation
+* **[String] Name** _(Key)_: Name of the cluster role/group to look for (normally the same as the Availability Group name).
+* **[Uint64] RetryIntervalSec** _(Write)_: The interval, in seconds, to check for the presence of the cluster role/group. Default value is 20 seconds.
+* **[Uint32] RetryCount** _(Write)_: Maximum number of retries until the resource will timeout and throw an error. Default value is 30 times.
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,10 @@ This resource will wait for a cluster role/group to be created. This is used to 
 * Target machine must be running SQL Server Database Engine 2012 or later.
 * Target machine must have access to the Failover Cluster PowerShell module.
 
+#### Security Requirements
+
+* The account running this resource must have permission in the cluster to be able to run the cmdlet Get-ClusterGroup.
+
 #### Parameters
 
 * **[String] Name** _(Key)_: Name of the cluster role/group to look for (normally the same as the Availability Group name).

--- a/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
@@ -167,7 +167,7 @@ try
             }
 
             Context 'When the system is in the desired state' {
-                $mockExpectedClusterGroupName =$mockClusterGroupName
+                $mockExpectedClusterGroupName = $mockClusterGroupName
 
                 It 'Should find the cluster group and return withput throwing' {
                      { Set-TargetResource @testParameters } | Should -Not -Throw

--- a/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
@@ -128,9 +128,9 @@ try
                 } -ParameterFilter $mockGetClusterGroup_ParameterFilter_UnknownGroup -Verifiable
             }
 
-            $mockExpectedClusterGroupName = $mockClusterGroupName
-
             Context 'When the system is in the desired state' {
+                $mockExpectedClusterGroupName = $mockClusterGroupName
+
                 It 'Should return that desired state is present ($true)' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -139,9 +139,9 @@ try
                 }
             }
 
-            $mockExpectedClusterGroupName = $mockOtherClusterGroupName
-
             Context 'When the system is not in the desired state' {
+                $mockExpectedClusterGroupName = $mockOtherClusterGroupName
+
                 It 'Should return that desired state is absent ($false)' {
                     $testParameters.Name = $mockOtherClusterGroupName
 
@@ -166,9 +166,9 @@ try
                 } -ParameterFilter $mockGetClusterGroup_ParameterFilter_UnknownGroup -Verifiable
             }
 
-            $mockExpectedClusterGroupName =$mockClusterGroupName
-
             Context 'When the system is in the desired state' {
+                $mockExpectedClusterGroupName =$mockClusterGroupName
+
                 It 'Should find the cluster group and return withput throwing' {
                      { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -176,9 +176,9 @@ try
                 }
             }
 
-            $mockExpectedClusterGroupName = $mockOtherClusterGroupName
-
             Context 'When the system is not in the desired state' {
+                $mockExpectedClusterGroupName = $mockOtherClusterGroupName
+
                 It 'Should throw the correct error message' {
                     $testParameters.Name = $mockOtherClusterGroupName
 
@@ -196,4 +196,3 @@ finally
 {
     Invoke-TestCleanup
 }
-

--- a/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
@@ -1,0 +1,168 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xWaitForAvailabilityGroup'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup {
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $mockClusterGroupName = 'AGTest'
+        $mockRetryInterval = 1
+        $mockRetryCount = 2
+
+        $mockOtherClusterGroupName = 'UnknownAG'
+
+        # Function stub of Get-ClusterGroup (when we do not have Failover Cluster powershell module available)
+        function Get-ClusterGroup {
+            throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+        }
+
+        $mockGetClusterGroup = {
+            if ($Name -ne $mockExpectedClusterGroupName)
+            {
+                throw ('Mock Get-ClusterGroup called with unexpected name. Expected ''{0}'', but was ''{1}''' -f $mockExpectedClusterGroupName, $Name)
+            }
+
+            return New-Object -TypeName PSObject -Property @{
+                Name = $Name
+            }
+        }
+
+        $mockGetClusterGroup_ParameterFilter_KnownGroup = {
+            $Name -eq $mockClusterGroupName
+        }
+
+        $mockGetClusterGroup_ParameterFilter_UnknownGroup = {
+            $Name -eq $mockOtherClusterGroupName
+        }
+
+        # Default parameters that are used for the It-blocks
+        $mockDefaultParameters = @{
+            Name = $mockClusterGroupName
+            RetryIntervalSec = $mockRetryInterval
+            RetryCount = $mockRetryCount
+        }
+
+        Describe 'MSFT_xWaitForAvailabilityGroup\Get-TargetResource' -Tag 'Get' {
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+            }
+
+            Context 'When the system is either in the desired state or not in desired state' {
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.RetryIntervalSec | Should -Be $mockRetryInterval
+                    $result.RetryCount | Should -Be $mockRetryCount
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+
+        Describe 'MSFT_xWaitForAvailabilityGroup\Get-TargetResource' -Tag 'Test'{
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+
+                Mock -CommandName Get-ClusterGroup -MockWith $mockGetClusterGroup -ParameterFilter $mockGetClusterGroup_ParameterFilter_KnownGroup -Verifiable
+                Mock -CommandName Get-ClusterGroup -MockWith {
+                    return $null
+                } -ParameterFilter $mockGetClusterGroup_ParameterFilter_UnknownGroup -Verifiable
+            }
+
+            $mockExpectedClusterGroupName =$mockClusterGroupName
+
+            Context 'When the system is in the desired state' {
+                It 'Should return that desired state is present ($true)' {
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                }
+            }
+
+            $mockExpectedClusterGroupName = $mockOtherClusterGroupName
+
+            Context 'When the system is not in the desired state' {
+                It 'Should return that desired state is present ($true)' {
+                    $testParameters.Name = $mockOtherClusterGroupName
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $false
+
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe 'MSFT_xWaitForAvailabilityGroup\Get-TargetResource' -Tag 'Set'{
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+
+                Mock -CommandName Start-Sleep
+                Mock -CommandName Get-ClusterGroup -MockWith $mockGetClusterGroup -ParameterFilter $mockGetClusterGroup_ParameterFilter_KnownGroup -Verifiable
+                Mock -CommandName Get-ClusterGroup -MockWith {
+                    return $null
+                } -ParameterFilter $mockGetClusterGroup_ParameterFilter_UnknownGroup -Verifiable
+            }
+
+            $mockExpectedClusterGroupName =$mockClusterGroupName
+
+            Context 'When the system is in the desired state' {
+                It 'Should find the cluster group and return withput throwing' {
+                     { Set-TargetResource @testParameters } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                }
+            }
+
+            $mockExpectedClusterGroupName = $mockOtherClusterGroupName
+
+            Context 'When the system is not in the desired state' {
+                It 'Should throw the correct error message' {
+                    $testParameters.Name = $mockOtherClusterGroupName
+
+                     { Set-TargetResource @testParameters } | Should -Throw 'Cluster group UnknownAG not found after 2 attempts with 1 sec interval'
+
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 2
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}
+

--- a/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xWaitForAvailabilityGroup.Tests.ps1
@@ -118,7 +118,7 @@ try
         }
 
 
-        Describe 'MSFT_xWaitForAvailabilityGroup\Get-TargetResource' -Tag 'Test'{
+        Describe 'MSFT_xWaitForAvailabilityGroup\Test-TargetResource' -Tag 'Test'{
             BeforeEach {
                 $testParameters = $mockDefaultParameters.Clone()
 
@@ -135,27 +135,27 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
 
-                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1 -Scope It
                 }
             }
 
             $mockExpectedClusterGroupName = $mockOtherClusterGroupName
 
             Context 'When the system is not in the desired state' {
-                It 'Should return that desired state is present ($true)' {
+                It 'Should return that desired state is absent ($false)' {
                     $testParameters.Name = $mockOtherClusterGroupName
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
 
-                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1 -Scope It
                 }
             }
 
             Assert-VerifiableMocks
         }
 
-        Describe 'MSFT_xWaitForAvailabilityGroup\Get-TargetResource' -Tag 'Set'{
+        Describe 'MSFT_xWaitForAvailabilityGroup\Set-TargetResource' -Tag 'Set'{
             BeforeEach {
                 $testParameters = $mockDefaultParameters.Clone()
 
@@ -172,7 +172,7 @@ try
                 It 'Should find the cluster group and return withput throwing' {
                      { Set-TargetResource @testParameters } | Should -Not -Throw
 
-                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 1 -Scope It
                 }
             }
 
@@ -184,7 +184,7 @@ try
 
                     { Set-TargetResource @testParameters } | Should -Throw 'Cluster group UnknownAG not found after 2 attempts with 1 sec interval'
 
-                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 2
+                    Assert-MockCalled -CommandName Get-ClusterGroup -Exactly -Times 2 -Scope It
                 }
             }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xWaitForAvailabilityGroup
  - Updated README.md with a description for the resources and revised the parameter descriptions.
  - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).
  - Cleaned up code and fixed PSSA rules warnings (issue #268).
  - Added unit tests (issue #297).
  - Added descriptive text to README.md that the account that runs the resource must have permission to run the cmdlet Get-ClusterGroup (issue #307).
  - Added read-only parameter GroupExist which will return $true if the cluster role/group exist, otherwise it returns $false (issue #510).
  - Added examples.

**This Pull Request (PR) fixes the following issues:**
Fixes #505 
Fixes #268 
Fixes #297 
Fixes #307 
Fixes #510 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/507)
<!-- Reviewable:end -->
