### PR TITLE
xSQLServerSetup: Updated xSQLServerSetup module Get-Resource method to detect DQ, DQC, BOL, SDK features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   - Fixed typos in markdown files; CHANGELOG, CONTRIBUTING, README and ISSUE_TEMPLATE.
 - Changes to xSQLServerAlwaysOnService
   - Get-TargetResource should no longer fail silently with error 'Index operation failed; the array index evaluated to null.' (issue #519). Now if the Server.IsHadrEnabled property return neither $true or $false the Get-TargetResource function will throw an error.
+- Changes to xSQLServerSetUp
+  - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490).
+  - Added change to detect DQ, DQC, BOL, SDK features. Now Test-Resource returns true after calling set for DQ, DQC, BOL, SDK features.
 
 ## 7.0.0.0
 
@@ -97,8 +100,6 @@
   - Now it skips cluster validation för add node (issue #442).
   - Now it ignores parameters that are not allowed for action Addnode (issue #441).
   - Added support for vNext CTP 1.4 (issue #472).
-  - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490).
-  - Added change to detect DQ, DQC, BOL, SDK features. Now Test-Resource returns true after calling set for DQ, DQC, BOL, SDK features.
 - Added new resource
   - xSQLServerAlwaysOnAvailabilityGroupReplica
 - Changes to xSQLServerDatabaseRecoveryModel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,8 +164,8 @@
   - Changed so that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
   - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier, i.e 'E:' (issue #418). All paths (except SourcePath) can now be set to just the qualifier.
-- Enables CodeCov.io code coverage reporting.
-- Added badge for CodeCov.io to README.md.
+  - Enables CodeCov.io code coverage reporting.
+  - Added badge for CodeCov.io to README.md.
 - Examples
   - xSQLServerMaxDop
     - 1-SetMaxDopToOne.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@
   - BREAKING CHANGE: Changed helper function Import-SQLPSModule to support SqlServer module (issue #91). The SqlServer module is the preferred module so if it is found it will be used, and if not found an attempt will be done to load SQLPS module instead.
 - Changes to xSQLServerScript
   - Updated tests for this resource, because they failed when Import-SQLPSModule was updated.
+  
+ - Changes to xSQLServerSetup
+   - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490)
+   - Added change to detect DQ, DQC, BOL, SDK features. Now Test-Resource returns true after calling set for DQ, DQC, BOL, SDK features.
 
 ## 6.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,10 +140,6 @@
   - BREAKING CHANGE: Changed helper function Import-SQLPSModule to support SqlServer module (issue #91). The SqlServer module is the preferred module so if it is found it will be used, and if not found an attempt will be done to load SQLPS module instead.
 - Changes to xSQLServerScript
   - Updated tests for this resource, because they failed when Import-SQLPSModule was updated.
-  
- - Changes to xSQLServerSetup
-   - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490)
-   - Added change to detect DQ, DQC, BOL, SDK features. Now Test-Resource returns true after calling set for DQ, DQC, BOL, SDK features.
 
 ## 6.0.0.0
 
@@ -164,8 +160,8 @@
   - Changed so that instead of connection to localhost it is using $env:COMPUTERNAME as the host name to which it connects. And for cluster installation it uses the parameter FailoverClusterNetworkName as the host name to which it connects (issue #407).
   - When called with Action = 'PrepareFailoverCluster', the SQLSysAdminAccounts and FailoverClusterGroup parameters are no longer passed to the setup process (issues #410 and 411).
   - Solved the problem that InstanceDir and InstallSQLDataDir could not be set to just a qualifier, i.e 'E:' (issue #418). All paths (except SourcePath) can now be set to just the qualifier.
-  - Enables CodeCov.io code coverage reporting.
-  - Added badge for CodeCov.io to README.md.
+- Enables CodeCov.io code coverage reporting.
+- Added badge for CodeCov.io to README.md.
 - Examples
   - xSQLServerMaxDop
     - 1-SetMaxDopToOne.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@
   - Now it skips cluster validation för add node (issue #442).
   - Now it ignores parameters that are not allowed for action Addnode (issue #441).
   - Added support for vNext CTP 1.4 (issue #472).
+  - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490).
+  - Added change to detect DQ, DQC, BOL, SDK features. Now Test-Resource returns true after calling set for DQ, DQC, BOL, SDK features.
 - Added new resource
   - xSQLServerAlwaysOnAvailabilityGroupReplica
 - Changes to xSQLServerDatabaseRecoveryModel

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -117,7 +117,7 @@ function Get-TargetResource
 
     $integrationServiceName = "MsDtsServer$($sqlVersion)0"
 
-    $features = 'ADV_SDK'
+    $features = ''
     $clusteredSqlGroupName = ''
     $clusteredSqlHostname = ''
     $clusteredSqlIPAddress = ''

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -145,6 +145,32 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Replication feature not detected'
         }
 
+        # Check if Data Quality Client sub component is configured
+        New-VerboseMessage -Message "Detecting Data Quality Client (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        $isDQCInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_DQ_CLIENT_Full
+        if ($isDQCInstalled -eq 1)
+        {
+            New-VerboseMessage -Message 'Data Quality Client feature detected'
+            $features += 'DQC,'
+        }
+        else
+        {
+            New-VerboseMessage -Message 'Data Quality Client feature not detected'
+        }
+
+        # Check if Data Quality Services sub component is configured
+        New-VerboseMessage -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        $isDQInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*" -ErrorAction SilentlyContinue)
+        if ($isDQInstalled)
+        {
+            New-VerboseMessage -Message 'Data Quality Services feature detected'
+            $features += 'DQ,'
+        }
+        else
+        {
+            New-VerboseMessage -Message 'Data Quality Services feature not detected'
+        }
+
         $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
         $registryClientComponentsFullFeatureList = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -170,6 +170,17 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
         }
 
+        Write-Debug -Message "Detecting Client Tools SDK feature ($clientComponentsFullRegistryPath)"
+        if (($registryClientComponentsFullFeatureList -like '*SDK_Full=3*') -and ($registryClientComponentsFullFeatureList -like '*SDK_FNS=3*'))
+        {
+            New-VerboseMessage -Message 'Client Tools SDK feature detected'
+            $features += 'SDK,'
+        }
+        else
+        {
+            New-VerboseMessage -Message 'Client Tools SDK feature not detected'
+        }
+
         $instanceId = $fullInstanceId.Split('.')[1]
         $instanceDirectory = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\Setup" -Name 'SqlProgramDir').SqlProgramDir.Trim("\")
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -171,6 +171,19 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Data Quality Services feature not detected'
         }
 
+        # Check if Documentation Components "BOL" is configured
+        New-VerboseMessage -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        $isBOLInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_BOL_Components
+        if ($isBOLInstalled -eq 1)
+        {
+            New-VerboseMessage -Message 'Documentation Components feature detected'
+            $features += 'BOL,'
+        }
+        else
+        {
+            New-VerboseMessage -Message 'Documentation Components feature not detected'
+        }
+
         $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
         $registryClientComponentsFullFeatureList = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -117,7 +117,7 @@ function Get-TargetResource
 
     $integrationServiceName = "MsDtsServer$($sqlVersion)0"
 
-    $features = ''
+    $features = 'ADV_SDK'
     $clusteredSqlGroupName = ''
     $clusteredSqlHostname = ''
     $clusteredSqlIPAddress = ''

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -159,7 +159,7 @@ function Get-TargetResource
         }
 
         # Check if Data Quality Services sub component is configured
-        New-VerboseMessage -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        New-VerboseMessage -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*)"
         $isDQInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*" -ErrorAction SilentlyContinue)
         if ($isDQInstalled)
         {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -888,8 +888,9 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
+            Features = 'SQLENGINE,REPLICATION,DQC,DQ,BOL,CONN,BC,SDK,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
         }
+		$featuresForSqlServer2016 = ''
         
         $mockDefaultClusterParameters = @{
             SetupCredential = $mockSetupCredential
@@ -1315,11 +1316,11 @@ try
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS'
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,BOL,FULLTEXT,RS,AS,IS'
                         }
                         else
                         {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,BOL,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
                         }
                     }
                 }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -35,7 +35,7 @@ function Invoke-TestCleanup {
 try
 {
     Invoke-TestSetup
-    
+
     InModuleScope $script:DSCResourceName {
         # Testing each supported SQL Server version
         $testProductVersion = @(
@@ -45,22 +45,22 @@ try
             11, # SQL Server 2012
             10 # SQL Server 2008 and 2008 R2
         )
-        
+
         $mockSqlDatabaseEngineName = 'MSSQL'
         $mockSqlAgentName = 'SQLAgent'
         $mockSqlFullTextName = 'MSSQLFDLauncher'
         $mockSqlReportingName = 'ReportServer'
         $mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
         $mockSqlAnalysisName = 'MSOLAP'
-        
+
         $mockSqlCollation = 'Finnish_Swedish_CI_AS'
         $mockSqlLoginMode = 'Integrated'
-        
+
         $mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
         $mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
         $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
         $mockSqlSystemAdministrator = 'COMPANY\Stacy'
-        
+
         $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
         $mockSqlAnalysisAdmins = @('COMPANY\Stacy', 'COMPANY\SSAS Administrators')
         $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
@@ -68,7 +68,7 @@ try
         $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
         $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
         $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
-        
+
         $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
         $mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
         $mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
@@ -76,14 +76,14 @@ try
         $mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
         $mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
         $mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
-        
+
         $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
         $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
         $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
         $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
         $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
         $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
-        
+
         $mockNamedInstance_InstanceName = 'TEST'
         $mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
         $mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
@@ -91,16 +91,16 @@ try
         $mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
         $mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
         $mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
-        
+
         $mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
         $mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
         $mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
-        
+
         $mockmockSetupCredentialUserName = "COMPANY\sqladmin"
-        
+
         $mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
         $mockSetupCredential = New-Object System.Management.Automation.PSCredential($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
-        
+
         $mockSqlServiceAccount = 'COMPANY\SqlAccount'
         $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
         $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
@@ -110,16 +110,16 @@ try
         $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
         $mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
         $mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-        
+
         $mockClusterNodes = @($env:COMPUTERNAME, 'SQL01', 'SQL02')
-        
+
         $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
         $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
         $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
         $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
         $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
         $mockSqlBackupPath = 'O:\MSSQL\Backup'
-        
+
         $mockClusterDiskMap = {
             @{
                 SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
@@ -130,7 +130,7 @@ try
                 Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
             }
         }
-        
+
         $mockCSVClusterDiskMap = @{
             SysData = @{ Path = 'C:\ClusterStorage\SysData'; Name = "Cluster Virtual Disk (SQL System Data Disk)" }
             UserData = @{ Path = 'C:\ClusterStorage\SQLData'; Name = "Cluster Virtual Disk (SQL Data Disk)" }
@@ -139,7 +139,7 @@ try
             TempDbLogs = @{ Path = 'C:\ClusterStorage\TempDBLogs'; Name = "Cluster Virtual Disk (SQL TempDBLog Disk)" }
             Backup = @{ Path = 'C:\ClusterStorage\SQLBackup'; Name = "Cluster Virtual Disk (SQL Backup Disk)" }
         }
-        
+
         $mockClusterSites = @(
             @{
                 Name = 'SiteA'
@@ -152,46 +152,46 @@ try
                 Mask = '255.255.255.0'
             }
         )
-        
+
         #region Function mocks
         $mockGetSqlMajorVersion = {
             return $mockSqlMajorVersion
         }
-        
+
         $mockEmptyHashtable = {
             return @()
         }
-        
+
         $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
         $mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
         $mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
         $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
         $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
         $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
-        
+
         $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
-        
+
         $mockGetItemProperty_UninstallProducts2008R2 = {
             return @(
                 $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
                 $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber # Mock product ADV_SSMS 2012
             )
         }
-        
+
         $mockGetItemProperty_UninstallProducts2012 = {
             return @(
                 $mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
                 $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber # Mock product SSMS 2014
             )
         }
-        
+
         $mockGetItemProperty_UninstallProducts2014 = {
             return @(
                 $mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
                 $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
             )
         }
-        
+
         $mockGetItemProperty_UninstallProducts = {
             return @(
                 $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
@@ -202,7 +202,7 @@ try
                 $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_DatabaseService = {
             return @(
                 (
@@ -212,7 +212,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_AgentService = {
             return @(
                 (
@@ -222,7 +222,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_FullTextService = {
             return @(
                 (
@@ -232,7 +232,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_ReportingService = {
             return @(
                 (
@@ -242,7 +242,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_IntegrationService = {
             return @(
                 (
@@ -252,7 +252,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_DefaultInstance_AnalysisService = {
             return @(
                 (
@@ -262,7 +262,7 @@ try
                 )
             )
         }
-        
+
         $mockGetService_DefaultInstance = {
             return @(
                 (
@@ -297,7 +297,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_DatabaseService = {
             return @(
                 (
@@ -307,7 +307,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_AgentService = {
             return @(
                 (
@@ -317,7 +317,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_FullTextService = {
             return @(
                 (
@@ -327,7 +327,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_ReportingService = {
             return @(
                 (
@@ -337,7 +337,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_IntegrationService = {
             return @(
                 (
@@ -347,7 +347,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_NamedInstance_AnalysisService = {
             return @(
                 (
@@ -357,7 +357,7 @@ try
                 )
             )
         }
-        
+
         $mockGetService_NamedInstance = {
             return @(
                 (
@@ -392,7 +392,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_ConfigurationState = {
             return @(
                 (
@@ -401,7 +401,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_DQFeature = {
             return @(
                 (
@@ -410,7 +410,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_BOLandDQCFeature = {
             return @(
                 (
@@ -420,7 +420,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_ClientComponentsFull_FeatureList = {
             return @(
                 (
@@ -429,7 +429,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
             return @(
                 (
@@ -438,8 +438,8 @@ try
                 )
             )
         }
-        
-        
+
+
         $mockGetItemProperty_SQL = {
             return @(
                 (
@@ -452,7 +452,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_SharedDirectory = {
             return @(
                 (
@@ -461,7 +461,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItem_SharedDirectory = {
             return @(
                 (
@@ -470,7 +470,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_SharedWowDirectory = {
             return @(
                 (
@@ -479,7 +479,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItem_SharedWowDirectory = {
             return @(
                 (
@@ -488,7 +488,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_Setup = {
             return @(
                 (
@@ -497,7 +497,7 @@ try
                 )
             )
         }
-        
+
         $mockGetItemProperty_ServicesAnalysis = {
             return @(
                 (
@@ -506,7 +506,7 @@ try
                 )
             )
         }
-        
+
         $mockConnectSQL = {
             return @(
                 (
@@ -530,7 +530,7 @@ try
                 )
             )
         }
-        
+
         $mockConnectSQLCluster = {
             return @(
                 (
@@ -555,7 +555,7 @@ try
                 )
             )
         }
-        
+
         $mockConnectSQLAnalysis = {
             return @(
                 (
@@ -583,7 +583,7 @@ try
                 )
             )
         }
-        
+
         $mockRobocopyExecutableName = 'Robocopy.exe'
         $mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
         $mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
@@ -594,7 +594,7 @@ try
         $mockRobocopyArgumentUseUnbufferedIO = '/J'
         $mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
         $mockRobocopyArgumentDestinationPath = 'D:\Temp'
-        
+
         $mockGetCommand = {
             return @(
                 (
@@ -608,36 +608,36 @@ try
                 )
             )
         }
-        
+
         $mockStartProcessExpectedArgument = '' # Set dynamically during runtime
         $mockStartProcessExitCode = 0 # Set dynamically during runtime
-        
+
         $mockStartProcess = {
             if ($ArgumentList -cne $mockStartProcessExpectedArgument)
             {
                 throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
             }
-            
+
             return New-Object Object |
             Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
         }
-        
+
         $mockStartProcess_WithExitCode = {
             return New-Object Object |
             Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
         }
-        
+
         $mockSourcePathUNCWithoutLeaf = '\\server\share'
         $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
         $mockNewGuid = {
             return New-Object Object |
             Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
         }
-        
+
         $mockGetTemporaryFolder = {
             return $mockSourcePathUNC
         }
-        
+
         $mockGetCimInstance_MSClusterResource = {
             return @(
                 (
@@ -648,7 +648,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
             return @(
                 (
@@ -657,7 +657,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
             return @(
                 (
@@ -686,7 +686,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
             return @(
                 (
@@ -721,13 +721,13 @@ try
                 )
             )
         }
-        
+
         $mockGetCimInstance_MSClusterNetwork = {
             return @(
                 (
                     $mockClusterSites | ForEach-Object {
                         $network = $_
-                        
+
                         New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
                         Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
@@ -737,7 +737,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
             return @(
                 (
@@ -746,32 +746,32 @@ try
                 )
             )
         }
-        
+
         $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
             return @(
                 (
                     @('Network Name', 'IP Address') | ForEach-Object {
                         $resourceType = $_
-                        
+
                         $propertyValue = @{
                             MemberType = 'NoteProperty'
                             Name = 'PrivateProperties'
                             Value = $null
                         }
-                        
+
                         switch ($resourceType)
                         {
                             'Network Name'
                             {
                                 $propertyValue.Value = @{ DnsName = $mockDefaultInstance_FailoverClusterNetworkName }
                             }
-                            
+
                             'IP Address'
                             {
                                 $propertyValue.Value = @{ Address = $mockDefaultInstance_FailoverClusterIPAddress }
                             }
                         }
-                        
+
                         return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
                         Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
                         Add-Member @propertyValue -PassThru -Force
@@ -779,7 +779,7 @@ try
                 )
             )
         }
-        
+
         # Mock to return physical disks that are part of the "Available Storage" cluster role
         $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
             return @(
@@ -795,7 +795,7 @@ try
                 )
             )
         }
-        
+
         $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
             return @(
                 (
@@ -807,13 +807,13 @@ try
                 )
             )
         }
-        
+
         $mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
             $clusterDiskName = $InputObject.Name
-            
+
             # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
             $clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
-            
+
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition', 'root/MSCluster' |
@@ -821,7 +821,7 @@ try
                 )
             )
         }
-        
+
         <#
         Needed a way to see into the Set-method for the arguments the Set-method is building and sending to 'setup.exe', and fail
         the test if the arguments is different from the expected arguments.
@@ -829,7 +829,7 @@ try
         StartWin32Process throws an error message, similiar to what Pester would have reported (expected -> but was).
         #>
         $mockStartWin32ProcessExpectedArgument = @{ }
-        
+
         $mockStartWin32ProcessExpectedArgumentClusterDefault = @{
             IAcceptSQLServerLicenseTerms = 'True'
             Quiet = 'True'
@@ -838,10 +838,10 @@ try
             SQLSysAdminAccounts = 'COMPANY\sqladmin'
             FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
         }
-        
+
         $mockStartWin32Process = {
             $argumentHashTable = @{ }
-            
+
             # Break the argument string into a hash table
             ($Arguments -split ' ?/') | ForEach-Object {
                 if ($_ -imatch '(\w+)="?([^/]+)"?')
@@ -855,32 +855,32 @@ try
                     {
                         $value = ($Matches[2] -replace '" "', ' ') -replace '"', ''
                     }
-                    
+
                     $null = $argumentHashTable.Add($key, $value)
                 }
             }
-            
+
             # Start by checking whether we have the same number of parameters
             Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
             Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',')) -Verbose
             Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
-            
+
             $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
-            
+
             Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
             foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
             {
                 $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
                 $argumentKeyName | Should Be $argumentKey
-                
+
                 $argumentValue = $argumentHashTable.$argumentKey
                 $argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
             }
-            
+
             return 'Process Started'
         }
         #endregion Function mocks
-        
+
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
             SetupCredential = $mockSetupCredential
@@ -888,30 +888,31 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLENGINE,REPLICATION,DQC,DQ,BOL,CONN,BC,SDK,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
+            Features = 'SQLEngine,Replication,Dqc,Dq,Bol,Conn,Bc,Sdk,FullText,Rs,As,Is,Ssms,Adv_Ssms'
         }
+
         $featuresForSqlServer2016 = ''
-        
+
         $mockDefaultClusterParameters = @{
             SetupCredential = $mockSetupCredential
-            
+
             # Feature support is tested elsewhere, so just include the minimum
             Features = 'SQLEngine'
-            
+
         }
-        
+
         Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
             #region Setting up TestDrive:\
-            
+
             # Local path to TestDrive:\
             $mockSourcePath = $TestDrive.FullName
-            
+
             # UNC path to TestDrive:\
             $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-            
+
             #endregion Setting up TestDrive:\
-            
+
             BeforeEach {
                 # General mocks
                 Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
@@ -921,7 +922,7 @@ try
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                     ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
                 } -MockWith $mockGetItemProperty_SQL -Verifiable
-                
+
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     (
                         $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
@@ -929,47 +930,47 @@ try
                     ) -and
                     $Name -eq 'ImagePath'
                 } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-                
+
                 # Mocking SharedDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-                
+
                 Mock -CommandName Get-Item -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                 } -MockWith $mockGetItem_SharedDirectory -Verifiable
-                
+
                 # Mocking SharedWowDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-                
+
                 Mock -CommandName Get-Item -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-                
+
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                 } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
             }
-            
+
             $testProductVersion | ForEach-Object -Process {
                 $mockSqlMajorVersion = $_
-                
+
                 $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-                
+
                 $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
                 $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
                 $mockDynamicSqlTempDatabasePath = ''
                 $mockDynamicSqlTempDatabaseLogPath = ''
                 $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
                 $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -979,7 +980,7 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
@@ -1003,7 +1004,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockEmptyHashtable -Verifiable
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
@@ -1011,24 +1012,24 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
@@ -1037,15 +1038,15 @@ try
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -1054,15 +1055,15 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                     }
-                    
+
                     It 'Should not return any names of installed features' {
                         $result = Get-TargetResource @testParameters
                         $result.Features | Should Be ''
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
@@ -1092,7 +1093,7 @@ try
                         $result.ISSvcAccountUsername | Should BeNullOrEmpty
                     }
                 }
-                
+
                 Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -1102,7 +1103,7 @@ try
                             SourceCredential = $mockSetupCredential
                             SourcePath = $mockSourcePathUNC
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
@@ -1126,7 +1127,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockEmptyHashtable -Verifiable
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
@@ -1134,24 +1135,24 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
@@ -1160,15 +1161,15 @@ try
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -1177,15 +1178,15 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                     }
-                    
+
                     It 'Should not return any names of installed features' {
                         $result = Get-TargetResource @testParameters
                         $result.Features | Should Be ''
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePathUNC
@@ -1215,8 +1216,8 @@ try
                         $result.ISSvcAccountUsername | Should BeNullOrEmpty
                     }
                 }
-                
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN' and 'BC'" {
+
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN', 'SDK' and 'BC'" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters.Remove('Features')
@@ -1225,7 +1226,7 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 10)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1233,7 +1234,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 11)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1241,7 +1242,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 12)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1249,69 +1250,69 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                        
+
                         #region Mock Get-CimInstance
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                        
+
                         # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                         Mock -CommandName Get-CimInstance -MockWith {
                             throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                         } -Verifiable
                         #endregion Mock Get-CimInstance
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
                     }
-                    
+
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13, 14))
@@ -1324,7 +1325,7 @@ try
                         }
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -1334,7 +1335,7 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 10)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1342,7 +1343,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 11)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1350,7 +1351,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 12)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1358,69 +1359,69 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                        
+
                         #region Mock Get-CimInstance
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                        
+
                         # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                         Mock -CommandName Get-CimInstance -MockWith {
                             throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                         } -Verifiable
                         #endregion Mock Get-CimInstance
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
@@ -1429,15 +1430,15 @@ try
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
@@ -1460,40 +1461,40 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 2 -Scope It
                         }
-                        
+
                         #region Assert Get-CimInstance
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                         } -Exactly -Times 1 -Scope It
                         #endregion Assert Get-CimInstance
                     }
-                    
+
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13, 14))
@@ -1506,7 +1507,7 @@ try
                             $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
                         }
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
@@ -1536,7 +1537,7 @@ try
                         $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
                     }
                 }
-                
+
                 Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -1546,7 +1547,7 @@ try
                             SourceCredential = $mockSetupCredential
                             SourcePath = $mockSourcePathUNC
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 10)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1554,7 +1555,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 11)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1562,7 +1563,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 12)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1570,69 +1571,69 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                        
+
                         #region Mock Get-CimInstance
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                         } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                        
+
                         # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                         Mock -CommandName Get-CimInstance -MockWith {
                             throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                         } -Verifiable
                         #endregion Mock Get-CimInstance
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
@@ -1641,15 +1642,15 @@ try
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
@@ -1672,40 +1673,40 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 2 -Scope It
                         }
-                        
+
                         #region Assert Get-CimInstance
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                         } -Exactly -Times 1 -Scope It
                         #endregion Assert Get-CimInstance
                     }
-                    
+
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13, 14))
@@ -1718,7 +1719,7 @@ try
                             $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
                         }
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePathUNC
@@ -1748,16 +1749,16 @@ try
                         $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
                     }
                 }
-                
+
                 $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-                
+
                 $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
                 $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
                 $mockDynamicSqlTempDatabasePath = ''
                 $mockDynamicSqlTempDatabaseLogPath = ''
                 $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
                 $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -1767,7 +1768,7 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             # Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
@@ -1791,45 +1792,45 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockEmptyHashtable -Verifiable
                         }
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -1838,15 +1839,15 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                     }
-                    
+
                     It 'Should not return any names of installed features' {
                         $result = Get-TargetResource @testParameters
                         $result.Features | Should Be ''
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
@@ -1876,7 +1877,7 @@ try
                         $result.ISSvcAccountUsername | Should BeNullOrEmpty
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -1886,7 +1887,7 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 10)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1894,7 +1895,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 11)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1902,7 +1903,7 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
                         }
-                        
+
                         if ($mockSqlMajorVersion -eq 12)
                         {
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1910,82 +1911,82 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
                         }
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
-                        
+
                         #region Mock Get-CimInstance
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
                         } -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
                         } -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
                         } -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
                         } -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
                         } -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
-                        
+
                         # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                         Mock -CommandName Get-CimInstance -MockWith {
                             throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                         } -Verifiable
                         #endregion Mock Get-CimInstance
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
-                    
+
                     It 'Should return the same values as passed as parameters' {
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should Be $testParameters.InstanceName
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
@@ -2008,40 +2009,40 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 2 -Scope It
                         }
-                        
+
                         #region Assert Get-CimInstance
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                         } -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             $ClassName -eq 'Win32_Service' -and
                             $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
                         } -Exactly -Times 1 -Scope It
                         #endregion Assert Get-CimInstance
                     }
-                    
+
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13, 14))
@@ -2054,7 +2055,7 @@ try
                             $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
                         }
                     }
-                    
+
                     It 'Should return the correct values in the hash table' {
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
@@ -2084,9 +2085,9 @@ try
                         $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
-                    
+
                     BeforeAll {
                         $testParams = $mockDefaultParameters.Clone()
                         $testParams.Remove('Features')
@@ -2095,34 +2096,34 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith { } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith { } -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should not attempt to collect cluster information for a standalone instance' {
-                        
+
                         $currentState = Get-TargetResource @testParams
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
-                        
+
                         $currentState.FailoverClusterGroupName | Should BeNullOrEmpty
                         $currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
                         $currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
-                    
+
                     BeforeEach {
                         $testParams = $mockDefaultParameters.Clone()
                         $testParams.Remove('Features')
@@ -2131,60 +2132,60 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-                        
+
                         $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-                        
+
                         Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
                             $Filter -eq "Type = 'SQL Server'"
                         }
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-                        
+
                         Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
                     }
-                    
+
                     It 'Should collect information for a clustered instance' {
                         $currentState = Get-TargetResource @testParams
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-                        
+
                         $currentState.InstanceName | Should Be $testParams.InstanceName
                     }
-                    
+
                     It 'Should return correct cluster information' {
                         $currentState = Get-TargetResource @testParams
-                        
+
                         $currentState.FailoverClusterGroupName | Should Be $mockDefaultInstance_FailoverClusterGroupName
                         $currentState.FailoverClusterIPAddress | Should Be $mockDefaultInstance_FailoverClusterIPAddress
                         $currentSTate.FailoverClusterNetworkName | Should Be $mockDefaultInstance_FailoverClusterNetworkName
                     }
                 }
             }
-            
+
             Assert-VerifiableMocks
         }
-        
+
         Describe "xSQLServerSetup\Test-TargetResource" -Tag 'Test' {
             #region Setting up TestDrive:\
-            
+
             # Local path to TestDrive:\
             $mockSourcePath = $TestDrive.FullName
-            
+
             # UNC path to TestDrive:\
             $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-            
+
             #endregion Setting up TestDrive:\
-            
+
             BeforeEach {
                 # General mocks
                 Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
@@ -2194,7 +2195,7 @@ try
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                     ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
                 } -MockWith $mockGetItemProperty_SQL -Verifiable
-                
+
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     (
                         $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
@@ -2202,43 +2203,43 @@ try
                     ) -and
                     $Name -eq 'ImagePath'
                 } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-                
+
                 # Mocking SharedDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-                
+
                 Mock -CommandName Get-Item -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                 } -MockWith $mockGetItem_SharedDirectory -Verifiable
-                
+
                 # Mocking SharedWowDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-                
+
                 Mock -CommandName Get-Item -ParameterFilter {
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
             }
-            
+
             # For this test we only need to test one SQL Server version. Mocking SQL Server 2016 for the 'not in the desired state' test.
             $mockSqlMajorVersion = 13
-            
+
             $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-            
+
             $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
             $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
             $mockDynamicSqlTempDatabasePath = ''
             $mockDynamicSqlTempDatabaseLogPath = ''
             $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
             $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-            
+
             Context 'When the system is not in the desired state' {
                 BeforeEach {
                     $testParameters = $mockDefaultParameters
@@ -2247,7 +2248,7 @@ try
                         SourceCredential = $null
                         SourcePath = $mockSourcePath
                     }
-                    
+
                     # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -2257,43 +2258,43 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                     } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                     } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -MockWith $mockGetItemProperty_Setup -Verifiable
                 }
-                
+
                 It 'Should return that the desired state is absent when no products are installed' {
                     Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                    
+
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -Exactly -Times 0 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -Exactly -Times 0 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -2302,67 +2303,67 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -Exactly -Times 6 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                 }
-                
+
                 It 'Should return that the desired state is asbent when SSMS product is missing' {
                     Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                    
+
                     #region Mock Get-CimInstance
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                    
+
                     # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                     Mock -CommandName Get-CimInstance -MockWith {
                         throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                     } -Verifiable
                     #endregion Mock Get-CimInstance
-                    
+
                     # Change the default features for this test.
                     $testParameters.Features = 'SSMS'
-                    
+
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -2371,97 +2372,97 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -Exactly -Times 6 -Scope It
-                    
+
                     #region Assert Get-CimInstance
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -Exactly -Times 1 -Scope It
                     #endregion Assert Get-CimInstance
                 }
-                
+
                 It 'Should return that the desired state is asbent when ADV_SSMS product is missing' {
                     Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                    
+
                     #region Mock Get-CimInstance
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                    
+
                     # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                     Mock -CommandName Get-CimInstance -MockWith {
                         throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                     } -Verifiable
                     #endregion Mock Get-CimInstance
-                    
+
                     # Change the default features for this test.
                     $testParameters.Features = 'ADV_SSMS'
-                    
+
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -2470,58 +2471,58 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -Exactly -Times 6 -Scope It
-                    
+
                     #region Assert Get-CimInstance
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -Exactly -Times 1 -Scope It
                     #endregion Assert Get-CimInstance
                 }
-                
+
                 It 'Should return that the desired state is absent when a clustered instance cannot be found' {
                     $testClusterParameters = $testParameters.Clone()
-                    
+
                     $testClusterParameters += @{
                         FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                         FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
-                    
+
                     $result = Test-TargetResource @testClusterParameters
-                    
+
                     $result | Should Be $false
                 }
-                
+
                 # This is a test for regression testing of issue #432
                 It 'Should return false if a SQL Server failover cluster is missing features' {
                     $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-                    
+
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
@@ -2530,24 +2531,24 @@ try
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                         }
                     } -Verifiable
-                    
+
                     $testClusterParameters = $testParameters.Clone()
                     $testClusterParameters['Features'] = 'SQLEngine,AS'
-                    
+
                     $testClusterParameters += @{
                         FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                         FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
-                    
+
                     $result = Test-TargetResource @testClusterParameters
                     $result | Should Be $false
                 }
             }
-            
+
             # For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.
             $mockSqlMajorVersion = 12
-            
+
             Context "When the system is in the desired state" {
                 BeforeEach {
                     $testParameters = $mockDefaultParameters
@@ -2556,7 +2557,7 @@ try
                         SourceCredential = $null
                         SourcePath = $mockSourcePath
                     }
-                    
+
                     # Mock all SSMS products.
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -2566,97 +2567,97 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
                     } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
                     } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                    
+
                     Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                    
+
                     #region Mock Get-CimInstance
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-                    
+
                     # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
                     Mock -CommandName Get-CimInstance -MockWith {
                         throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
                     } -Verifiable
                     #endregion Mock Get-CimInstance
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                     } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                     } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                     } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-                    
+
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -MockWith $mockGetItemProperty_Setup -Verifiable
                 }
-                
+
                 It 'Should return that the desired state is present' {
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $true
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -2665,109 +2666,109 @@ try
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                         $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                     } -Exactly -Times 6 -Scope It
-                    
+
                     #region Assert Get-CimInstance
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
                     } -Exactly -Times 1 -Scope It
-                    
+
                     Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                         $ClassName -eq 'Win32_Service' -and
                         $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
                     } -Exactly -Times 1 -Scope It
                     #endregion Assert Get-CimInstance
                 }
-                
+
                 It 'Should return that the desired state is present when the correct clustered instance was found' {
                     $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-                    
+
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
                         $Filter -eq "Type = 'SQL Server'"
                     }
-                    
+
                     Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                    
+
                     Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-                    
+
                     $testClusterParameters = $testParameters.Clone()
-                    
+
                     $testClusterParameters += @{
                         FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                         FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
-                    
+
                     $result = Test-TargetResource @testClusterParameters
-                    
+
                     $result | Should Be $true
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
                     Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
                 }
-                
+
                 It 'Should not return false after a clustered install due to the presence of a variable called "FailoverClusterDisks"' {
                     $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-                    
+
                     Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-                    
+
                     Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
                         $Filter -eq "Type = 'SQL Server'"
                     }
-                    
+
                     Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                    
+
                     Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-                    
+
                     $testClusterParameters = $testParameters.Clone()
-                    
+
                     $testClusterParameters += @{
                         FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                         FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
-                    
+
                     $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
                     $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
                     $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
                     $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
                     $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
                     $mockDynamicSqlBackupPath = $mockSqlBackupPath
-                    
+
                     New-Variable -Name 'FailoverClusterDisks' -Value (& $mockClusterDiskMap)['UserData']
-                    
+
                     $result = Test-TargetResource @testClusterParameters
-                    
+
                     $result | Should Be $true
                 }
-                
+
                 # This is a test for regression testing of issue #432
                 It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
                     $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-                    
+
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
                             Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
@@ -2776,34 +2777,34 @@ try
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                         }
                     } -Verifiable
-                    
+
                     $testClusterParameters = $testParameters.Clone()
                     $testClusterParameters['Features'] = 'SQLEngine,AS'
-                    
+
                     $testClusterParameters += @{
                         FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
                         FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                         FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                     }
-                    
+
                     $result = Test-TargetResource @testClusterParameters
                     $result | Should Be $true
                 }
             }
-            
+
             Assert-VerifiableMocks
         }
-        
+
         Describe "xSQLServerSetup\Set-TargetResource" -Tag 'Set' {
             #region Setting up TestDrive:\
-            
+
             # Local path to TestDrive:\
             $mockSourcePath = $TestDrive.FullName
-            
+
             # UNC path to TestDrive:\
             $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-            
+
             <#
                 Mocking folder structure. This takes the leaf from the $mockSourcePath (the Guid in this case) and
                 uses that to create a mock folder to mimic the temp folder that would be created in, for example,
@@ -2815,7 +2816,7 @@ try
             {
                 New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
             }
-            
+
             <#
                 Mocking folder structure. This takes the leaf from the New-Guid mock and uses that
                 to create a mock folder to mimic the temp folder that would be created in, for example,
@@ -2827,18 +2828,18 @@ try
             {
                 New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
             }
-            
+
             # Mocking executable setup.exe which will be used for tests without parameter SourceCredential
             Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
-            
+
             # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
             Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-            
+
             # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
             Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-            
+
             #endregion Setting up TestDrive:\
-            
+
             BeforeEach {
                 # General mocks
                 Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
@@ -2848,7 +2849,7 @@ try
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                     ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
                 } -MockWith $mockGetItemProperty_SQL -Verifiable
-                
+
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     (
                         $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
@@ -2856,33 +2857,33 @@ try
                     ) -and
                     $Name -eq 'ImagePath'
                 } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-                
+
                 # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
                 Mock -CommandName Get-ItemProperty -Verifiable
-                
+
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                 } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-                
+
                 Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
                 Mock -CommandName WaitForWin32ProcessEnd -Verifiable
                 Mock -CommandName Test-TargetResource -MockWith {
                     return $true
                 } -Verifiable
             }
-            
+
             $testProductVersion | ForEach-Object -Process {
                 $mockSqlMajorVersion = $_
-                
+
                 $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-                
+
                 $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
                 $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
                 $mockDynamicSqlTempDatabasePath = ''
                 $mockDynamicSqlTempDatabaseLogPath = ''
                 $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
                 $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
                     BeforeEach {
                         Mock -CommandName New-SmbMapping -Verifiable
@@ -2891,7 +2892,7 @@ try
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -2900,10 +2901,10 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
@@ -2918,12 +2919,12 @@ try
                             InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
                             InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
                         }
-                        
+
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -2939,9 +2940,9 @@ try
                             InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
                             InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
@@ -2954,7 +2955,7 @@ try
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                             ($Name -eq $mockDefaultInstance_InstanceName)
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -2964,12 +2965,12 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
+
                         Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
-                    
+
                     if ($mockSqlMajorVersion -in (13, 14))
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
@@ -2979,13 +2980,13 @@ try
                                 SourceCredential = $null
                                 SourcePath = $mockSourcePath
                             }
-                            
+
                             $testParameters.Features = 'SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
-                        
+
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters = $mockDefaultParameters.Clone()
                             $testParameters += @{
@@ -2993,10 +2994,10 @@ try
                                 SourceCredential = $null
                                 SourcePath = $mockSourcePath
                             }
-                            
+
                             $testParameters.Features = 'ADV_SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
                     }
@@ -3009,9 +3010,9 @@ try
                                 SourceCredential = $null
                                 SourcePath = $mockSourcePath
                             }
-                            
+
                             $testParameters.Features = 'SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3019,9 +3020,9 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3029,7 +3030,7 @@ try
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3039,12 +3040,12 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
-                        
+
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters = $mockDefaultParameters.Clone()
                             $testParameters += @{
@@ -3052,9 +3053,9 @@ try
                                 SourceCredential = $null
                                 SourcePath = $mockSourcePath
                             }
-                            
+
                             $testParameters.Features = 'ADV_SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3062,9 +3063,9 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'ADV_SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3072,7 +3073,7 @@ try
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3082,15 +3083,15 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
-                            
+
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
                     }
                 }
-                
+
                 Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -3099,32 +3100,32 @@ try
                             SourceCredential = $mockSetupCredential
                             SourcePath = $mockSourcePathUNC
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
                         }
-                        
+
                         # Mocking SharedDirectory (when previously installed and should not be installed again).
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                         } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-                        
+
                         # Mocking SharedWowDirectory (when previously installed and should not be installed again).
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                         } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Start-Process -Verifiable
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3135,9 +3136,9 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
-                        
+
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3148,9 +3149,9 @@ try
                             SQLSysAdminAccounts = 'COMPANY\sqladmin'
                             ASSysAdminAccounts = 'COMPANY\sqladmin'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
@@ -3163,7 +3164,7 @@ try
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                             ($Name -eq $mockDefaultInstance_InstanceName)
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3173,26 +3174,26 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
-                        
+
+
                         Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
-                    
+
                     if ($mockSqlMajorVersion -in (13, 14))
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'SSMS'
                             $mockStartWin32ProcessExpectedArgument = ''
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
-                        
+
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'ADV_SSMS'
                             $mockStartWin32ProcessExpectedArgument = ''
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
                     }
@@ -3200,7 +3201,7 @@ try
                     {
                         It 'Should set the system in the desired state when feature is SSMS' {
                             $testParameters.Features = 'SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3208,9 +3209,9 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3218,7 +3219,7 @@ try
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3228,16 +3229,16 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
-                            
+
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
-                        
+
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters.Features = 'ADV_SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3245,16 +3246,16 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'ADV_SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3264,14 +3265,14 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
                     }
                 }
-                
+
                 Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -3282,19 +3283,19 @@ try
                             ForceReboot = $true
                             SuppressReboot = $true
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
                         }
-                        
+
                         Mock -CommandName New-SmbMapping -Verifiable
                         Mock -CommandName Remove-SmbMapping -Verifiable
                         Mock -CommandName Start-Process -Verifiable
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3305,7 +3306,7 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
@@ -3317,9 +3318,9 @@ try
                             SQLSysAdminAccounts = 'COMPANY\sqladmin'
                             ASSysAdminAccounts = 'COMPANY\sqladmin'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
-                        
+
                         Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
@@ -3332,7 +3333,7 @@ try
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                             ($Name -eq $mockDefaultInstance_InstanceName)
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3342,26 +3343,26 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
-                        
+
+
                         Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
-                    
+
                     if ($mockSqlMajorVersion -in (13, 14))
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
-                        
+
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'ADV_SSMS'
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
                     }
@@ -3369,7 +3370,7 @@ try
                     {
                         It 'Should set the system in the desired state when feature is SSMS' {
                             $testParameters.Features = 'SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3377,9 +3378,9 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3387,7 +3388,7 @@ try
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3397,16 +3398,16 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
-                            
+
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
-                        
+
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters.Features = 'ADV_SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3414,16 +3415,16 @@ try
                                 InstanceName = 'MSSQLSERVER'
                                 Features = 'ADV_SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3433,23 +3434,23 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
                     }
                 }
-                
+
                 $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-                
+
                 $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
                 $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
                 $mockDynamicSqlTempDatabasePath = ''
                 $mockDynamicSqlTempDatabaseLogPath = ''
                 $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
                 $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
@@ -3459,12 +3460,12 @@ try
                             SourcePath = $mockSourcePath
                             ForceReboot = $true
                         }
-                        
+
                         if ($mockSqlMajorVersion -in (13, 14))
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
                         }
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -3473,11 +3474,11 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
@@ -3489,9 +3490,9 @@ try
                             SQLSysAdminAccounts = 'COMPANY\sqladmin'
                             ASSysAdminAccounts = 'COMPANY\sqladmin'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3499,9 +3500,9 @@ try
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                             ($Name -eq $mockDefaultInstance_InstanceName)
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
@@ -3510,25 +3511,25 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -Exactly -Times 6 -Scope It
-                        
+
                         Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
-                    
+
                     if ($mockSqlMajorVersion -in (13, 14))
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
-                        
+
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
                             $mockStartWin32ProcessExpectedArgument = @{ }
-                            
+
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
                     }
@@ -3536,7 +3537,7 @@ try
                     {
                         It 'Should set the system in the desired state when feature is SSMS' {
                             $testParameters.Features = 'SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3544,9 +3545,9 @@ try
                                 InstanceName = 'TEST'
                                 Features = 'SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -3554,7 +3555,7 @@ try
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3564,15 +3565,15 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
-                        
+
                         It 'Should set the system in the desired state when feature is ADV_SSMS' {
                             $testParameters.Features = 'ADV_SSMS'
-                            
+
                             $mockStartWin32ProcessExpectedArgument = @{
                                 Quiet = 'True'
                                 IAcceptSQLServerLicenseTerms = 'True'
@@ -3580,16 +3581,16 @@ try
                                 InstanceName = 'TEST'
                                 Features = 'ADV_SSMS'
                             }
-                            
+
                             { Set-TargetResource @testParameters } | Should Not Throw
-                            
+
                             Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
                                 ($Name -eq $mockDefaultInstance_InstanceName)
                             } -Exactly -Times 0 -Scope It
-                            
+
                             Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -3599,14 +3600,14 @@ try
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                             } -Exactly -Times 6 -Scope It
-                            
+
                             Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
                     }
                 }
-                
+
                 # For testing AddNode action
                 Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
                     BeforeAll {
@@ -3621,39 +3622,39 @@ try
                             ASSvcAccount = $mockAnalysisServiceCredential
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                         }
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
                             $Filter -eq "Name = 'Available Storage'"
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Verfiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
                             $ResultClassName -eq 'MSCluster_DiskPartition'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolume'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                     }
-                    
+
                     It 'Should pass proper parameters to setup' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3668,22 +3669,22 @@ try
                             AsSvcPassword = $mockAnalysisServiceCredential.GetNetworkCredential().Password
                             SkipRules = 'Cluster_VerifyForErrors'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
                             $Credential | Should Not BeNullOrEmpty
                             return 'Process started.'
                         }
-                        
+
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
                 }
-                
+
                 # For testing InstallFailoverCluster action
                 Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
                     BeforeAll {
@@ -3693,7 +3694,7 @@ try
                         $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
                         $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
                         $mockDynamicSqlBackupPath = $mockSqlBackupPath
-                        
+
                         $testParameters = $mockDefaultClusterParameters.Clone()
                         $testParameters += @{
                             InstanceName = 'MSSQLSERVER'
@@ -3702,7 +3703,7 @@ try
                             FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                            
+
                             # Ensure we use "clustered" disks for our paths
                             InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
                             SQLUserDBDir = $mockDynamicSqlUserDatabasePath
@@ -3711,55 +3712,55 @@ try
                             SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
                             $Filter -eq "Name = 'Available Storage'"
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Verfiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
                             $ResultClassName -eq 'MSCluster_DiskPartition'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolume'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                     }
-                    
+
                     It 'Should pass proper parameters to setup' {
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
@@ -3775,10 +3776,10 @@ try
                             SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass proper parameters to setup when only InstallSQLDataDir is assigned a path' {
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
@@ -3789,16 +3790,17 @@ try
                             SkipRules = 'Cluster_VerifyForErrors'
                             InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
                         }
-                        
+
                         $setTargetResourceParameters = $testParameters.Clone()
                         $setTargetResourceParameters.Remove('SQLUserDBDir')
                         $setTargetResourceParameters.Remove('SQLUserDBLogDir')
                         $setTargetResourceParameters.Remove('SQLTempDbDir')
                         $setTargetResourceParameters.Remove('SQLTempDbLogDir')
                         $setTargetResourceParameters.Remove('SQLBackupDir')
+
                         { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass proper parameters to setup when three variables are assigned the same drive, but different paths' {
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
@@ -3811,39 +3813,39 @@ try
                             SQLUserDBDir = 'E:\SQLData\UserDb'
                             SQLUserDBLogDir = 'E:\SQLData\UserDbLogs'
                         }
-                        
+
                         $setTargetResourceParameters = $testParameters.Clone()
                         $setTargetResourceParameters.Remove('SQLTempDbDir')
                         $setTargetResourceParameters.Remove('SQLTempDbLogDir')
                         $setTargetResourceParameters.Remove('SQLBackupDir')
-                        
+
                         $setTargetResourceParameters['InstallSQLDataDir'] = 'E:\SQLData\' # This ends with \ to test removal of paths ending with \
                         $setTargetResourceParameters['SQLUserDBDir'] = 'E:\SQLData\UserDb'
                         $setTargetResourceParameters['SQLUserDBLogDir'] = 'E:\SQLData\UserDbLogs'
-                        
+
                         { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass the SetupCredential object to the StartWin32Process function' {
                         $mockStartWin32Process_SetupCredential = {
                             $Credential | Should Not BeNullOrEmpty
                             return 'Process started.'
                         }
-                        
+
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {
                         $badPathParameters = $testParameters.Clone()
-                        
+
                         # Pass in a bad path
                         $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-                        
+
                         { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
                     }
-                    
+
                     It 'Should properly map paths to clustered disk resources' {
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
@@ -3859,14 +3861,14 @@ try
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should build a DEFAULT address string when no network is specified' {
                         $missingNetworkParams = $testParameters.Clone()
                         $missingNetworkParams.Remove('FailoverClusterIPAddress')
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'InstallFailoverCluster'
@@ -3881,34 +3883,34 @@ try
                             FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
                             SkipRules = 'Cluster_VerifyForErrors'
                         }
-                        
+
                         { Set-TargetResource @missingNetworkParams } | Should Not Throw
                     }
-                    
+
                     It 'Should throw an error when an invalid IP Address is specified' {
                         $invalidAddressParameters = $testParameters.Clone()
-                        
+
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
                             FailoverClusterIPAddress = '192.168.0.100'
                         }
-                        
+
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
                     }
-                    
+
                     It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
                         $invalidAddressParameters = $testParameters.Clone()
-                        
+
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
                             FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
                         }
-                        
+
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
                     }
-                    
+
                     It 'Should build a valid IP address string for a single address' {
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
@@ -3923,17 +3925,17 @@ try
                             SkipRules = 'Cluster_VerifyForErrors'
                             Action = 'InstallFailoverCluster'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should build a valid IP address string for a multi-subnet cluster' {
                         $multiSubnetParameters = $testParameters.Clone()
                         $multiSubnetParameters.Remove('FailoverClusterIPAddress')
                         $multiSubnetParameters += @{
                             FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
                         }
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
@@ -3948,20 +3950,20 @@ try
                             SkipRules = 'Cluster_VerifyForErrors'
                             Action = 'InstallFailoverCluster'
                         }
-                        
+
                         { Set-TargetResource @multiSubnetParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
                         $csvTestParameters = $testParameters.Clone()
-                        
+
                         $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['SysData'].Path
                         $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
                         $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
                         $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
                         $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
                         $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path
-                        
+
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
                             SkipRules = 'Cluster_VerifyForErrors'
@@ -3981,20 +3983,20 @@ try
                             SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
                             SQLBackupDir = $mockCSVClusterDiskMap['Backup'].Path
                         }
-                        
+
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
                         $csvTestParameters = $testParameters.Clone()
-                        
+
                         $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
                         $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
                         $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
                         $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
                         $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
                         $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
-                        
+
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
                             SkipRules = 'Cluster_VerifyForErrors'
@@ -4014,71 +4016,71 @@ try
                             SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
                             SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
                         }
-                        
+
                         { Set-TargetResource @csvTestParameters } | Should Not Throw
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
                     BeforeAll {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters.Remove('Features')
                         $testParameters.Remove('SourceCredential')
                         $testParameters.Remove('ASSysAdminAccounts')
-                        
+
                         $testParameters += @{
                             Features = 'SQLENGINE'
                             InstanceName = 'MSSQLSERVER'
                             SourcePath = $mockSourcePath
                             Action = 'PrepareFailoverCluster'
                         }
-                        
+
                         Mock -CommandName NetUse -Verifiable
                         Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
                         Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
                         } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-                        
+
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
-                        
+
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Verfiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
                             $ResultClass -eq 'MSCluster_DiskPartition'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
                     }
-                    
+
                     It 'Should pass correct arguments to the setup process' {
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'PrepareFailoverCluster'
@@ -4088,7 +4090,7 @@ try
                         $mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
 
                         { Set-TargetResource @testParameters } | Should Not throw
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -4099,29 +4101,29 @@ try
                         Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
                             $ResultClass -eq 'MSCluster_DiskPartition'
                         } -Exactly -Times 0 -Scope It
-                        
+
                         Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Exactly -Times 0 -Scope It
                     }
                 }
-                
+
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
                     BeforeEach {
                         $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
@@ -4130,7 +4132,7 @@ try
                         $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
                         $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
                         $mockDynamicSqlBackupPath = $mockSqlBackupPath
-                        
+
                         $testParameters = $mockDefaultClusterParameters.Clone()
                         $testParameters += @{
                             InstanceName = 'MSSQLSERVER'
@@ -4139,7 +4141,7 @@ try
                             FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                            
+
                             # Ensure we use "clustered" disks for our paths
                             InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
                             SQLUserDBDir = $mockDynamicSqlUserDatabasePath
@@ -4149,50 +4151,50 @@ try
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
                     }
-                    
+
                     BeforeAll {
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
                             $Filter -eq "Name = 'Available Storage'"
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Verfiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
                             $ResultClassName -eq 'MSCluster_DiskPartition'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolume'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
                             $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
                         } -Verifiable
-                        
+
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                     }
-                    
+
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {
                         $badPathParameters = $testParameters.Clone()
-                        
+
                         # Pass in a bad path
                         $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-                        
+
                         { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
                     }
-                    
+
                     It 'Should properly map paths to clustered disk resources' {
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'CompleteFailoverCluster'
@@ -4207,14 +4209,14 @@ try
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should build a DEFAULT address string when no network is specified' {
                         $missingNetworkParams = $testParameters.Clone()
                         $missingNetworkParams.Remove('FailoverClusterIPAddress')
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             Action = 'CompleteFailoverCluster'
@@ -4229,34 +4231,34 @@ try
                             FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
                             SkipRules = 'Cluster_VerifyForErrors'
                         }
-                        
+
                         { Set-TargetResource @missingNetworkParams } | Should Not Throw
                     }
-                    
+
                     It 'Should throw an error when an invalid IP Address is specified' {
                         $invalidAddressParameters = $testParameters.Clone()
-                        
+
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
                             FailoverClusterIPAddress = '192.168.0.100'
                         }
-                        
+
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
                     }
-                    
+
                     It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
                         $invalidAddressParameters = $testParameters.Clone()
-                        
+
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
                             FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
                         }
-                        
+
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
                     }
-                    
+
                     It 'Should build a valid IP address string for a single address' {
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
@@ -4271,17 +4273,17 @@ try
                             SkipRules = 'Cluster_VerifyForErrors'
                             Action = 'CompleteFailoverCluster'
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should build a valid IP address string for a multi-subnet cluster' {
                         $multiSubnetParameters = $testParameters.Clone()
                         $multiSubnetParameters.Remove('FailoverClusterIPAddress')
                         $multiSubnetParameters += @{
                             FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
                         }
-                        
+
                         $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartWin32ProcessExpectedArgument += @{
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
@@ -4296,17 +4298,17 @@ try
                             SkipRules = 'Cluster_VerifyForErrors'
                             Action = 'CompleteFailoverCluster'
                         }
-                        
+
                         { Set-TargetResource @multiSubnetParameters } | Should Not Throw
                     }
-                    
+
                     It 'Should pass proper parameters to setup' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             IAcceptSQLServerLicenseTerms = 'True'
                             SkipRules = 'Cluster_VerifyForErrors'
                             Quiet = 'True'
                             SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            
+
                             Action = 'CompleteFailoverCluster'
                             InstanceName = 'MSSQLSERVER'
                             Features = 'SQLEngine'
@@ -4321,16 +4323,16 @@ try
                             SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
-                        
+
                         { Set-TargetResource @testParameters } | Should Not Throw
                     }
                 }
-                
+
             }
-            
+
             Assert-VerifiableMocks
         }
-        
+
         # Tests only the parts of the code that does not already get tested thru the other tests.
         Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
             Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
@@ -4338,11 +4340,11 @@ try
                     Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
                     Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
                 }
-                
-                
+
+
                 It 'Should use Unbuffered IO when copying' {
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-                    
+
                     $mockStartProcessExpectedArgument =
                     $mockRobocopyArgumentSourcePath,
                     $mockRobocopyArgumentDestinationPath,
@@ -4350,21 +4352,21 @@ try
                     $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                     $mockRobocopyArgumentUseUnbufferedIO,
                     $mockRobocopyArgumentSilent -join ' '
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
-                
+
                 It 'Should not use Unbuffered IO when copying' {
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
-                    
+
                     $mockStartProcessExpectedArgument =
                     $mockRobocopyArgumentSourcePath,
                     $mockRobocopyArgumentDestinationPath,
@@ -4372,187 +4374,187 @@ try
                     $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
                     '',
                     $mockRobocopyArgumentSilent -join ' '
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
             }
-            
+
             Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
                 BeforeEach {
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-                    
+
                     Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
                     Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
                 }
-                
+
                 It 'Should throw the correct error message when error code is 8' {
                     $mockStartProcessExitCode = 8
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
-                
+
                 It 'Should throw the correct error message when error code is 16' {
                     $mockStartProcessExitCode = 16
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
-                
+
                 It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
                     $mockStartProcessExitCode = 9
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
             }
-            
+
             Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
                 BeforeEach {
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-                    
+
                     Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
                     Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
                 }
-                
+
                 It 'Should finish succesfully with exit code 1' {
                     $mockStartProcessExitCode = 1
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
-                
+
                 It 'Should finish succesfully with exit code 2' {
                     $mockStartProcessExitCode = 2
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
-                
+
                 It 'Should finish succesfully with exit code 3' {
                     $mockStartProcessExitCode = 3
-                    
+
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
                         DestinationPath = $mockRobocopyArgumentDestinationPath
                     }
-                    
+
                     { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
                 }
             }
         }
-        
+
         Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
             $serviceTypes = @('SQL', 'AGT', 'IS', 'RS', 'AS', 'FT')
-            
+
             BeforeAll {
                 $mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
-                
+
                 $mockSystemServiceAccount = (
                     New-Object System.Management.Automation.PSCredential 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
                 )
-                
+
                 $mockVirtualServiceAccount = (
                     New-Object System.Management.Automation.PSCredential 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
                 )
-                
+
                 $mockManagedServiceAccount = (
                     New-Object System.Management.Automation.PSCredential 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
                 )
-                
+
                 $mockDomainServiceAccount = (
                     New-Object System.Management.Automation.PSCredential 'COMPANY\sql.service', $mockServiceAccountPassword
                 )
             }
-            
+
             $serviceTypes | ForEach-Object {
-                
+
                 $serviceType = $_
-                
+
                 Context "When service type is $serviceType" {
-                    
+
                     It "Should return the correct parameters when the account is a system account." {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
-                        
+
                         $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
                         $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
                     }
-                    
+
                     It "Should return the correct parameters when the account is a virtual service account" {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
-                        
+
                         $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
                         $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
                     }
-                    
+
                     It "Should return the correct parameters when the account is a managed service account" {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
-                        
+
                         $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
                         $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
                     }
-                    
+
                     It "Should return the correct parameters when the account is a domain account" {
                         $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
-                        
+
                         $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
                         $result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
                     }
                 }
             }
         }
-        
+
         Describe 'Get-TemporaryFolder' -Tag 'Helper' {
             BeforeAll {
                 $mockExpectedTempPath = [IO.Path]::GetTempPath()
             }
-            
+
             Context "When using Get-TemporaryFolder" {
                 It "Should return the correct temporary path." {
                     Get-TemporaryFolder | Should BeExactly $mockExpectedTempPath

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -869,7 +869,7 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK'
+            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,ADV_SDK'
         }
 
         $mockDefaultClusterParameters = @{

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -890,7 +890,7 @@ try
             #>
             Features = 'SQLENGINE,REPLICATION,DQC,DQ,BOL,CONN,BC,SDK,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
         }
-		$featuresForSqlServer2016 = ''
+        $featuresForSqlServer2016 = ''
         
         $mockDefaultClusterParameters = @{
             SetupCredential = $mockSetupCredential

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -406,7 +406,7 @@ try
             return @(
                 (
                     New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SQL_SSMS_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SQL_Tools_Standard_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
                 )
             )
         }
@@ -419,6 +419,7 @@ try
                 )
             )
         }
+        
 
         $mockGetItemProperty_SQL = {
             return @(
@@ -868,7 +869,7 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms'
+            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK'
         }
 
         $mockDefaultClusterParameters = @{

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -869,7 +869,7 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,ADV_SDK'
+            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK'
         }
 
         $mockDefaultClusterParameters = @{

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -402,6 +402,34 @@ try
             )
         }
 
+        $mockGetItemProperty_DQFeature = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
+				)
+			)
+		}
+
+        $mockGetItemProperty_BOLFeature = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru -Force
+				)
+			)
+		}
+
+
+        $mockGetItemProperty_DQCFeature = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru -Force
+				)
+			)
+		}
+
         $mockGetItemProperty_ClientComponentsFull_FeatureList = {
             return @(
                 (
@@ -869,7 +897,7 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK'
+            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
         }
 
         $mockDefaultClusterParameters = @{
@@ -993,6 +1021,18 @@ try
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
@@ -1106,6 +1146,18 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1260,6 +1312,18 @@ try
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
 
@@ -1359,6 +1423,18 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1565,6 +1641,18 @@ try
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
@@ -1739,6 +1827,18 @@ try
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
@@ -1885,6 +1985,18 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -2185,6 +2297,18 @@ try
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -2540,6 +2664,18 @@ try
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                     } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                     Mock -CommandName Get-ItemProperty -ParameterFilter {
                         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
@@ -3653,6 +3789,18 @@ try
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
 
@@ -3942,6 +4090,18 @@ try
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -10,17 +10,17 @@ $script:DSCResourceName = 'MSFT_xSQLServerSetup'
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ((-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-	(-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))))
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))))
 {
-	& git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-											  -DSCModuleName $script:DSCModuleName `
-											  -DSCResourceName $script:DSCResourceName `
-											  -TestType Unit
+                                              -DSCModuleName $script:DSCModuleName `
+                                              -DSCResourceName $script:DSCResourceName `
+                                              -TestType Unit
 
 #endregion HEADER
 
@@ -28,4539 +28,4539 @@ function Invoke-TestSetup {
 }
 
 function Invoke-TestCleanup {
-	Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
 # Begin Testing
 try
 {
-	Invoke-TestSetup
-	
-	InModuleScope $script:DSCResourceName {
-		# Testing each supported SQL Server version
-		$testProductVersion = @(
-			14, # SQL Server "2017"
-			13, # SQL Server 2016
-			12, # SQL Server 2014
-			11, # SQL Server 2012
-			10 # SQL Server 2008 and 2008 R2
-		)
-		
-		$mockSqlDatabaseEngineName = 'MSSQL'
-		$mockSqlAgentName = 'SQLAgent'
-		$mockSqlFullTextName = 'MSSQLFDLauncher'
-		$mockSqlReportingName = 'ReportServer'
-		$mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
-		$mockSqlAnalysisName = 'MSOLAP'
-		
-		$mockSqlCollation = 'Finnish_Swedish_CI_AS'
-		$mockSqlLoginMode = 'Integrated'
-		
-		$mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
-		$mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
-		$mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
-		$mockSqlSystemAdministrator = 'COMPANY\Stacy'
-		
-		$mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
-		$mockSqlAnalysisAdmins = @('COMPANY\Stacy', 'COMPANY\SSAS Administrators')
-		$mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
-		$mockSqlAnalysisTempDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
-		$mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
-		$mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
-		$mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
-		
-		$mockDefaultInstance_InstanceName = 'MSSQLSERVER'
-		$mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
-		$mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
-		$mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
-		$mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
-		$mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
-		$mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
-		
-		$mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-		$mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
-		$mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
-		$mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
-		$mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
-		$mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
-		
-		$mockNamedInstance_InstanceName = 'TEST'
-		$mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
-		$mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
-		$mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
-		$mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
-		$mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
-		$mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
-		
-		$mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-		$mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
-		$mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
-		
-		$mockmockSetupCredentialUserName = "COMPANY\sqladmin"
-		
-		$mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-		$mockSetupCredential = New-Object System.Management.Automation.PSCredential($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
-		
-		$mockSqlServiceAccount = 'COMPANY\SqlAccount'
-		$mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
-		$mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-		$mockAgentServiceAccount = 'COMPANY\AgentAccount'
-		$mockAgentServicePassword = 'Ag3ntP@ssw0rd'
-		$mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount, ($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-		$mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
-		$mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
-		$mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-		
-		$mockClusterNodes = @($env:COMPUTERNAME, 'SQL01', 'SQL02')
-		
-		$mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
-		$mockSqlUserDatabasePath = 'K:\MSSQL\Data'
-		$mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
-		$mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
-		$mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
-		$mockSqlBackupPath = 'O:\MSSQL\Backup'
-		
-		$mockClusterDiskMap = {
-			@{
-				SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
-				UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
-				UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
-				TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
-				TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
-				Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
-			}
-		}
-		
-		$mockCSVClusterDiskMap = @{
-			SysData = @{ Path = 'C:\ClusterStorage\SysData'; Name = "Cluster Virtual Disk (SQL System Data Disk)" }
-			UserData = @{ Path = 'C:\ClusterStorage\SQLData'; Name = "Cluster Virtual Disk (SQL Data Disk)" }
-			UserLogs = @{ Path = 'C:\ClusterStorage\SQLLogs'; Name = "Cluster Virtual Disk (SQL Log Disk)" }
-			TempDbData = @{ Path = 'C:\ClusterStorage\TempDBData'; Name = "Cluster Virtual Disk (SQL TempDBData Disk)" }
-			TempDbLogs = @{ Path = 'C:\ClusterStorage\TempDBLogs'; Name = "Cluster Virtual Disk (SQL TempDBLog Disk)" }
-			Backup = @{ Path = 'C:\ClusterStorage\SQLBackup'; Name = "Cluster Virtual Disk (SQL Backup Disk)" }
-		}
-		
-		$mockClusterSites = @(
-			@{
-				Name = 'SiteA'
-				Address = $mockDefaultInstance_FailoverClusterIPAddress
-				Mask = '255.255.255.0'
-			},
-			@{
-				Name = 'SiteB'
-				Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
-				Mask = '255.255.255.0'
-			}
-		)
-		
-		#region Function mocks
-		$mockGetSqlMajorVersion = {
-			return $mockSqlMajorVersion
-		}
-		
-		$mockEmptyHashtable = {
-			return @()
-		}
-		
-		$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
-		$mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
-		$mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
-		$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
-		$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
-		$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
-		
-		$mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
-		
-		$mockGetItemProperty_UninstallProducts2008R2 = {
-			return @(
-				$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
-				$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber # Mock product ADV_SSMS 2012
-			)
-		}
-		
-		$mockGetItemProperty_UninstallProducts2012 = {
-			return @(
-				$mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-				$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber # Mock product SSMS 2014
-			)
-		}
-		
-		$mockGetItemProperty_UninstallProducts2014 = {
-			return @(
-				$mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
-				$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
-			)
-		}
-		
-		$mockGetItemProperty_UninstallProducts = {
-			return @(
-				$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
-				$mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-				$mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
-				$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber, # Mock product ADV_SSMS 2012
-				$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber, # Mock product SSMS 2014
-				$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_DatabaseService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_AgentService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_FullTextService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_ReportingService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_IntegrationService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_DefaultInstance_AnalysisService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetService_DefaultInstance = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_DatabaseService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_AgentService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_FullTextService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_ReportingService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_IntegrationService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_NamedInstance_AnalysisService = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetService_NamedInstance = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_ConfigurationState = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_DQFeature = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_BOLandDQCFeature = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_ClientComponentsFull_FeatureList = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
-				)
-			)
-		}
-		
-		
-		$mockGetItemProperty_SQL = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
-				),
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_SharedDirectory = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItem_SharedDirectory = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_SharedWowDirectory = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItem_SharedWowDirectory = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_Setup = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetItemProperty_ServicesAnalysis = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
-				)
-			)
-		}
-		
-		$mockConnectSQL = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-					Add-Member ScriptProperty Logins {
-						return @((New-Object Object |
-								Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-								Add-Member ScriptMethod ListMembers {
-									return @('sysadmin')
-								} -PassThru -Force
-							))
-					} -PassThru -Force
-				)
-			)
-		}
-		
-		$mockConnectSQLCluster = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-					Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
-					Add-Member ScriptProperty Logins {
-						return @((New-Object Object |
-								Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-								Add-Member ScriptMethod ListMembers {
-									return @('sysadmin')
-								} -PassThru -Force
-							))
-					} -PassThru -Force
-				)
-			)
-		}
-		
-		$mockConnectSQLAnalysis = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member ScriptProperty ServerProperties  {
-						return @{
-							'CollationName' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force)
-							'DataDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force)
-							'TempDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force)
-							'LogDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force)
-							'BackupDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force)
-						}
-					} -PassThru |
-					Add-Member ScriptProperty Roles  {
-						return @{
-							'Administrators' = @(New-Object Object |
-								Add-Member ScriptProperty Members {
-									return New-Object Object |
-									Add-Member ScriptProperty Name {
-										return $mockSqlAnalysisAdmins
-									} -PassThru -Force
-								} -PassThru -Force
+    Invoke-TestSetup
+    
+    InModuleScope $script:DSCResourceName {
+        # Testing each supported SQL Server version
+        $testProductVersion = @(
+            14, # SQL Server "2017"
+            13, # SQL Server 2016
+            12, # SQL Server 2014
+            11, # SQL Server 2012
+            10 # SQL Server 2008 and 2008 R2
+        )
+        
+        $mockSqlDatabaseEngineName = 'MSSQL'
+        $mockSqlAgentName = 'SQLAgent'
+        $mockSqlFullTextName = 'MSSQLFDLauncher'
+        $mockSqlReportingName = 'ReportServer'
+        $mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
+        $mockSqlAnalysisName = 'MSOLAP'
+        
+        $mockSqlCollation = 'Finnish_Swedish_CI_AS'
+        $mockSqlLoginMode = 'Integrated'
+        
+        $mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
+        $mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
+        $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
+        $mockSqlSystemAdministrator = 'COMPANY\Stacy'
+        
+        $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
+        $mockSqlAnalysisAdmins = @('COMPANY\Stacy', 'COMPANY\SSAS Administrators')
+        $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
+        $mockSqlAnalysisTempDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
+        $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
+        $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
+        $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
+        
+        $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+        $mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
+        $mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
+        $mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
+        $mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
+        $mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
+        $mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
+        
+        $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+        $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+        $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
+        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
+        $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
+        
+        $mockNamedInstance_InstanceName = 'TEST'
+        $mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
+        $mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
+        $mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
+        $mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
+        $mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
+        $mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
+        
+        $mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+        $mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
+        $mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
+        
+        $mockmockSetupCredentialUserName = "COMPANY\sqladmin"
+        
+        $mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+        $mockSetupCredential = New-Object System.Management.Automation.PSCredential($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
+        
+        $mockSqlServiceAccount = 'COMPANY\SqlAccount'
+        $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
+        $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        $mockAgentServiceAccount = 'COMPANY\AgentAccount'
+        $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
+        $mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount, ($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
+        $mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
+        $mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        
+        $mockClusterNodes = @($env:COMPUTERNAME, 'SQL01', 'SQL02')
+        
+        $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
+        $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
+        $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
+        $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
+        $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
+        $mockSqlBackupPath = 'O:\MSSQL\Backup'
+        
+        $mockClusterDiskMap = {
+            @{
+                SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
+                UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
+                UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
+                TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
+                TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
+                Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
+            }
+        }
+        
+        $mockCSVClusterDiskMap = @{
+            SysData = @{ Path = 'C:\ClusterStorage\SysData'; Name = "Cluster Virtual Disk (SQL System Data Disk)" }
+            UserData = @{ Path = 'C:\ClusterStorage\SQLData'; Name = "Cluster Virtual Disk (SQL Data Disk)" }
+            UserLogs = @{ Path = 'C:\ClusterStorage\SQLLogs'; Name = "Cluster Virtual Disk (SQL Log Disk)" }
+            TempDbData = @{ Path = 'C:\ClusterStorage\TempDBData'; Name = "Cluster Virtual Disk (SQL TempDBData Disk)" }
+            TempDbLogs = @{ Path = 'C:\ClusterStorage\TempDBLogs'; Name = "Cluster Virtual Disk (SQL TempDBLog Disk)" }
+            Backup = @{ Path = 'C:\ClusterStorage\SQLBackup'; Name = "Cluster Virtual Disk (SQL Backup Disk)" }
+        }
+        
+        $mockClusterSites = @(
+            @{
+                Name = 'SiteA'
+                Address = $mockDefaultInstance_FailoverClusterIPAddress
+                Mask = '255.255.255.0'
+            },
+            @{
+                Name = 'SiteB'
+                Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
+                Mask = '255.255.255.0'
+            }
+        )
+        
+        #region Function mocks
+        $mockGetSqlMajorVersion = {
+            return $mockSqlMajorVersion
+        }
+        
+        $mockEmptyHashtable = {
+            return @()
+        }
+        
+        $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
+        $mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
+        $mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
+        $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
+        $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
+        $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
+        
+        $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+        
+        $mockGetItemProperty_UninstallProducts2008R2 = {
+            return @(
+                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
+                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber # Mock product ADV_SSMS 2012
+            )
+        }
+        
+        $mockGetItemProperty_UninstallProducts2012 = {
+            return @(
+                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber # Mock product SSMS 2014
+            )
+        }
+        
+        $mockGetItemProperty_UninstallProducts2014 = {
+            return @(
+                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+            )
+        }
+        
+        $mockGetItemProperty_UninstallProducts = {
+            return @(
+                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
+                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber, # Mock product ADV_SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber, # Mock product SSMS 2014
+                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_DatabaseService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_AgentService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_FullTextService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_ReportingService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_IntegrationService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_DefaultInstance_AnalysisService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetService_DefaultInstance = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_DatabaseService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_AgentService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_FullTextService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_ReportingService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_IntegrationService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_NamedInstance_AnalysisService = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetService_NamedInstance = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_ConfigurationState = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_DQFeature = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_BOLandDQCFeature = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_ClientComponentsFull_FeatureList = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
+                )
+            )
+        }
+        
+        
+        $mockGetItemProperty_SQL = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
+                ),
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_SharedDirectory = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItem_SharedDirectory = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_SharedWowDirectory = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItem_SharedWowDirectory = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_Setup = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetItemProperty_ServicesAnalysis = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
+                )
+            )
+        }
+        
+        $mockConnectSQL = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+                    Add-Member ScriptProperty Logins {
+                        return @((New-Object Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+                                Add-Member ScriptMethod ListMembers {
+                                    return @('sysadmin')
+                                } -PassThru -Force
+                            ))
+                    } -PassThru -Force
+                )
+            )
+        }
+        
+        $mockConnectSQLCluster = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+                    Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
+                    Add-Member ScriptProperty Logins {
+                        return @((New-Object Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+                                Add-Member ScriptMethod ListMembers {
+                                    return @('sysadmin')
+                                } -PassThru -Force
+                            ))
+                    } -PassThru -Force
+                )
+            )
+        }
+        
+        $mockConnectSQLAnalysis = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member ScriptProperty ServerProperties  {
+                        return @{
+                            'CollationName' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force)
+                            'DataDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force)
+                            'TempDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force)
+                            'LogDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force)
+                            'BackupDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force)
+                        }
+                    } -PassThru |
+                    Add-Member ScriptProperty Roles  {
+                        return @{
+                            'Administrators' = @(New-Object Object |
+                                Add-Member ScriptProperty Members {
+                                    return New-Object Object |
+                                    Add-Member ScriptProperty Name {
+                                        return $mockSqlAnalysisAdmins
+                                    } -PassThru -Force
+                                } -PassThru -Force
                                 ) }
-					} -PassThru -Force
-				)
-			)
-		}
-		
-		$mockRobocopyExecutableName = 'Robocopy.exe'
-		$mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
-		$mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
-		$mockRobocopyExectuableVersion = '' # Set dynamically during runtime
-		$mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
-		$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
-		$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
-		$mockRobocopyArgumentUseUnbufferedIO = '/J'
-		$mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
-		$mockRobocopyArgumentDestinationPath = 'D:\Temp'
-		
-		$mockGetCommand = {
-			return @(
-				(
-					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
-					Add-Member ScriptProperty FileVersionInfo {
-						return @((New-Object Object |
-								Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
-							))
-					} -PassThru -Force
-				)
-			)
-		}
-		
-		$mockStartProcessExpectedArgument = '' # Set dynamically during runtime
-		$mockStartProcessExitCode = 0 # Set dynamically during runtime
-		
-		$mockStartProcess = {
-			if ($ArgumentList -cne $mockStartProcessExpectedArgument)
-			{
-				throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
-			}
-			
-			return New-Object Object |
-			Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
-		}
-		
-		$mockStartProcess_WithExitCode = {
-			return New-Object Object |
-			Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
-		}
-		
-		$mockSourcePathUNCWithoutLeaf = '\\server\share'
-		$mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
-		$mockNewGuid = {
-			return New-Object Object |
-			Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
-		}
-		
-		$mockGetTemporaryFolder = {
-			return $mockSourcePathUNC
-		}
-		
-		$mockGetCimInstance_MSClusterResource = {
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Name }) -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Name }) -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Name }) -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Name }) -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Name }) -PassThru -Force
-				),
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Path }) -PassThru -Force |
-					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Name }) -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimInstance_MSClusterNetwork = {
-			return @(
-				(
-					$mockClusterSites | ForEach-Object {
-						$network = $_
-						
-						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
-						Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
-						Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
-						Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
-					}
-				)
-			)
-		}
-		
-		$mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
-				)
-			)
-		}
-		
-		$mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
-			return @(
-				(
-					@('Network Name', 'IP Address') | ForEach-Object {
-						$resourceType = $_
-						
-						$propertyValue = @{
-							MemberType = 'NoteProperty'
-							Name = 'PrivateProperties'
-							Value = $null
-						}
-						
-						switch ($resourceType)
-						{
-							'Network Name'
-							{
-								$propertyValue.Value = @{ DnsName = $mockDefaultInstance_FailoverClusterNetworkName }
-							}
-							
-							'IP Address'
-							{
-								$propertyValue.Value = @{ Address = $mockDefaultInstance_FailoverClusterIPAddress }
-							}
-						}
-						
-						return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-						Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
-						Add-Member @propertyValue -PassThru -Force
-					}
-				)
-			)
-		}
-		
-		# Mock to return physical disks that are part of the "Available Storage" cluster role
-		$mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
-			return @(
-				(
-					# $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-					(& $mockClusterDiskMap).Keys | ForEach-Object {
-						$diskName = $_
-						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
-						Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
-						Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
-					}
-				)
-			)
-		}
-		
-		$mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
-			return @(
-				(
-					$mockClusterNodes | ForEach-Object {
-						$node = $_
-						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
-						Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
-					}
-				)
-			)
-		}
-		
-		$mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
-			$clusterDiskName = $InputObject.Name
-			
-			# $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-			$clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
-			
-			return @(
-				(
-					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition', 'root/MSCluster' |
-					Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
-				)
-			)
-		}
-		
+                    } -PassThru -Force
+                )
+            )
+        }
+        
+        $mockRobocopyExecutableName = 'Robocopy.exe'
+        $mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
+        $mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
+        $mockRobocopyExectuableVersion = '' # Set dynamically during runtime
+        $mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
+        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
+        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
+        $mockRobocopyArgumentUseUnbufferedIO = '/J'
+        $mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
+        $mockRobocopyArgumentDestinationPath = 'D:\Temp'
+        
+        $mockGetCommand = {
+            return @(
+                (
+                    New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
+                    Add-Member ScriptProperty FileVersionInfo {
+                        return @((New-Object Object |
+                                Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
+                            ))
+                    } -PassThru -Force
+                )
+            )
+        }
+        
+        $mockStartProcessExpectedArgument = '' # Set dynamically during runtime
+        $mockStartProcessExitCode = 0 # Set dynamically during runtime
+        
+        $mockStartProcess = {
+            if ($ArgumentList -cne $mockStartProcessExpectedArgument)
+            {
+                throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
+            }
+            
+            return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
+        }
+        
+        $mockStartProcess_WithExitCode = {
+            return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
+        }
+        
+        $mockSourcePathUNCWithoutLeaf = '\\server\share'
+        $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
+        $mockNewGuid = {
+            return New-Object Object |
+            Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
+        }
+        
+        $mockGetTemporaryFolder = {
+            return $mockSourcePathUNC
+        }
+        
+        $mockGetCimInstance_MSClusterResource = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Name }) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Name }) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Name }) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Name }) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Name }) -PassThru -Force
+                ),
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Path }) -PassThru -Force |
+                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Name }) -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimInstance_MSClusterNetwork = {
+            return @(
+                (
+                    $mockClusterSites | ForEach-Object {
+                        $network = $_
+                        
+                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
+                    }
+                )
+            )
+        }
+        
+        $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
+                )
+            )
+        }
+        
+        $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
+            return @(
+                (
+                    @('Network Name', 'IP Address') | ForEach-Object {
+                        $resourceType = $_
+                        
+                        $propertyValue = @{
+                            MemberType = 'NoteProperty'
+                            Name = 'PrivateProperties'
+                            Value = $null
+                        }
+                        
+                        switch ($resourceType)
+                        {
+                            'Network Name'
+                            {
+                                $propertyValue.Value = @{ DnsName = $mockDefaultInstance_FailoverClusterNetworkName }
+                            }
+                            
+                            'IP Address'
+                            {
+                                $propertyValue.Value = @{ Address = $mockDefaultInstance_FailoverClusterIPAddress }
+                            }
+                        }
+                        
+                        return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
+                        Add-Member @propertyValue -PassThru -Force
+                    }
+                )
+            )
+        }
+        
+        # Mock to return physical disks that are part of the "Available Storage" cluster role
+        $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
+            return @(
+                (
+                    # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+                    (& $mockClusterDiskMap).Keys | ForEach-Object {
+                        $diskName = $_
+                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
+                    }
+                )
+            )
+        }
+        
+        $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
+            return @(
+                (
+                    $mockClusterNodes | ForEach-Object {
+                        $node = $_
+                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
+                    }
+                )
+            )
+        }
+        
+        $mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
+            $clusterDiskName = $InputObject.Name
+            
+            # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+            $clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
+            
+            return @(
+                (
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition', 'root/MSCluster' |
+                    Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
+                )
+            )
+        }
+        
         <#
         Needed a way to see into the Set-method for the arguments the Set-method is building and sending to 'setup.exe', and fail
         the test if the arguments is different from the expected arguments.
         Solved this by dynamically set the expected arguments before each It-block. If the arguments differs the mock of
         StartWin32Process throws an error message, similiar to what Pester would have reported (expected -> but was).
         #>
-		$mockStartWin32ProcessExpectedArgument = @{ }
-		
-		$mockStartWin32ProcessExpectedArgumentClusterDefault = @{
-			IAcceptSQLServerLicenseTerms = 'True'
-			Quiet = 'True'
-			InstanceName = 'MSSQLSERVER'
-			Features = 'SQLENGINE'
-			SQLSysAdminAccounts = 'COMPANY\sqladmin'
-			FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-		}
-		
-		$mockStartWin32Process = {
-			$argumentHashTable = @{ }
-			
-			# Break the argument string into a hash table
-			($Arguments -split ' ?/') | ForEach-Object {
-				if ($_ -imatch '(\w+)="?([^/]+)"?')
-				{
-					$key = $Matches[1]
-					if ($key -in ('FailoverClusterDisks', 'FailoverClusterIPAddresses'))
-					{
-						$value = ($Matches[2] -replace '" "', '; ') -replace '"', ''
-					}
-					else
-					{
-						$value = ($Matches[2] -replace '" "', ' ') -replace '"', ''
-					}
-					
-					$null = $argumentHashTable.Add($key, $value)
-				}
-			}
-			
-			# Start by checking whether we have the same number of parameters
-			Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
-			Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',')) -Verbose
-			Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
-			
-			$argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
-			
-			Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
-			foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
-			{
-				$argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
-				$argumentKeyName | Should Be $argumentKey
-				
-				$argumentValue = $argumentHashTable.$argumentKey
-				$argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
-			}
-			
-			return 'Process Started'
-		}
-		#endregion Function mocks
-		
-		# Default parameters that are used for the It-blocks
-		$mockDefaultParameters = @{
-			SetupCredential = $mockSetupCredential
+        $mockStartWin32ProcessExpectedArgument = @{ }
+        
+        $mockStartWin32ProcessExpectedArgumentClusterDefault = @{
+            IAcceptSQLServerLicenseTerms = 'True'
+            Quiet = 'True'
+            InstanceName = 'MSSQLSERVER'
+            Features = 'SQLENGINE'
+            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+        }
+        
+        $mockStartWin32Process = {
+            $argumentHashTable = @{ }
+            
+            # Break the argument string into a hash table
+            ($Arguments -split ' ?/') | ForEach-Object {
+                if ($_ -imatch '(\w+)="?([^/]+)"?')
+                {
+                    $key = $Matches[1]
+                    if ($key -in ('FailoverClusterDisks', 'FailoverClusterIPAddresses'))
+                    {
+                        $value = ($Matches[2] -replace '" "', '; ') -replace '"', ''
+                    }
+                    else
+                    {
+                        $value = ($Matches[2] -replace '" "', ' ') -replace '"', ''
+                    }
+                    
+                    $null = $argumentHashTable.Add($key, $value)
+                }
+            }
+            
+            # Start by checking whether we have the same number of parameters
+            Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
+            Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',')) -Verbose
+            Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
+            
+            $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
+            
+            Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
+            foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
+            {
+                $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
+                $argumentKeyName | Should Be $argumentKey
+                
+                $argumentValue = $argumentHashTable.$argumentKey
+                $argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
+            }
+            
+            return 'Process Started'
+        }
+        #endregion Function mocks
+        
+        # Default parameters that are used for the It-blocks
+        $mockDefaultParameters = @{
+            SetupCredential = $mockSetupCredential
             <#
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-			Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
-		}
-		
-		$mockDefaultClusterParameters = @{
-			SetupCredential = $mockSetupCredential
-			
-			# Feature support is tested elsewhere, so just include the minimum
-			Features = 'SQLEngine'
-			
-		}
-		
-		Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
-			#region Setting up TestDrive:\
-			
-			# Local path to TestDrive:\
-			$mockSourcePath = $TestDrive.FullName
-			
-			# UNC path to TestDrive:\
-			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
-			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-			
-			#endregion Setting up TestDrive:\
-			
-			BeforeEach {
-				# General mocks
-				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-				} -MockWith $mockGetItemProperty_SQL -Verifiable
-				
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					(
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-					) -and
-					$Name -eq 'ImagePath'
-				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-				
-				# Mocking SharedDirectory
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-				} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-				
-				Mock -CommandName Get-Item -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-				} -MockWith $mockGetItem_SharedDirectory -Verifiable
-				
-				# Mocking SharedWowDirectory
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-				} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-				
-				Mock -CommandName Get-Item -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-				} -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-				
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-				} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-			}
-			
-			$testProductVersion | ForEach-Object -Process {
-				$mockSqlMajorVersion = $_
-				
-				$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-				
-				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-				$mockDynamicSqlTempDatabasePath = ''
-				$mockDynamicSqlTempDatabaseLogPath = ''
-				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-						}
-						else
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockEmptyHashtable -Verifiable
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-					}
-					
-					It 'Should not return any names of installed features' {
-						$result = Get-TargetResource @testParameters
-						$result.Features | Should Be ''
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePath
-						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-						$result.InstanceID | Should BeNullOrEmpty
-						$result.InstallSharedDir | Should BeNullOrEmpty
-						$result.InstallSharedWOWDir | Should BeNullOrEmpty
-						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
-						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
-						$result.SqlCollation | Should BeNullOrEmpty
-						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
-						$result.SecurityMode | Should BeNullOrEmpty
-						$result.InstallSQLDataDir | Should BeNullOrEmpty
-						$result.SQLUserDBDir | Should BeNullOrEmpty
-						$result.SQLUserDBLogDir | Should BeNullOrEmpty
-						$result.SQLBackupDir | Should BeNullOrEmpty
-						$result.FTSvcAccountUsername | Should BeNullOrEmpty
-						$result.RSSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASCollation | Should BeNullOrEmpty
-						$result.ASSysAdminAccounts | Should BeNullOrEmpty
-						$result.ASDataDir | Should BeNullOrEmpty
-						$result.ASLogDir | Should BeNullOrEmpty
-						$result.ASBackupDir | Should BeNullOrEmpty
-						$result.ASTempDir | Should BeNullOrEmpty
-						$result.ASConfigDir | Should BeNullOrEmpty
-						$result.ISSvcAccountUsername | Should BeNullOrEmpty
-					}
-				}
-				
-				Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $mockSetupCredential
-							SourcePath = $mockSourcePathUNC
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-						}
-						else
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockEmptyHashtable -Verifiable
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-					}
-					
-					It 'Should not return any names of installed features' {
-						$result = Get-TargetResource @testParameters
-						$result.Features | Should Be ''
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePathUNC
-						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-						$result.InstanceID | Should BeNullOrEmpty
-						$result.InstallSharedDir | Should BeNullOrEmpty
-						$result.InstallSharedWOWDir | Should BeNullOrEmpty
-						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
-						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
-						$result.SqlCollation | Should BeNullOrEmpty
-						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
-						$result.SecurityMode | Should BeNullOrEmpty
-						$result.InstallSQLDataDir | Should BeNullOrEmpty
-						$result.SQLUserDBDir | Should BeNullOrEmpty
-						$result.SQLUserDBLogDir | Should BeNullOrEmpty
-						$result.SQLBackupDir | Should BeNullOrEmpty
-						$result.FTSvcAccountUsername | Should BeNullOrEmpty
-						$result.RSSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASCollation | Should BeNullOrEmpty
-						$result.ASSysAdminAccounts | Should BeNullOrEmpty
-						$result.ASDataDir | Should BeNullOrEmpty
-						$result.ASLogDir | Should BeNullOrEmpty
-						$result.ASBackupDir | Should BeNullOrEmpty
-						$result.ASTempDir | Should BeNullOrEmpty
-						$result.ASConfigDir | Should BeNullOrEmpty
-						$result.ISSvcAccountUsername | Should BeNullOrEmpty
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN' and 'BC'" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						if ($mockSqlMajorVersion -eq 10)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 11)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 12)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-						
-						#region Mock Get-CimInstance
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-						
-						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-						Mock -CommandName Get-CimInstance -MockWith {
-							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-						} -Verifiable
-						#endregion Mock Get-CimInstance
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
-					}
-					
-					It 'Should return correct names of installed features' {
-						$result = Get-TargetResource @testParameters
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,ADV_SDK'
-						}
-						else
-						{
-							$result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS,ADV_SDK'
-						}
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						if ($mockSqlMajorVersion -eq 10)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 11)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 12)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-						
-						#region Mock Get-CimInstance
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-						
-						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-						Mock -CommandName Get-CimInstance -MockWith {
-							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-						} -Verifiable
-						#endregion Mock Get-CimInstance
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 1 -Scope It
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 0 -Scope It
-						}
-						else
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 2 -Scope It
-						}
-						
-						#region Assert Get-CimInstance
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-						} -Exactly -Times 1 -Scope It
-						#endregion Assert Get-CimInstance
-					}
-					
-					It 'Should return correct names of installed features' {
-						$result = Get-TargetResource @testParameters
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
-							$result.Features | Should Be $featuresForSqlServer2016
-						}
-						else
-						{
-							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-						}
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePath
-						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-						$result.InstanceID | Should Be $mockDefaultInstance_InstanceName
-						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-						$result.SqlCollation | Should Be $mockSqlCollation
-						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-						$result.SecurityMode | Should Be 'Windows'
-						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASCollation | Should Be $mockSqlAnalysisCollation
-						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-					}
-				}
-				
-				Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $mockSetupCredential
-							SourcePath = $mockSourcePathUNC
-						}
-						
-						if ($mockSqlMajorVersion -eq 10)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 11)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 12)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-						
-						#region Mock Get-CimInstance
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-						
-						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-						Mock -CommandName Get-CimInstance -MockWith {
-							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-						} -Verifiable
-						#endregion Mock Get-CimInstance
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 1 -Scope It
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 0 -Scope It
-						}
-						else
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 2 -Scope It
-						}
-						
-						#region Assert Get-CimInstance
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-						} -Exactly -Times 1 -Scope It
-						#endregion Assert Get-CimInstance
-					}
-					
-					It 'Should return correct names of installed features' {
-						$result = Get-TargetResource @testParameters
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
-							$result.Features | Should Be $featuresForSqlServer2016
-						}
-						else
-						{
-							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-						}
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePathUNC
-						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-						$result.InstanceID | Should Be $mockDefaultInstance_InstanceName
-						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-						$result.SqlCollation | Should Be $mockSqlCollation
-						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-						$result.SecurityMode | Should Be 'Windows'
-						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASCollation | Should Be $mockSqlAnalysisCollation
-						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-					}
-				}
-				
-				$mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-				
-				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-				$mockDynamicSqlTempDatabasePath = ''
-				$mockDynamicSqlTempDatabaseLogPath = ''
-				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockNamedInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							# Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-						}
-						else
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockEmptyHashtable -Verifiable
-						}
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-					}
-					
-					It 'Should not return any names of installed features' {
-						$result = Get-TargetResource @testParameters
-						$result.Features | Should Be ''
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePath
-						$result.InstanceName | Should Be $mockNamedInstance_InstanceName
-						$result.InstanceID | Should BeNullOrEmpty
-						$result.InstallSharedDir | Should BeNullOrEmpty
-						$result.InstallSharedWOWDir | Should BeNullOrEmpty
-						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
-						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
-						$result.SqlCollation | Should BeNullOrEmpty
-						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
-						$result.SecurityMode | Should BeNullOrEmpty
-						$result.InstallSQLDataDir | Should BeNullOrEmpty
-						$result.SQLUserDBDir | Should BeNullOrEmpty
-						$result.SQLUserDBLogDir | Should BeNullOrEmpty
-						$result.SQLBackupDir | Should BeNullOrEmpty
-						$result.FTSvcAccountUsername | Should BeNullOrEmpty
-						$result.RSSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASSvcAccountUsername | Should BeNullOrEmpty
-						$result.ASCollation | Should BeNullOrEmpty
-						$result.ASSysAdminAccounts | Should BeNullOrEmpty
-						$result.ASDataDir | Should BeNullOrEmpty
-						$result.ASLogDir | Should BeNullOrEmpty
-						$result.ASBackupDir | Should BeNullOrEmpty
-						$result.ASTempDir | Should BeNullOrEmpty
-						$result.ASConfigDir | Should BeNullOrEmpty
-						$result.ISSvcAccountUsername | Should BeNullOrEmpty
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters += @{
-							InstanceName = $mockNamedInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						if ($mockSqlMajorVersion -eq 10)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 11)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-						}
-						
-						if ($mockSqlMajorVersion -eq 12)
-						{
-							Mock -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-						}
-						
-						Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
-						
-						#region Mock Get-CimInstance
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-						} -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-						} -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-						} -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-						} -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
-						
-						Mock -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-						} -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
-						
-						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-						Mock -CommandName Get-CimInstance -MockWith {
-							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-						} -Verifiable
-						#endregion Mock Get-CimInstance
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-					}
-					
-					It 'Should return the same values as passed as parameters' {
-						$result = Get-TargetResource @testParameters
-						$result.InstanceName | Should Be $testParameters.InstanceName
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -Exactly -Times 1 -Scope It
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 0 -Scope It
-						}
-						else
-						{
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 2 -Scope It
-						}
-						
-						#region Assert Get-CimInstance
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-						} -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							$ClassName -eq 'Win32_Service' -and
-							$Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-						} -Exactly -Times 1 -Scope It
-						#endregion Assert Get-CimInstance
-					}
-					
-					It 'Should return correct names of installed features' {
-						$result = Get-TargetResource @testParameters
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
-							$result.Features | Should Be $featuresForSqlServer2016
-						}
-						else
-						{
-							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-						}
-					}
-					
-					It 'Should return the correct values in the hash table' {
-						$result = Get-TargetResource @testParameters
-						$result.SourcePath | Should Be $mockSourcePath
-						$result.InstanceName | Should Be $mockNamedInstance_InstanceName
-						$result.InstanceID | Should Be $mockNamedInstance_InstanceName
-						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-						$result.SqlCollation | Should Be $mockSqlCollation
-						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-						$result.SecurityMode | Should Be 'Windows'
-						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-						$result.ASCollation | Should Be $mockSqlAnalysisCollation
-						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
-					
-					BeforeAll {
-						$testParams = $mockDefaultParameters.Clone()
-						$testParams.Remove('Features')
-						$testParams += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith { } -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should not attempt to collect cluster information for a standalone instance' {
-						
-						$currentState = Get-TargetResource @testParams
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
-						
-						$currentState.FailoverClusterGroupName | Should BeNullOrEmpty
-						$currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
-						$currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
-					
-					BeforeEach {
-						$testParams = $mockDefaultParameters.Clone()
-						$testParams.Remove('Features')
-						$testParams += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-						}
-						
-						$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-						
-						Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-							$Filter -eq "Type = 'SQL Server'"
-						}
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-						
-						Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-					}
-					
-					It 'Should collect information for a clustered instance' {
-						$currentState = Get-TargetResource @testParams
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-						
-						$currentState.InstanceName | Should Be $testParams.InstanceName
-					}
-					
-					It 'Should return correct cluster information' {
-						$currentState = Get-TargetResource @testParams
-						
-						$currentState.FailoverClusterGroupName | Should Be $mockDefaultInstance_FailoverClusterGroupName
-						$currentState.FailoverClusterIPAddress | Should Be $mockDefaultInstance_FailoverClusterIPAddress
-						$currentSTate.FailoverClusterNetworkName | Should Be $mockDefaultInstance_FailoverClusterNetworkName
-					}
-				}
-			}
-			
-			Assert-VerifiableMocks
-		}
-		
-		Describe "xSQLServerSetup\Test-TargetResource" -Tag 'Test' {
-			#region Setting up TestDrive:\
-			
-			# Local path to TestDrive:\
-			$mockSourcePath = $TestDrive.FullName
-			
-			# UNC path to TestDrive:\
-			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
-			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-			
-			#endregion Setting up TestDrive:\
-			
-			BeforeEach {
-				# General mocks
-				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-				} -MockWith $mockGetItemProperty_SQL -Verifiable
-				
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					(
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-					) -and
-					$Name -eq 'ImagePath'
-				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-				
-				# Mocking SharedDirectory
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-				} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-				
-				Mock -CommandName Get-Item -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-				} -MockWith $mockGetItem_SharedDirectory -Verifiable
-				
-				# Mocking SharedWowDirectory
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-				} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-				
-				Mock -CommandName Get-Item -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-				} -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-			}
-			
-			# For this test we only need to test one SQL Server version. Mocking SQL Server 2016 for the 'not in the desired state' test.
-			$mockSqlMajorVersion = 13
-			
-			$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-			
-			$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-			$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-			$mockDynamicSqlTempDatabasePath = ''
-			$mockDynamicSqlTempDatabaseLogPath = ''
-			$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-			$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-			
-			Context 'When the system is not in the desired state' {
-				BeforeEach {
-					$testParameters = $mockDefaultParameters
-					$testParameters += @{
-						InstanceName = $mockDefaultInstance_InstanceName
-						SourceCredential = $null
-						SourcePath = $mockSourcePath
-					}
-					
-					# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-					} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-					} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -MockWith $mockGetItemProperty_Setup -Verifiable
-				}
-				
-				It 'Should return that the desired state is absent when no products are installed' {
-					Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-					
-					Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-					
-					$result = Test-TargetResource @testParameters
-					$result | Should Be $false
-					
-					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -Exactly -Times 0 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -Exactly -Times 0 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -Exactly -Times 6 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-				}
-				
-				It 'Should return that the desired state is asbent when SSMS product is missing' {
-					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-					
-					#region Mock Get-CimInstance
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-					
-					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-					Mock -CommandName Get-CimInstance -MockWith {
-						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-					} -Verifiable
-					#endregion Mock Get-CimInstance
-					
-					# Change the default features for this test.
-					$testParameters.Features = 'SSMS'
-					
-					$result = Test-TargetResource @testParameters
-					$result | Should Be $false
-					
-					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -Exactly -Times 6 -Scope It
-					
-					#region Assert Get-CimInstance
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -Exactly -Times 1 -Scope It
-					#endregion Assert Get-CimInstance
-				}
-				
-				It 'Should return that the desired state is asbent when ADV_SSMS product is missing' {
-					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-					
-					#region Mock Get-CimInstance
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-					
-					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-					Mock -CommandName Get-CimInstance -MockWith {
-						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-					} -Verifiable
-					#endregion Mock Get-CimInstance
-					
-					# Change the default features for this test.
-					$testParameters.Features = 'ADV_SSMS'
-					
-					$result = Test-TargetResource @testParameters
-					$result | Should Be $false
-					
-					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -Exactly -Times 6 -Scope It
-					
-					#region Assert Get-CimInstance
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -Exactly -Times 1 -Scope It
-					#endregion Assert Get-CimInstance
-				}
-				
-				It 'Should return that the desired state is absent when a clustered instance cannot be found' {
-					$testClusterParameters = $testParameters.Clone()
-					
-					$testClusterParameters += @{
-						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-					}
-					
-					$result = Test-TargetResource @testClusterParameters
-					
-					$result | Should Be $false
-				}
-				
-				# This is a test for regression testing of issue #432
-				It 'Should return false if a SQL Server failover cluster is missing features' {
-					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-					
-					Mock -CommandName Get-TargetResource -MockWith {
-						return @{
-							Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
-							FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-						}
-					} -Verifiable
-					
-					$testClusterParameters = $testParameters.Clone()
-					$testClusterParameters['Features'] = 'SQLEngine,AS'
-					
-					$testClusterParameters += @{
-						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-					}
-					
-					$result = Test-TargetResource @testClusterParameters
-					$result | Should Be $false
-				}
-			}
-			
-			# For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.
-			$mockSqlMajorVersion = 12
-			
-			Context "When the system is in the desired state" {
-				BeforeEach {
-					$testParameters = $mockDefaultParameters
-					$testParameters += @{
-						InstanceName = $mockDefaultInstance_InstanceName
-						SourceCredential = $null
-						SourcePath = $mockSourcePath
-					}
-					
-					# Mock all SSMS products.
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-					} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-					} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-					
-					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-					
-					#region Mock Get-CimInstance
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-					
-					Mock -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-					
-					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-					Mock -CommandName Get-CimInstance -MockWith {
-						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-					} -Verifiable
-					#endregion Mock Get-CimInstance
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-					} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-					} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-					} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-					
-					Mock -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -MockWith $mockGetItemProperty_Setup -Verifiable
-				}
-				
-				It 'Should return that the desired state is present' {
-					$result = Test-TargetResource @testParameters
-					$result | Should Be $true
-					
-					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-					} -Exactly -Times 6 -Scope It
-					
-					#region Assert Get-CimInstance
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-					} -Exactly -Times 1 -Scope It
-					
-					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-						$ClassName -eq 'Win32_Service' -and
-						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-					} -Exactly -Times 1 -Scope It
-					#endregion Assert Get-CimInstance
-				}
-				
-				It 'Should return that the desired state is present when the correct clustered instance was found' {
-					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-					
-					Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-					
-					Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-						$Filter -eq "Type = 'SQL Server'"
-					}
-					
-					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-					
-					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-					
-					$testClusterParameters = $testParameters.Clone()
-					
-					$testClusterParameters += @{
-						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-					}
-					
-					$result = Test-TargetResource @testClusterParameters
-					
-					$result | Should Be $true
-					
-					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-					Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
-				}
-				
-				It 'Should not return false after a clustered install due to the presence of a variable called "FailoverClusterDisks"' {
-					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-					
-					Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-					
-					Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-						$Filter -eq "Type = 'SQL Server'"
-					}
-					
-					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-					
-					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-					
-					$testClusterParameters = $testParameters.Clone()
-					
-					$testClusterParameters += @{
-						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-					}
-					
-					$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-					$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-					$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-					$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-					$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-					$mockDynamicSqlBackupPath = $mockSqlBackupPath
-					
-					New-Variable -Name 'FailoverClusterDisks' -Value (& $mockClusterDiskMap)['UserData']
-					
-					$result = Test-TargetResource @testClusterParameters
-					
-					$result | Should Be $true
-				}
-				
-				# This is a test for regression testing of issue #432
-				It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
-					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-					
-					Mock -CommandName Get-TargetResource -MockWith {
-						return @{
-							Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
-							FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-						}
-					} -Verifiable
-					
-					$testClusterParameters = $testParameters.Clone()
-					$testClusterParameters['Features'] = 'SQLEngine,AS'
-					
-					$testClusterParameters += @{
-						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-					}
-					
-					$result = Test-TargetResource @testClusterParameters
-					$result | Should Be $true
-				}
-			}
-			
-			Assert-VerifiableMocks
-		}
-		
-		Describe "xSQLServerSetup\Set-TargetResource" -Tag 'Set' {
-			#region Setting up TestDrive:\
-			
-			# Local path to TestDrive:\
-			$mockSourcePath = $TestDrive.FullName
-			
-			# UNC path to TestDrive:\
-			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
-			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-			
+            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
+        }
+        
+        $mockDefaultClusterParameters = @{
+            SetupCredential = $mockSetupCredential
+            
+            # Feature support is tested elsewhere, so just include the minimum
+            Features = 'SQLEngine'
+            
+        }
+        
+        Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
+            #region Setting up TestDrive:\
+            
+            # Local path to TestDrive:\
+            $mockSourcePath = $TestDrive.FullName
+            
+            # UNC path to TestDrive:\
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+            
+            #endregion Setting up TestDrive:\
+            
+            BeforeEach {
+                # General mocks
+                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+                } -MockWith $mockGetItemProperty_SQL -Verifiable
+                
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    (
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+                    ) -and
+                    $Name -eq 'ImagePath'
+                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+                
+                # Mocking SharedDirectory
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+                
+                Mock -CommandName Get-Item -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                } -MockWith $mockGetItem_SharedDirectory -Verifiable
+                
+                # Mocking SharedWowDirectory
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+                
+                Mock -CommandName Get-Item -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
+                
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+            }
+            
+            $testProductVersion | ForEach-Object -Process {
+                $mockSqlMajorVersion = $_
+                
+                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+                
+                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+                $mockDynamicSqlTempDatabasePath = ''
+                $mockDynamicSqlTempDatabaseLogPath = ''
+                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+                        }
+                        else
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockEmptyHashtable -Verifiable
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                    }
+                    
+                    It 'Should not return any names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        $result.Features | Should Be ''
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePath
+                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstanceID | Should BeNullOrEmpty
+                        $result.InstallSharedDir | Should BeNullOrEmpty
+                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
+                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
+                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
+                        $result.SqlCollation | Should BeNullOrEmpty
+                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
+                        $result.SecurityMode | Should BeNullOrEmpty
+                        $result.InstallSQLDataDir | Should BeNullOrEmpty
+                        $result.SQLUserDBDir | Should BeNullOrEmpty
+                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
+                        $result.SQLBackupDir | Should BeNullOrEmpty
+                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
+                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASCollation | Should BeNullOrEmpty
+                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
+                        $result.ASDataDir | Should BeNullOrEmpty
+                        $result.ASLogDir | Should BeNullOrEmpty
+                        $result.ASBackupDir | Should BeNullOrEmpty
+                        $result.ASTempDir | Should BeNullOrEmpty
+                        $result.ASConfigDir | Should BeNullOrEmpty
+                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
+                    }
+                }
+                
+                Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $mockSetupCredential
+                            SourcePath = $mockSourcePathUNC
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+                        }
+                        else
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockEmptyHashtable -Verifiable
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                    }
+                    
+                    It 'Should not return any names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        $result.Features | Should Be ''
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePathUNC
+                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstanceID | Should BeNullOrEmpty
+                        $result.InstallSharedDir | Should BeNullOrEmpty
+                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
+                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
+                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
+                        $result.SqlCollation | Should BeNullOrEmpty
+                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
+                        $result.SecurityMode | Should BeNullOrEmpty
+                        $result.InstallSQLDataDir | Should BeNullOrEmpty
+                        $result.SQLUserDBDir | Should BeNullOrEmpty
+                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
+                        $result.SQLBackupDir | Should BeNullOrEmpty
+                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
+                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASCollation | Should BeNullOrEmpty
+                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
+                        $result.ASDataDir | Should BeNullOrEmpty
+                        $result.ASLogDir | Should BeNullOrEmpty
+                        $result.ASBackupDir | Should BeNullOrEmpty
+                        $result.ASTempDir | Should BeNullOrEmpty
+                        $result.ASConfigDir | Should BeNullOrEmpty
+                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN' and 'BC'" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 10)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 11)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 12)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                        
+                        #region Mock Get-CimInstance
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                        
+                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                        Mock -CommandName Get-CimInstance -MockWith {
+                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                        } -Verifiable
+                        #endregion Mock Get-CimInstance
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
+                    }
+                    
+                    It 'Should return correct names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS'
+                        }
+                        else
+                        {
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
+                        }
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 10)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 11)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 12)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                        
+                        #region Mock Get-CimInstance
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                        
+                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                        Mock -CommandName Get-CimInstance -MockWith {
+                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                        } -Verifiable
+                        #endregion Mock Get-CimInstance
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 1 -Scope It
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 0 -Scope It
+                        }
+                        else
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 2 -Scope It
+                        }
+                        
+                        #region Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        #endregion Assert Get-CimInstance
+                    }
+                    
+                    It 'Should return correct names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $result.Features | Should Be $featuresForSqlServer2016
+                        }
+                        else
+                        {
+                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+                        }
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePath
+                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstanceID | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+                        $result.SqlCollation | Should Be $mockSqlCollation
+                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+                        $result.SecurityMode | Should Be 'Windows'
+                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
+                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+                    }
+                }
+                
+                Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $mockSetupCredential
+                            SourcePath = $mockSourcePathUNC
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 10)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 11)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 12)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                        
+                        #region Mock Get-CimInstance
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                        
+                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                        Mock -CommandName Get-CimInstance -MockWith {
+                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                        } -Verifiable
+                        #endregion Mock Get-CimInstance
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 1 -Scope It
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 0 -Scope It
+                        }
+                        else
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 2 -Scope It
+                        }
+                        
+                        #region Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        #endregion Assert Get-CimInstance
+                    }
+                    
+                    It 'Should return correct names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $result.Features | Should Be $featuresForSqlServer2016
+                        }
+                        else
+                        {
+                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+                        }
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePathUNC
+                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstanceID | Should Be $mockDefaultInstance_InstanceName
+                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+                        $result.SqlCollation | Should Be $mockSqlCollation
+                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+                        $result.SecurityMode | Should Be 'Windows'
+                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
+                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+                    }
+                }
+                
+                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+                
+                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+                $mockDynamicSqlTempDatabasePath = ''
+                $mockDynamicSqlTempDatabaseLogPath = ''
+                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockNamedInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            # Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+                        }
+                        else
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockEmptyHashtable -Verifiable
+                        }
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                    }
+                    
+                    It 'Should not return any names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        $result.Features | Should Be ''
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePath
+                        $result.InstanceName | Should Be $mockNamedInstance_InstanceName
+                        $result.InstanceID | Should BeNullOrEmpty
+                        $result.InstallSharedDir | Should BeNullOrEmpty
+                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
+                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
+                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
+                        $result.SqlCollation | Should BeNullOrEmpty
+                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
+                        $result.SecurityMode | Should BeNullOrEmpty
+                        $result.InstallSQLDataDir | Should BeNullOrEmpty
+                        $result.SQLUserDBDir | Should BeNullOrEmpty
+                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
+                        $result.SQLBackupDir | Should BeNullOrEmpty
+                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
+                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
+                        $result.ASCollation | Should BeNullOrEmpty
+                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
+                        $result.ASDataDir | Should BeNullOrEmpty
+                        $result.ASLogDir | Should BeNullOrEmpty
+                        $result.ASBackupDir | Should BeNullOrEmpty
+                        $result.ASTempDir | Should BeNullOrEmpty
+                        $result.ASConfigDir | Should BeNullOrEmpty
+                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters += @{
+                            InstanceName = $mockNamedInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 10)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 11)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+                        }
+                        
+                        if ($mockSqlMajorVersion -eq 12)
+                        {
+                            Mock -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+                        }
+                        
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
+                        
+                        #region Mock Get-CimInstance
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
+                        } -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
+                        
+                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                        Mock -CommandName Get-CimInstance -MockWith {
+                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                        } -Verifiable
+                        #endregion Mock Get-CimInstance
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                    }
+                    
+                    It 'Should return the same values as passed as parameters' {
+                        $result = Get-TargetResource @testParameters
+                        $result.InstanceName | Should Be $testParameters.InstanceName
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -Exactly -Times 1 -Scope It
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 0 -Scope It
+                        }
+                        else
+                        {
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 2 -Scope It
+                        }
+                        
+                        #region Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                        } -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and
+                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
+                        } -Exactly -Times 1 -Scope It
+                        #endregion Assert Get-CimInstance
+                    }
+                    
+                    It 'Should return correct names of installed features' {
+                        $result = Get-TargetResource @testParameters
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $result.Features | Should Be $featuresForSqlServer2016
+                        }
+                        else
+                        {
+                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+                        }
+                    }
+                    
+                    It 'Should return the correct values in the hash table' {
+                        $result = Get-TargetResource @testParameters
+                        $result.SourcePath | Should Be $mockSourcePath
+                        $result.InstanceName | Should Be $mockNamedInstance_InstanceName
+                        $result.InstanceID | Should Be $mockNamedInstance_InstanceName
+                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+                        $result.SqlCollation | Should Be $mockSqlCollation
+                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+                        $result.SecurityMode | Should Be 'Windows'
+                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
+                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
+                    
+                    BeforeAll {
+                        $testParams = $mockDefaultParameters.Clone()
+                        $testParams.Remove('Features')
+                        $testParams += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith { } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should not attempt to collect cluster information for a standalone instance' {
+                        
+                        $currentState = Get-TargetResource @testParams
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
+                        
+                        $currentState.FailoverClusterGroupName | Should BeNullOrEmpty
+                        $currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
+                        $currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
+                    
+                    BeforeEach {
+                        $testParams = $mockDefaultParameters.Clone()
+                        $testParams.Remove('Features')
+                        $testParams += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                        }
+                        
+                        $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                        
+                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+                            $Filter -eq "Type = 'SQL Server'"
+                        }
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                        
+                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                    }
+                    
+                    It 'Should collect information for a clustered instance' {
+                        $currentState = Get-TargetResource @testParams
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                        
+                        $currentState.InstanceName | Should Be $testParams.InstanceName
+                    }
+                    
+                    It 'Should return correct cluster information' {
+                        $currentState = Get-TargetResource @testParams
+                        
+                        $currentState.FailoverClusterGroupName | Should Be $mockDefaultInstance_FailoverClusterGroupName
+                        $currentState.FailoverClusterIPAddress | Should Be $mockDefaultInstance_FailoverClusterIPAddress
+                        $currentSTate.FailoverClusterNetworkName | Should Be $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                }
+            }
+            
+            Assert-VerifiableMocks
+        }
+        
+        Describe "xSQLServerSetup\Test-TargetResource" -Tag 'Test' {
+            #region Setting up TestDrive:\
+            
+            # Local path to TestDrive:\
+            $mockSourcePath = $TestDrive.FullName
+            
+            # UNC path to TestDrive:\
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+            
+            #endregion Setting up TestDrive:\
+            
+            BeforeEach {
+                # General mocks
+                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+                } -MockWith $mockGetItemProperty_SQL -Verifiable
+                
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    (
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+                    ) -and
+                    $Name -eq 'ImagePath'
+                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+                
+                # Mocking SharedDirectory
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+                
+                Mock -CommandName Get-Item -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                } -MockWith $mockGetItem_SharedDirectory -Verifiable
+                
+                # Mocking SharedWowDirectory
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+                
+                Mock -CommandName Get-Item -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
+            }
+            
+            # For this test we only need to test one SQL Server version. Mocking SQL Server 2016 for the 'not in the desired state' test.
+            $mockSqlMajorVersion = 13
+            
+            $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+            
+            $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+            $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+            $mockDynamicSqlTempDatabasePath = ''
+            $mockDynamicSqlTempDatabaseLogPath = ''
+            $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+            $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+            
+            Context 'When the system is not in the desired state' {
+                BeforeEach {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        InstanceName = $mockDefaultInstance_InstanceName
+                        SourceCredential = $null
+                        SourcePath = $mockSourcePath
+                    }
+                    
+                    # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                    } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                    } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -MockWith $mockGetItemProperty_Setup -Verifiable
+                }
+                
+                It 'Should return that the desired state is absent when no products are installed' {
+                    Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                    
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -Exactly -Times 0 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -Exactly -Times 0 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -Exactly -Times 6 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                }
+                
+                It 'Should return that the desired state is asbent when SSMS product is missing' {
+                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                    
+                    #region Mock Get-CimInstance
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                    
+                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                    } -Verifiable
+                    #endregion Mock Get-CimInstance
+                    
+                    # Change the default features for this test.
+                    $testParameters.Features = 'SSMS'
+                    
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -Exactly -Times 6 -Scope It
+                    
+                    #region Assert Get-CimInstance
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    #endregion Assert Get-CimInstance
+                }
+                
+                It 'Should return that the desired state is asbent when ADV_SSMS product is missing' {
+                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                    
+                    #region Mock Get-CimInstance
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                    
+                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                    } -Verifiable
+                    #endregion Mock Get-CimInstance
+                    
+                    # Change the default features for this test.
+                    $testParameters.Features = 'ADV_SSMS'
+                    
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -Exactly -Times 6 -Scope It
+                    
+                    #region Assert Get-CimInstance
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    #endregion Assert Get-CimInstance
+                }
+                
+                It 'Should return that the desired state is absent when a clustered instance cannot be found' {
+                    $testClusterParameters = $testParameters.Clone()
+                    
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                    
+                    $result = Test-TargetResource @testClusterParameters
+                    
+                    $result | Should Be $false
+                }
+                
+                # This is a test for regression testing of issue #432
+                It 'Should return false if a SQL Server failover cluster is missing features' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                    
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                            Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
+                            FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                        }
+                    } -Verifiable
+                    
+                    $testClusterParameters = $testParameters.Clone()
+                    $testClusterParameters['Features'] = 'SQLEngine,AS'
+                    
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                    
+                    $result = Test-TargetResource @testClusterParameters
+                    $result | Should Be $false
+                }
+            }
+            
+            # For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.
+            $mockSqlMajorVersion = 12
+            
+            Context "When the system is in the desired state" {
+                BeforeEach {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        InstanceName = $mockDefaultInstance_InstanceName
+                        SourceCredential = $null
+                        SourcePath = $mockSourcePath
+                    }
+                    
+                    # Mock all SSMS products.
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                    } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                    } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+                    
+                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+                    
+                    #region Mock Get-CimInstance
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+                    
+                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+                    } -Verifiable
+                    #endregion Mock Get-CimInstance
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                    } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                    } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                    } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+                    
+                    Mock -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -MockWith $mockGetItemProperty_Setup -Verifiable
+                }
+                
+                It 'Should return that the desired state is present' {
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                    } -Exactly -Times 6 -Scope It
+                    
+                    #region Assert Get-CimInstance
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+                    } -Exactly -Times 1 -Scope It
+                    
+                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                        $ClassName -eq 'Win32_Service' -and
+                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+                    } -Exactly -Times 1 -Scope It
+                    #endregion Assert Get-CimInstance
+                }
+                
+                It 'Should return that the desired state is present when the correct clustered instance was found' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+                        $Filter -eq "Type = 'SQL Server'"
+                    }
+                    
+                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                    
+                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                    
+                    $testClusterParameters = $testParameters.Clone()
+                    
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                    
+                    $result = Test-TargetResource @testClusterParameters
+                    
+                    $result | Should Be $true
+                    
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                    Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
+                }
+                
+                It 'Should not return false after a clustered install due to the presence of a variable called "FailoverClusterDisks"' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+                    
+                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+                        $Filter -eq "Type = 'SQL Server'"
+                    }
+                    
+                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                    
+                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                    
+                    $testClusterParameters = $testParameters.Clone()
+                    
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                    
+                    $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+                    $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+                    $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+                    $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+                    $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+                    $mockDynamicSqlBackupPath = $mockSqlBackupPath
+                    
+                    New-Variable -Name 'FailoverClusterDisks' -Value (& $mockClusterDiskMap)['UserData']
+                    
+                    $result = Test-TargetResource @testClusterParameters
+                    
+                    $result | Should Be $true
+                }
+                
+                # This is a test for regression testing of issue #432
+                It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
+                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                    
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                            Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
+                            FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                        }
+                    } -Verifiable
+                    
+                    $testClusterParameters = $testParameters.Clone()
+                    $testClusterParameters['Features'] = 'SQLEngine,AS'
+                    
+                    $testClusterParameters += @{
+                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                    }
+                    
+                    $result = Test-TargetResource @testClusterParameters
+                    $result | Should Be $true
+                }
+            }
+            
+            Assert-VerifiableMocks
+        }
+        
+        Describe "xSQLServerSetup\Set-TargetResource" -Tag 'Set' {
+            #region Setting up TestDrive:\
+            
+            # Local path to TestDrive:\
+            $mockSourcePath = $TestDrive.FullName
+            
+            # UNC path to TestDrive:\
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+            
             <#
                 Mocking folder structure. This takes the leaf from the $mockSourcePath (the Guid in this case) and
                 uses that to create a mock folder to mimic the temp folder that would be created in, for example,
                 temp folder 'C:\Windows\Temp'.
                 This folder is used when SourcePath is called with a leaf, for example '\\server\share\folder'.
             #>
-			$mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
-			if (-not (Test-Path $mediaTempSourcePathWithLeaf))
-			{
-				New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
-			}
-			
+            $mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
+            if (-not (Test-Path $mediaTempSourcePathWithLeaf))
+            {
+                New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
+            }
+            
             <#
                 Mocking folder structure. This takes the leaf from the New-Guid mock and uses that
                 to create a mock folder to mimic the temp folder that would be created in, for example,
                 temp folder 'C:\Windows\Temp'.
                 This folder is used when SourcePath is called without a leaf, for example '\\server\share'.
             #>
-			$mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
-			if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
-			{
-				New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
-			}
-			
-			# Mocking executable setup.exe which will be used for tests without parameter SourceCredential
-			Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
-			
-			# Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
-			Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-			
-			# Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
-			Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-			
-			#endregion Setting up TestDrive:\
-			
-			BeforeEach {
-				# General mocks
-				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-				} -MockWith $mockGetItemProperty_SQL -Verifiable
-				
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					(
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-					) -and
-					$Name -eq 'ImagePath'
-				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-				
-				# Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
-				Mock -CommandName Get-ItemProperty -Verifiable
-				
-				Mock -CommandName Get-ItemProperty -ParameterFilter {
-					$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-				} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-				
-				Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
-				Mock -CommandName WaitForWin32ProcessEnd -Verifiable
-				Mock -CommandName Test-TargetResource -MockWith {
-					return $true
-				} -Verifiable
-			}
-			
-			$testProductVersion | ForEach-Object -Process {
-				$mockSqlMajorVersion = $_
-				
-				$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-				
-				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-				$mockDynamicSqlTempDatabasePath = ''
-				$mockDynamicSqlTempDatabaseLogPath = ''
-				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-					BeforeEach {
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Start-Process -Verifiable
-						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should set the system in the desired state when feature is SQLENGINE' {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-							ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-							SQLSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
-							ASSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
-							InstanceDir = 'D:'
-							InstallSQLDataDir = 'E:'
-							InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
-							InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
-						}
-						
-						$mockStartWin32ProcessExpectedArgument = @{
-							Quiet = 'True'
-							IAcceptSQLServerLicenseTerms = 'True'
-							Action = 'Install'
-							AGTSVCSTARTUPTYPE = 'Automatic'
-							InstanceName = 'MSSQLSERVER'
-							Features = $testParameters.Features
-							SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-							ASSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-							PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-							InstanceDir = 'D:\'
-							InstallSQLDataDir = 'E:\'
-							InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
-							InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Start-Process -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-							($Name -eq $mockDefaultInstance_InstanceName)
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-					}
-					
-					if ($mockSqlMajorVersion -in (13, 14))
-					{
-						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-							$testParameters = $mockDefaultParameters.Clone()
-							$testParameters += @{
-								InstanceName = $mockDefaultInstance_InstanceName
-								SourceCredential = $null
-								SourcePath = $mockSourcePath
-							}
-							
-							$testParameters.Features = 'SSMS'
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-						
-						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-							$testParameters = $mockDefaultParameters.Clone()
-							$testParameters += @{
-								InstanceName = $mockDefaultInstance_InstanceName
-								SourceCredential = $null
-								SourcePath = $mockSourcePath
-							}
-							
-							$testParameters.Features = 'ADV_SSMS'
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-					}
-					else
-					{
-						It 'Should set the system in the desired state when feature is SSMS' {
-							$testParameters = $mockDefaultParameters.Clone()
-							$testParameters += @{
-								InstanceName = $mockDefaultInstance_InstanceName
-								SourceCredential = $null
-								SourcePath = $mockSourcePath
-							}
-							
-							$testParameters.Features = 'SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-						
-						It 'Should set the system in the desired state when feature is ADV_SSMS' {
-							$testParameters = $mockDefaultParameters.Clone()
-							$testParameters += @{
-								InstanceName = $mockDefaultInstance_InstanceName
-								SourceCredential = $null
-								SourcePath = $mockSourcePath
-							}
-							
-							$testParameters.Features = 'ADV_SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'ADV_SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-					}
-				}
-				
-				Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $mockSetupCredential
-							SourcePath = $mockSourcePathUNC
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
-						}
-						
-						# Mocking SharedDirectory (when previously installed and should not be installed again).
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-						} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-						
-						# Mocking SharedWowDirectory (when previously installed and should not be installed again).
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-						} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Start-Process -Verifiable
-						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should set the system in the desired state when feature is SQLENGINE' {
-						
-						$mockStartWin32ProcessExpectedArgument = @{
-							Quiet = 'True'
-							IAcceptSQLServerLicenseTerms = 'True'
-							Action = 'Install'
-							AgtSvcStartupType = 'Automatic'
-							InstanceName = 'MSSQLSERVER'
-							Features = $testParameters.Features
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							ASSysAdminAccounts = 'COMPANY\sqladmin'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
-						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-							($Name -eq $mockDefaultInstance_InstanceName)
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						
-						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-					}
-					
-					if ($mockSqlMajorVersion -in (13, 14))
-					{
-						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = 'SSMS'
-							$mockStartWin32ProcessExpectedArgument = ''
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-						
-						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = 'ADV_SSMS'
-							$mockStartWin32ProcessExpectedArgument = ''
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-					}
-					else
-					{
-						It 'Should set the system in the desired state when feature is SSMS' {
-							$testParameters.Features = 'SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-						
-						It 'Should set the system in the desired state when feature is ADV_SSMS' {
-							$testParameters.Features = 'ADV_SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'ADV_SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-					}
-				}
-				
-				Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters += @{
-							InstanceName = $mockDefaultInstance_InstanceName
-							SourceCredential = $mockSetupCredential
-							SourcePath = $mockSourcePathUNCWithoutLeaf
-							ForceReboot = $true
-							SuppressReboot = $true
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
-						}
-						
-						Mock -CommandName New-SmbMapping -Verifiable
-						Mock -CommandName Remove-SmbMapping -Verifiable
-						Mock -CommandName Start-Process -Verifiable
-						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should set the system in the desired state when feature is SQLENGINE' {
-						$mockStartWin32ProcessExpectedArgument = @{
-							Quiet = 'True'
-							IAcceptSQLServerLicenseTerms = 'True'
-							Action = 'Install'
-							AGTSVCSTARTUPTYPE = 'Automatic'
-							InstanceName = 'MSSQLSERVER'
-							Features = $testParameters.Features
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							ASSysAdminAccounts = 'COMPANY\sqladmin'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-						
-						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
-						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
-						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName New-Guid -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-							($Name -eq $mockDefaultInstance_InstanceName)
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						
-						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-					}
-					
-					if ($mockSqlMajorVersion -in (13, 14))
-					{
-						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = 'SSMS'
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-						
-						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = 'ADV_SSMS'
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-					}
-					else
-					{
-						It 'Should set the system in the desired state when feature is SSMS' {
-							$testParameters.Features = 'SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-						
-						It 'Should set the system in the desired state when feature is ADV_SSMS' {
-							$testParameters.Features = 'ADV_SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'MSSQLSERVER'
-								Features = 'ADV_SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-					}
-				}
-				
-				$mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-				
-				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-				$mockDynamicSqlTempDatabasePath = ''
-				$mockDynamicSqlTempDatabaseLogPath = ''
-				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
-					BeforeEach {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters += @{
-							InstanceName = $mockNamedInstance_InstanceName
-							SourceCredential = $null
-							SourcePath = $mockSourcePath
-							ForceReboot = $true
-						}
-						
-						if ($mockSqlMajorVersion -in (13, 14))
-						{
-							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
-						}
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should set the system in the desired state when feature is SQLENGINE' {
-						$mockStartWin32ProcessExpectedArgument = @{
-							Quiet = 'True'
-							IAcceptSQLServerLicenseTerms = 'True'
-							Action = 'Install'
-							AGTSVCSTARTUPTYPE = 'Automatic'
-							InstanceName = 'TEST'
-							Features = $testParameters.Features
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							ASSysAdminAccounts = 'COMPANY\sqladmin'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-							($Name -eq $mockDefaultInstance_InstanceName)
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-						} -Exactly -Times 6 -Scope It
-						
-						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-					}
-					
-					if ($mockSqlMajorVersion -in (13, 14))
-					{
-						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-						
-						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-							$testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
-							$mockStartWin32ProcessExpectedArgument = @{ }
-							
-							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-						}
-					}
-					else
-					{
-						It 'Should set the system in the desired state when feature is SSMS' {
-							$testParameters.Features = 'SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'TEST'
-								Features = 'SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-						
-						It 'Should set the system in the desired state when feature is ADV_SSMS' {
-							$testParameters.Features = 'ADV_SSMS'
-							
-							$mockStartWin32ProcessExpectedArgument = @{
-								Quiet = 'True'
-								IAcceptSQLServerLicenseTerms = 'True'
-								Action = 'Install'
-								InstanceName = 'TEST'
-								Features = 'ADV_SSMS'
-							}
-							
-							{ Set-TargetResource @testParameters } | Should Not Throw
-							
-							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-								($Name -eq $mockDefaultInstance_InstanceName)
-							} -Exactly -Times 0 -Scope It
-							
-							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-							} -Exactly -Times 6 -Scope It
-							
-							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						}
-					}
-				}
-				
-				# For testing AddNode action
-				Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
-					BeforeAll {
-						$testParameters = $mockDefaultClusterParameters.Clone()
-						$testParameters['Features'] += 'AS'
-						$testParameters += @{
-							InstanceName = 'MSSQLSERVER'
-							SourcePath = $mockSourcePath
-							Action = 'AddNode'
-							AgtSvcAccount = $mockSQLAgentCredential
-							SqlSvcAccount = $mockSQLServiceCredential
-							ASSvcAccount = $mockAnalysisServiceCredential
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-						}
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-							$Filter -eq "Name = 'Available Storage'"
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-						} -Verfiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-							$Association -eq 'MSCluster_ResourceToPossibleOwner'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-							$ResultClassName -eq 'MSCluster_DiskPartition'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolume'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-						} -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-					}
-					
-					It 'Should pass proper parameters to setup' {
-						$mockStartWin32ProcessExpectedArgument = @{
-							IAcceptSQLServerLicenseTerms = 'True'
-							Quiet = 'True'
-							Action = 'AddNode'
-							InstanceName = 'MSSQLSERVER'
-							AgtSvcAccount = $mockAgentServiceAccount
-							AgtSvcPassword = $mockSqlAgentCredential.GetNetworkCredential().Password
-							SqlSvcAccount = $mockSqlServiceAccount
-							SqlSvcPassword = $mockSQLServiceCredential.GetNetworkCredential().Password
-							AsSvcAccount = $mockAnalysisServiceAccount
-							AsSvcPassword = $mockAnalysisServiceCredential.GetNetworkCredential().Password
-							SkipRules = 'Cluster_VerifyForErrors'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should pass the SetupCredential object to the StartWin32Process function' {
-						$mockStartWin32Process_SetupCredential = {
-							$Credential | Should Not BeNullOrEmpty
-							return 'Process started.'
-						}
-						
-						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-				}
-				
-				# For testing InstallFailoverCluster action
-				Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
-					BeforeAll {
-						$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-						$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-						$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-						$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-						$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-						$mockDynamicSqlBackupPath = $mockSqlBackupPath
-						
-						$testParameters = $mockDefaultClusterParameters.Clone()
-						$testParameters += @{
-							InstanceName = 'MSSQLSERVER'
-							SourcePath = $mockSourcePath
-							Action = 'InstallFailoverCluster'
-							FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-							
-							# Ensure we use "clustered" disks for our paths
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDbDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-						}
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-							$Filter -eq "Name = 'Available Storage'"
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-						} -Verfiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-							$Association -eq 'MSCluster_ResourceToPossibleOwner'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-							$ResultClassName -eq 'MSCluster_DiskPartition'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolume'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-						} -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-					}
-					
-					It 'Should pass proper parameters to setup' {
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'InstallFailoverCluster'
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							SkipRules = 'Cluster_VerifyForErrors'
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should pass proper parameters to setup when only InstallSQLDataDir is assigned a path' {
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'InstallFailoverCluster'
-							FailoverClusterDisks = 'SysData'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							SkipRules = 'Cluster_VerifyForErrors'
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-						}
-						
-						$setTargetResourceParameters = $testParameters.Clone()
-						$setTargetResourceParameters.Remove('SQLUserDBDir')
-						$setTargetResourceParameters.Remove('SQLUserDBLogDir')
-						$setTargetResourceParameters.Remove('SQLTempDbDir')
-						$setTargetResourceParameters.Remove('SQLTempDbLogDir')
-						$setTargetResourceParameters.Remove('SQLBackupDir')
-						{ Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-					}
-					
-					It 'Should pass proper parameters to setup when three variables are assigned the same drive, but different paths' {
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'InstallFailoverCluster'
-							FailoverClusterDisks = 'SysData'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							SkipRules = 'Cluster_VerifyForErrors'
-							InstallSQLDataDir = 'E:\SQLData'
-							SQLUserDBDir = 'E:\SQLData\UserDb'
-							SQLUserDBLogDir = 'E:\SQLData\UserDbLogs'
-						}
-						
-						$setTargetResourceParameters = $testParameters.Clone()
-						$setTargetResourceParameters.Remove('SQLTempDbDir')
-						$setTargetResourceParameters.Remove('SQLTempDbLogDir')
-						$setTargetResourceParameters.Remove('SQLBackupDir')
-						
-						$setTargetResourceParameters['InstallSQLDataDir'] = 'E:\SQLData\' # This ends with \ to test removal of paths ending with \
-						$setTargetResourceParameters['SQLUserDBDir'] = 'E:\SQLData\UserDb'
-						$setTargetResourceParameters['SQLUserDBLogDir'] = 'E:\SQLData\UserDbLogs'
-						
-						{ Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-					}
-					
-					It 'Should pass the SetupCredential object to the StartWin32Process function' {
-						$mockStartWin32Process_SetupCredential = {
-							$Credential | Should Not BeNullOrEmpty
-							return 'Process started.'
-						}
-						
-						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should throw an error when one or more paths are not resolved to clustered storage' {
-						$badPathParameters = $testParameters.Clone()
-						
-						# Pass in a bad path
-						$badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-						
-						{ Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
-					}
-					
-					It 'Should properly map paths to clustered disk resources' {
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'InstallFailoverCluster'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							SkipRules = 'Cluster_VerifyForErrors'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should build a DEFAULT address string when no network is specified' {
-						$missingNetworkParams = $testParameters.Clone()
-						$missingNetworkParams.Remove('FailoverClusterIPAddress')
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'InstallFailoverCluster'
-							FailoverClusterIPAddresses = 'DEFAULT'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-						}
-						
-						{ Set-TargetResource @missingNetworkParams } | Should Not Throw
-					}
-					
-					It 'Should throw an error when an invalid IP Address is specified' {
-						$invalidAddressParameters = $testParameters.Clone()
-						
-						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
-						$invalidAddressParameters += @{
-							FailoverClusterIPAddress = '192.168.0.100'
-						}
-						
-						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-					}
-					
-					It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
-						$invalidAddressParameters = $testParameters.Clone()
-						
-						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
-						$invalidAddressParameters += @{
-							FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
-						}
-						
-						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-					}
-					
-					It 'Should build a valid IP address string for a single address' {
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Action = 'InstallFailoverCluster'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should build a valid IP address string for a multi-subnet cluster' {
-						$multiSubnetParameters = $testParameters.Clone()
-						$multiSubnetParameters.Remove('FailoverClusterIPAddress')
-						$multiSubnetParameters += @{
-							FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
-						}
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Action = 'InstallFailoverCluster'
-						}
-						
-						{ Set-TargetResource @multiSubnetParameters } | Should Not Throw
-					}
-					
-					It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
-						$csvTestParameters = $testParameters.Clone()
-						
-						$csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['SysData'].Path
-						$csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
-						$csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
-						$csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
-						$csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
-						$csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path
-						
-						$mockStartWin32ProcessExpectedArgument = @{
-							IAcceptSQLServerLicenseTerms = 'True'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Quiet = 'True'
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							Action = 'InstallFailoverCluster'
-							InstanceName = 'MSSQLSERVER'
-							Features = 'SQLEngine'
-							FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name); $($mockCSVClusterDiskMap['UserLogs'].Name); $($mockCSVClusterDiskMap['SysData'].Name); $($mockCSVClusterDiskMap['TempDBData'].Name); $($mockCSVClusterDiskMap['TempDBLogs'].Name)"
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockCSVClusterDiskMap['SysData'].Path
-							SQLUserDBDir = $mockCSVClusterDiskMap['UserData'].Path
-							SQLUserDBLogDir = $mockCSVClusterDiskMap['UserLogs'].Path
-							SQLTempDBDir = $mockCSVClusterDiskMap['TempDBData'].Path
-							SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
-							SQLBackupDir = $mockCSVClusterDiskMap['Backup'].Path
-						}
-						
-						{ Set-TargetResource @csvTestParameters } | Should Not Throw
-					}
-					
-					It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
-						$csvTestParameters = $testParameters.Clone()
-						
-						$csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
-						$csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
-						$csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
-						$csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
-						$csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
-						$csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
-						
-						$mockStartWin32ProcessExpectedArgument = @{
-							IAcceptSQLServerLicenseTerms = 'True'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Quiet = 'True'
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							Action = 'InstallFailoverCluster'
-							InstanceName = 'MSSQLSERVER'
-							Features = 'SQLEngine'
-							FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name)"
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
-							SQLUserDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
-							SQLUserDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Logs"
-							SQLTempDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDB"
-							SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
-							SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
-						}
-						
-						{ Set-TargetResource @csvTestParameters } | Should Not Throw
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
-					BeforeAll {
-						$testParameters = $mockDefaultParameters.Clone()
-						$testParameters.Remove('Features')
-						$testParameters.Remove('SourceCredential')
-						$testParameters.Remove('ASSysAdminAccounts')
-						
-						$testParameters += @{
-							Features = 'SQLENGINE'
-							InstanceName = 'MSSQLSERVER'
-							SourcePath = $mockSourcePath
-							Action = 'PrepareFailoverCluster'
-						}
-						
-						Mock -CommandName NetUse -Verifiable
-						Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
-						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-						
-						Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-						} -MockWith $mockGetItemProperty_Setup -Verifiable
-						
-						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
-							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-						} -Verfiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
-							$Association -eq 'MSCluster_ResourceToPossibleOwner'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
-							$ResultClass -eq 'MSCluster_DiskPartition'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-						} -Verifiable
-					}
-					
-					It 'Should pass correct arguments to the setup process' {
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'PrepareFailoverCluster'
-							SkipRules = 'Cluster_VerifyForErrors'
-						}
-						$mockStartWin32ProcessExpectedArgument.Remove('FailoverClusterGroup')
-						$mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
+            $mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
+            if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
+            {
+                New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
+            }
+            
+            # Mocking executable setup.exe which will be used for tests without parameter SourceCredential
+            Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
+            
+            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
+            Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+            
+            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
+            Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+            
+            #endregion Setting up TestDrive:\
+            
+            BeforeEach {
+                # General mocks
+                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+                } -MockWith $mockGetItemProperty_SQL -Verifiable
+                
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    (
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+                    ) -and
+                    $Name -eq 'ImagePath'
+                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+                
+                # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
+                Mock -CommandName Get-ItemProperty -Verifiable
+                
+                Mock -CommandName Get-ItemProperty -ParameterFilter {
+                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+                
+                Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
+                Mock -CommandName WaitForWin32ProcessEnd -Verifiable
+                Mock -CommandName Test-TargetResource -MockWith {
+                    return $true
+                } -Verifiable
+            }
+            
+            $testProductVersion | ForEach-Object -Process {
+                $mockSqlMajorVersion = $_
+                
+                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+                
+                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+                $mockDynamicSqlTempDatabasePath = ''
+                $mockDynamicSqlTempDatabaseLogPath = ''
+                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+                    BeforeEach {
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Start-Process -Verifiable
+                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                            ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+                            SQLSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
+                            ASSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
+                            InstanceDir = 'D:'
+                            InstallSQLDataDir = 'E:'
+                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                        }
+                        
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            Quiet = 'True'
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Action = 'Install'
+                            AGTSVCSTARTUPTYPE = 'Automatic'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = $testParameters.Features
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+                            ASSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+                            PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+                            InstanceDir = 'D:\'
+                            InstallSQLDataDir = 'E:\'
+                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                            ($Name -eq $mockDefaultInstance_InstanceName)
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                    
+                    if ($mockSqlMajorVersion -in (13, 14))
+                    {
+                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+                            
+                            $testParameters.Features = 'SSMS'
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                        
+                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+                            
+                            $testParameters.Features = 'ADV_SSMS'
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                    }
+                    else
+                    {
+                        It 'Should set the system in the desired state when feature is SSMS' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+                            
+                            $testParameters.Features = 'SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                        
+                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
+                            $testParameters = $mockDefaultParameters.Clone()
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                            }
+                            
+                            $testParameters.Features = 'ADV_SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'ADV_SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+                
+                Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $mockSetupCredential
+                            SourcePath = $mockSourcePathUNC
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                        }
+                        
+                        # Mocking SharedDirectory (when previously installed and should not be installed again).
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+                        } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+                        
+                        # Mocking SharedWowDirectory (when previously installed and should not be installed again).
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+                        } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Start-Process -Verifiable
+                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            Quiet = 'True'
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Action = 'Install'
+                            AgtSvcStartupType = 'Automatic'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = $testParameters.Features
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            ASSysAdminAccounts = 'COMPANY\sqladmin'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                            ($Name -eq $mockDefaultInstance_InstanceName)
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        
+                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                    
+                    if ($mockSqlMajorVersion -in (13, 14))
+                    {
+                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = 'SSMS'
+                            $mockStartWin32ProcessExpectedArgument = ''
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                        
+                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = 'ADV_SSMS'
+                            $mockStartWin32ProcessExpectedArgument = ''
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                    }
+                    else
+                    {
+                        It 'Should set the system in the desired state when feature is SSMS' {
+                            $testParameters.Features = 'SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                        
+                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
+                            $testParameters.Features = 'ADV_SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'ADV_SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+                
+                Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = $mockDefaultInstance_InstanceName
+                            SourceCredential = $mockSetupCredential
+                            SourcePath = $mockSourcePathUNCWithoutLeaf
+                            ForceReboot = $true
+                            SuppressReboot = $true
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                        }
+                        
+                        Mock -CommandName New-SmbMapping -Verifiable
+                        Mock -CommandName Remove-SmbMapping -Verifiable
+                        Mock -CommandName Start-Process -Verifiable
+                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            Quiet = 'True'
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Action = 'Install'
+                            AGTSVCSTARTUPTYPE = 'Automatic'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = $testParameters.Features
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            ASSysAdminAccounts = 'COMPANY\sqladmin'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                        
+                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                            ($Name -eq $mockDefaultInstance_InstanceName)
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        
+                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                    
+                    if ($mockSqlMajorVersion -in (13, 14))
+                    {
+                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = 'SSMS'
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                        
+                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = 'ADV_SSMS'
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                    }
+                    else
+                    {
+                        It 'Should set the system in the desired state when feature is SSMS' {
+                            $testParameters.Features = 'SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                        
+                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
+                            $testParameters.Features = 'ADV_SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'MSSQLSERVER'
+                                Features = 'ADV_SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+                
+                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+                
+                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+                $mockDynamicSqlTempDatabasePath = ''
+                $mockDynamicSqlTempDatabaseLogPath = ''
+                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
+                    BeforeEach {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = $mockNamedInstance_InstanceName
+                            SourceCredential = $null
+                            SourcePath = $mockSourcePath
+                            ForceReboot = $true
+                        }
+                        
+                        if ($mockSqlMajorVersion -in (13, 14))
+                        {
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                        }
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            Quiet = 'True'
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Action = 'Install'
+                            AGTSVCSTARTUPTYPE = 'Automatic'
+                            InstanceName = 'TEST'
+                            Features = $testParameters.Features
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            ASSysAdminAccounts = 'COMPANY\sqladmin'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                            ($Name -eq $mockDefaultInstance_InstanceName)
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 6 -Scope It
+                        
+                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                    
+                    if ($mockSqlMajorVersion -in (13, 14))
+                    {
+                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                        
+                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+                            $testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
+                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            
+                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+                        }
+                    }
+                    else
+                    {
+                        It 'Should set the system in the desired state when feature is SSMS' {
+                            $testParameters.Features = 'SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'TEST'
+                                Features = 'SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                        
+                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
+                            $testParameters.Features = 'ADV_SSMS'
+                            
+                            $mockStartWin32ProcessExpectedArgument = @{
+                                Quiet = 'True'
+                                IAcceptSQLServerLicenseTerms = 'True'
+                                Action = 'Install'
+                                InstanceName = 'TEST'
+                                Features = 'ADV_SSMS'
+                            }
+                            
+                            { Set-TargetResource @testParameters } | Should Not Throw
+                            
+                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                                ($Name -eq $mockDefaultInstance_InstanceName)
+                            } -Exactly -Times 0 -Scope It
+                            
+                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                            } -Exactly -Times 6 -Scope It
+                            
+                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+                
+                # For testing AddNode action
+                Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
+                    BeforeAll {
+                        $testParameters = $mockDefaultClusterParameters.Clone()
+                        $testParameters['Features'] += 'AS'
+                        $testParameters += @{
+                            InstanceName = 'MSSQLSERVER'
+                            SourcePath = $mockSourcePath
+                            Action = 'AddNode'
+                            AgtSvcAccount = $mockSQLAgentCredential
+                            SqlSvcAccount = $mockSQLServiceCredential
+                            ASSvcAccount = $mockAnalysisServiceCredential
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                        }
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Verfiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                    }
+                    
+                    It 'Should pass proper parameters to setup' {
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            Quiet = 'True'
+                            Action = 'AddNode'
+                            InstanceName = 'MSSQLSERVER'
+                            AgtSvcAccount = $mockAgentServiceAccount
+                            AgtSvcPassword = $mockSqlAgentCredential.GetNetworkCredential().Password
+                            SqlSvcAccount = $mockSqlServiceAccount
+                            SqlSvcPassword = $mockSQLServiceCredential.GetNetworkCredential().Password
+                            AsSvcAccount = $mockAnalysisServiceAccount
+                            AsSvcPassword = $mockAnalysisServiceCredential.GetNetworkCredential().Password
+                            SkipRules = 'Cluster_VerifyForErrors'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass the SetupCredential object to the StartWin32Process function' {
+                        $mockStartWin32Process_SetupCredential = {
+                            $Credential | Should Not BeNullOrEmpty
+                            return 'Process started.'
+                        }
+                        
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                }
+                
+                # For testing InstallFailoverCluster action
+                Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
+                    BeforeAll {
+                        $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+                        $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+                        $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+                        $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+                        $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+                        $mockDynamicSqlBackupPath = $mockSqlBackupPath
+                        
+                        $testParameters = $mockDefaultClusterParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = 'MSSQLSERVER'
+                            SourcePath = $mockSourcePath
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                            
+                            # Ensure we use "clustered" disks for our paths
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDbDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                        }
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Verfiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                    }
+                    
+                    It 'Should pass proper parameters to setup' {
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass proper parameters to setup when only InstallSQLDataDir is assigned a path' {
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterDisks = 'SysData'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                        }
+                        
+                        $setTargetResourceParameters = $testParameters.Clone()
+                        $setTargetResourceParameters.Remove('SQLUserDBDir')
+                        $setTargetResourceParameters.Remove('SQLUserDBLogDir')
+                        $setTargetResourceParameters.Remove('SQLTempDbDir')
+                        $setTargetResourceParameters.Remove('SQLTempDbLogDir')
+                        $setTargetResourceParameters.Remove('SQLBackupDir')
+                        { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass proper parameters to setup when three variables are assigned the same drive, but different paths' {
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterDisks = 'SysData'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            InstallSQLDataDir = 'E:\SQLData'
+                            SQLUserDBDir = 'E:\SQLData\UserDb'
+                            SQLUserDBLogDir = 'E:\SQLData\UserDbLogs'
+                        }
+                        
+                        $setTargetResourceParameters = $testParameters.Clone()
+                        $setTargetResourceParameters.Remove('SQLTempDbDir')
+                        $setTargetResourceParameters.Remove('SQLTempDbLogDir')
+                        $setTargetResourceParameters.Remove('SQLBackupDir')
+                        
+                        $setTargetResourceParameters['InstallSQLDataDir'] = 'E:\SQLData\' # This ends with \ to test removal of paths ending with \
+                        $setTargetResourceParameters['SQLUserDBDir'] = 'E:\SQLData\UserDb'
+                        $setTargetResourceParameters['SQLUserDBLogDir'] = 'E:\SQLData\UserDbLogs'
+                        
+                        { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass the SetupCredential object to the StartWin32Process function' {
+                        $mockStartWin32Process_SetupCredential = {
+                            $Credential | Should Not BeNullOrEmpty
+                            return 'Process started.'
+                        }
+                        
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should throw an error when one or more paths are not resolved to clustered storage' {
+                        $badPathParameters = $testParameters.Clone()
+                        
+                        # Pass in a bad path
+                        $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
+                        
+                        { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
+                    }
+                    
+                    It 'Should properly map paths to clustered disk resources' {
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should build a DEFAULT address string when no network is specified' {
+                        $missingNetworkParams = $testParameters.Clone()
+                        $missingNetworkParams.Remove('FailoverClusterIPAddress')
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'InstallFailoverCluster'
+                            FailoverClusterIPAddresses = 'DEFAULT'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                        }
+                        
+                        { Set-TargetResource @missingNetworkParams } | Should Not Throw
+                    }
+                    
+                    It 'Should throw an error when an invalid IP Address is specified' {
+                        $invalidAddressParameters = $testParameters.Clone()
+                        
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = '192.168.0.100'
+                        }
+                        
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+                    
+                    It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
+                        $invalidAddressParameters = $testParameters.Clone()
+                        
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+                        }
+                        
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+                    
+                    It 'Should build a valid IP address string for a single address' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'InstallFailoverCluster'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should build a valid IP address string for a multi-subnet cluster' {
+                        $multiSubnetParameters = $testParameters.Clone()
+                        $multiSubnetParameters.Remove('FailoverClusterIPAddress')
+                        $multiSubnetParameters += @{
+                            FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
+                        }
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'InstallFailoverCluster'
+                        }
+                        
+                        { Set-TargetResource @multiSubnetParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
+                        $csvTestParameters = $testParameters.Clone()
+                        
+                        $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['SysData'].Path
+                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
+                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
+                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
+                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
+                        $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path
+                        
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Quiet = 'True'
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            Action = 'InstallFailoverCluster'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = 'SQLEngine'
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name); $($mockCSVClusterDiskMap['UserLogs'].Name); $($mockCSVClusterDiskMap['SysData'].Name); $($mockCSVClusterDiskMap['TempDBData'].Name); $($mockCSVClusterDiskMap['TempDBLogs'].Name)"
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockCSVClusterDiskMap['SysData'].Path
+                            SQLUserDBDir = $mockCSVClusterDiskMap['UserData'].Path
+                            SQLUserDBLogDir = $mockCSVClusterDiskMap['UserLogs'].Path
+                            SQLTempDBDir = $mockCSVClusterDiskMap['TempDBData'].Path
+                            SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
+                            SQLBackupDir = $mockCSVClusterDiskMap['Backup'].Path
+                        }
+                        
+                        { Set-TargetResource @csvTestParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
+                        $csvTestParameters = $testParameters.Clone()
+                        
+                        $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
+                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
+                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
+                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
+                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
+                        $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
+                        
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Quiet = 'True'
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            Action = 'InstallFailoverCluster'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = 'SQLEngine'
+                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name)"
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
+                            SQLUserDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
+                            SQLUserDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Logs"
+                            SQLTempDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDB"
+                            SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
+                            SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
+                        }
+                        
+                        { Set-TargetResource @csvTestParameters } | Should Not Throw
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
+                    BeforeAll {
+                        $testParameters = $mockDefaultParameters.Clone()
+                        $testParameters.Remove('Features')
+                        $testParameters.Remove('SourceCredential')
+                        $testParameters.Remove('ASSysAdminAccounts')
+                        
+                        $testParameters += @{
+                            Features = 'SQLENGINE'
+                            InstanceName = 'MSSQLSERVER'
+                            SourcePath = $mockSourcePath
+                            Action = 'PrepareFailoverCluster'
+                        }
+                        
+                        Mock -CommandName NetUse -Verifiable
+                        Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
+                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        
+                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Verfiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                            $ResultClass -eq 'MSCluster_DiskPartition'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Verifiable
+                    }
+                    
+                    It 'Should pass correct arguments to the setup process' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'PrepareFailoverCluster'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                        }
+                        $mockStartWin32ProcessExpectedArgument.Remove('FailoverClusterGroup')
+                        $mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
 
-						{ Set-TargetResource @testParameters } | Should Not throw
-						
-						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-							($Name -eq $mockDefaultInstance_InstanceName)
-						} -Exactly -Times 0 -Scope It
-						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-							$Association -eq 'MSCluster_ResourceToPossibleOwner'
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-							$ResultClass -eq 'MSCluster_DiskPartition'
-						} -Exactly -Times 0 -Scope It
-						
-						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-						} -Exactly -Times 0 -Scope It
-					}
-				}
-				
-				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
-					BeforeEach {
-						$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-						$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-						$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-						$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-						$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-						$mockDynamicSqlBackupPath = $mockSqlBackupPath
-						
-						$testParameters = $mockDefaultClusterParameters.Clone()
-						$testParameters += @{
-							InstanceName = 'MSSQLSERVER'
-							SourcePath = $mockSourcePath
-							Action = 'CompleteFailoverCluster'
-							FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-							
-							# Ensure we use "clustered" disks for our paths
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDbDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-						}
-					}
-					
-					BeforeAll {
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-							$Filter -eq "Name = 'Available Storage'"
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-						} -Verfiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-							$Association -eq 'MSCluster_ResourceToPossibleOwner'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-							$ResultClassName -eq 'MSCluster_DiskPartition'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolume'
-						} -Verifiable
-						
-						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-						} -Verifiable
-						
-						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-					}
-					
-					It 'Should throw an error when one or more paths are not resolved to clustered storage' {
-						$badPathParameters = $testParameters.Clone()
-						
-						# Pass in a bad path
-						$badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-						
-						{ Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
-					}
-					
-					It 'Should properly map paths to clustered disk resources' {
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'CompleteFailoverCluster'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							SkipRules = 'Cluster_VerifyForErrors'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should build a DEFAULT address string when no network is specified' {
-						$missingNetworkParams = $testParameters.Clone()
-						$missingNetworkParams.Remove('FailoverClusterIPAddress')
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							Action = 'CompleteFailoverCluster'
-							FailoverClusterIPAddresses = 'DEFAULT'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-						}
-						
-						{ Set-TargetResource @missingNetworkParams } | Should Not Throw
-					}
-					
-					It 'Should throw an error when an invalid IP Address is specified' {
-						$invalidAddressParameters = $testParameters.Clone()
-						
-						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
-						$invalidAddressParameters += @{
-							FailoverClusterIPAddress = '192.168.0.100'
-						}
-						
-						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-					}
-					
-					It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
-						$invalidAddressParameters = $testParameters.Clone()
-						
-						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
-						$invalidAddressParameters += @{
-							FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
-						}
-						
-						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-					}
-					
-					It 'Should build a valid IP address string for a single address' {
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Action = 'CompleteFailoverCluster'
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-					
-					It 'Should build a valid IP address string for a multi-subnet cluster' {
-						$multiSubnetParameters = $testParameters.Clone()
-						$multiSubnetParameters.Remove('FailoverClusterIPAddress')
-						$multiSubnetParameters += @{
-							FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
-						}
-						
-						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-						$mockStartWin32ProcessExpectedArgument += @{
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Action = 'CompleteFailoverCluster'
-						}
-						
-						{ Set-TargetResource @multiSubnetParameters } | Should Not Throw
-					}
-					
-					It 'Should pass proper parameters to setup' {
-						$mockStartWin32ProcessExpectedArgument = @{
-							IAcceptSQLServerLicenseTerms = 'True'
-							SkipRules = 'Cluster_VerifyForErrors'
-							Quiet = 'True'
-							SQLSysAdminAccounts = 'COMPANY\sqladmin'
-							
-							Action = 'CompleteFailoverCluster'
-							InstanceName = 'MSSQLSERVER'
-							Features = 'SQLEngine'
-							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-							SQLBackupDir = $mockDynamicSqlBackupPath
-						}
-						
-						{ Set-TargetResource @testParameters } | Should Not Throw
-					}
-				}
-				
-			}
-			
-			Assert-VerifiableMocks
-		}
-		
-		# Tests only the parts of the code that does not already get tested thru the other tests.
-		Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
-			Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
-				BeforeEach {
-					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-					Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
-				}
-				
-				
-				It 'Should use Unbuffered IO when copying' {
-					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-					
-					$mockStartProcessExpectedArgument =
-					$mockRobocopyArgumentSourcePath,
-					$mockRobocopyArgumentDestinationPath,
-					$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-					$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-					$mockRobocopyArgumentUseUnbufferedIO,
-					$mockRobocopyArgumentSilent -join ' '
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-				
-				It 'Should not use Unbuffered IO when copying' {
-					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
-					
-					$mockStartProcessExpectedArgument =
-					$mockRobocopyArgumentSourcePath,
-					$mockRobocopyArgumentDestinationPath,
-					$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-					$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-					'',
-					$mockRobocopyArgumentSilent -join ' '
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-			}
-			
-			Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
-				BeforeEach {
-					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-					
-					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-					Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
-				}
-				
-				It 'Should throw the correct error message when error code is 8' {
-					$mockStartProcessExitCode = 8
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-				
-				It 'Should throw the correct error message when error code is 16' {
-					$mockStartProcessExitCode = 16
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-				
-				It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
-					$mockStartProcessExitCode = 9
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-			}
-			
-			Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
-				BeforeEach {
-					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-					
-					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-					Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
-				}
-				
-				It 'Should finish succesfully with exit code 1' {
-					$mockStartProcessExitCode = 1
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-				
-				It 'Should finish succesfully with exit code 2' {
-					$mockStartProcessExitCode = 2
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-				
-				It 'Should finish succesfully with exit code 3' {
-					$mockStartProcessExitCode = 3
-					
-					$copyItemWithRoboCopyParameter = @{
-						Path = $mockRobocopyArgumentSourcePath
-						DestinationPath = $mockRobocopyArgumentDestinationPath
-					}
-					
-					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-					
-					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-				}
-			}
-		}
-		
-		Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
-			$serviceTypes = @('SQL', 'AGT', 'IS', 'RS', 'AS', 'FT')
-			
-			BeforeAll {
-				$mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
-				
-				$mockSystemServiceAccount = (
-					New-Object System.Management.Automation.PSCredential 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
-				)
-				
-				$mockVirtualServiceAccount = (
-					New-Object System.Management.Automation.PSCredential 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
-				)
-				
-				$mockManagedServiceAccount = (
-					New-Object System.Management.Automation.PSCredential 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
-				)
-				
-				$mockDomainServiceAccount = (
-					New-Object System.Management.Automation.PSCredential 'COMPANY\sql.service', $mockServiceAccountPassword
-				)
-			}
-			
-			$serviceTypes | ForEach-Object {
-				
-				$serviceType = $_
-				
-				Context "When service type is $serviceType" {
-					
-					It "Should return the correct parameters when the account is a system account." {
-						$result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
-						
-						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
-						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-					}
-					
-					It "Should return the correct parameters when the account is a virtual service account" {
-						$result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
-						
-						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
-						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-					}
-					
-					It "Should return the correct parameters when the account is a managed service account" {
-						$result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
-						
-						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
-						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-					}
-					
-					It "Should return the correct parameters when the account is a domain account" {
-						$result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
-						
-						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
-						$result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
-					}
-				}
-			}
-		}
-		
-		Describe 'Get-TemporaryFolder' -Tag 'Helper' {
-			BeforeAll {
-				$mockExpectedTempPath = [IO.Path]::GetTempPath()
-			}
-			
-			Context "When using Get-TemporaryFolder" {
-				It "Should return the correct temporary path." {
-					Get-TemporaryFolder | Should BeExactly $mockExpectedTempPath
-				}
-			}
-		}
-	}
+                        { Set-TargetResource @testParameters } | Should Not throw
+                        
+                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+                            ($Name -eq $mockDefaultInstance_InstanceName)
+                        } -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            $ResultClass -eq 'MSCluster_DiskPartition'
+                        } -Exactly -Times 0 -Scope It
+                        
+                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Exactly -Times 0 -Scope It
+                    }
+                }
+                
+                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
+                    BeforeEach {
+                        $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+                        $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+                        $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+                        $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+                        $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+                        $mockDynamicSqlBackupPath = $mockSqlBackupPath
+                        
+                        $testParameters = $mockDefaultClusterParameters.Clone()
+                        $testParameters += @{
+                            InstanceName = 'MSSQLSERVER'
+                            SourcePath = $mockSourcePath
+                            Action = 'CompleteFailoverCluster'
+                            FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                            
+                            # Ensure we use "clustered" disks for our paths
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDbDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                        }
+                    }
+                    
+                    BeforeAll {
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        } -Verfiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        } -Verifiable
+                        
+                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                    }
+                    
+                    It 'Should throw an error when one or more paths are not resolved to clustered storage' {
+                        $badPathParameters = $testParameters.Clone()
+                        
+                        # Pass in a bad path
+                        $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
+                        
+                        { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
+                    }
+                    
+                    It 'Should properly map paths to clustered disk resources' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'CompleteFailoverCluster'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should build a DEFAULT address string when no network is specified' {
+                        $missingNetworkParams = $testParameters.Clone()
+                        $missingNetworkParams.Remove('FailoverClusterIPAddress')
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            Action = 'CompleteFailoverCluster'
+                            FailoverClusterIPAddresses = 'DEFAULT'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                        }
+                        
+                        { Set-TargetResource @missingNetworkParams } | Should Not Throw
+                    }
+                    
+                    It 'Should throw an error when an invalid IP Address is specified' {
+                        $invalidAddressParameters = $testParameters.Clone()
+                        
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = '192.168.0.100'
+                        }
+                        
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+                    
+                    It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
+                        $invalidAddressParameters = $testParameters.Clone()
+                        
+                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
+                        $invalidAddressParameters += @{
+                            FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+                        }
+                        
+                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+                    }
+                    
+                    It 'Should build a valid IP address string for a single address' {
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'CompleteFailoverCluster'
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should build a valid IP address string for a multi-subnet cluster' {
+                        $multiSubnetParameters = $testParameters.Clone()
+                        $multiSubnetParameters.Remove('FailoverClusterIPAddress')
+                        $multiSubnetParameters += @{
+                            FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
+                        }
+                        
+                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+                        $mockStartWin32ProcessExpectedArgument += @{
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Action = 'CompleteFailoverCluster'
+                        }
+                        
+                        { Set-TargetResource @multiSubnetParameters } | Should Not Throw
+                    }
+                    
+                    It 'Should pass proper parameters to setup' {
+                        $mockStartWin32ProcessExpectedArgument = @{
+                            IAcceptSQLServerLicenseTerms = 'True'
+                            SkipRules = 'Cluster_VerifyForErrors'
+                            Quiet = 'True'
+                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
+                            
+                            Action = 'CompleteFailoverCluster'
+                            InstanceName = 'MSSQLSERVER'
+                            Features = 'SQLEngine'
+                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+                            SQLBackupDir = $mockDynamicSqlBackupPath
+                        }
+                        
+                        { Set-TargetResource @testParameters } | Should Not Throw
+                    }
+                }
+                
+            }
+            
+            Assert-VerifiableMocks
+        }
+        
+        # Tests only the parts of the code that does not already get tested thru the other tests.
+        Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
+            Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
+                BeforeEach {
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
+                }
+                
+                
+                It 'Should use Unbuffered IO when copying' {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+                    
+                    $mockStartProcessExpectedArgument =
+                    $mockRobocopyArgumentSourcePath,
+                    $mockRobocopyArgumentDestinationPath,
+                    $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                    $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                    $mockRobocopyArgumentUseUnbufferedIO,
+                    $mockRobocopyArgumentSilent -join ' '
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+                
+                It 'Should not use Unbuffered IO when copying' {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
+                    
+                    $mockStartProcessExpectedArgument =
+                    $mockRobocopyArgumentSourcePath,
+                    $mockRobocopyArgumentDestinationPath,
+                    $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                    $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                    '',
+                    $mockRobocopyArgumentSilent -join ' '
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+            
+            Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
+                BeforeEach {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+                    
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+                }
+                
+                It 'Should throw the correct error message when error code is 8' {
+                    $mockStartProcessExitCode = 8
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+                
+                It 'Should throw the correct error message when error code is 16' {
+                    $mockStartProcessExitCode = 16
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+                
+                It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
+                    $mockStartProcessExitCode = 9
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+            
+            Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
+                BeforeEach {
+                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+                    
+                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+                }
+                
+                It 'Should finish succesfully with exit code 1' {
+                    $mockStartProcessExitCode = 1
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+                
+                It 'Should finish succesfully with exit code 2' {
+                    $mockStartProcessExitCode = 2
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+                
+                It 'Should finish succesfully with exit code 3' {
+                    $mockStartProcessExitCode = 3
+                    
+                    $copyItemWithRoboCopyParameter = @{
+                        Path = $mockRobocopyArgumentSourcePath
+                        DestinationPath = $mockRobocopyArgumentDestinationPath
+                    }
+                    
+                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+                    
+                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+        
+        Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
+            $serviceTypes = @('SQL', 'AGT', 'IS', 'RS', 'AS', 'FT')
+            
+            BeforeAll {
+                $mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
+                
+                $mockSystemServiceAccount = (
+                    New-Object System.Management.Automation.PSCredential 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
+                )
+                
+                $mockVirtualServiceAccount = (
+                    New-Object System.Management.Automation.PSCredential 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
+                )
+                
+                $mockManagedServiceAccount = (
+                    New-Object System.Management.Automation.PSCredential 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
+                )
+                
+                $mockDomainServiceAccount = (
+                    New-Object System.Management.Automation.PSCredential 'COMPANY\sql.service', $mockServiceAccountPassword
+                )
+            }
+            
+            $serviceTypes | ForEach-Object {
+                
+                $serviceType = $_
+                
+                Context "When service type is $serviceType" {
+                    
+                    It "Should return the correct parameters when the account is a system account." {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
+                        
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
+                    
+                    It "Should return the correct parameters when the account is a virtual service account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
+                        
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
+                    
+                    It "Should return the correct parameters when the account is a managed service account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
+                        
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
+                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+                    }
+                    
+                    It "Should return the correct parameters when the account is a domain account" {
+                        $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
+                        
+                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
+                        $result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
+                    }
+                }
+            }
+        }
+        
+        Describe 'Get-TemporaryFolder' -Tag 'Helper' {
+            BeforeAll {
+                $mockExpectedTempPath = [IO.Path]::GetTempPath()
+            }
+            
+            Context "When using Get-TemporaryFolder" {
+                It "Should return the correct temporary path." {
+                    Get-TemporaryFolder | Should BeExactly $mockExpectedTempPath
+                }
+            }
+        }
+    }
 }
 finally
 {
-	Invoke-TestCleanup
+    Invoke-TestCleanup
 }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1,26 +1,26 @@
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-param()
+param ()
 
-$script:DSCModuleName      = 'xSQLServer'
-$script:DSCResourceName    = 'MSFT_xSQLServerSetup'
+$script:DSCModuleName = 'xSQLServer'
+$script:DSCResourceName = 'MSFT_xSQLServerSetup'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+if ((-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+	(-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))))
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+	& git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $script:DSCModuleName `
-    -DSCResourceName $script:DSCResourceName `
-    -TestType Unit
+											  -DSCModuleName $script:DSCModuleName `
+											  -DSCResourceName $script:DSCResourceName `
+											  -TestType Unit
 
 #endregion HEADER
 
@@ -28,381 +28,381 @@ function Invoke-TestSetup {
 }
 
 function Invoke-TestCleanup {
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+	Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
 # Begin Testing
 try
 {
-    Invoke-TestSetup
-
-    InModuleScope $script:DSCResourceName {
-        # Testing each supported SQL Server version
-        $testProductVersion = @(
-            14, # SQL Server "2017"
-            13, # SQL Server 2016
-            12, # SQL Server 2014
-            11, # SQL Server 2012
-            10  # SQL Server 2008 and 2008 R2
-        )
-
-        $mockSqlDatabaseEngineName = 'MSSQL'
-        $mockSqlAgentName = 'SQLAgent'
-        $mockSqlFullTextName = 'MSSQLFDLauncher'
-        $mockSqlReportingName = 'ReportServer'
-        $mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
-        $mockSqlAnalysisName = 'MSOLAP'
-
-        $mockSqlCollation = 'Finnish_Swedish_CI_AS'
-        $mockSqlLoginMode = 'Integrated'
-
-        $mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
-        $mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
-        $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
-        $mockSqlSystemAdministrator = 'COMPANY\Stacy'
-
-        $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
-        $mockSqlAnalysisAdmins = @('COMPANY\Stacy','COMPANY\SSAS Administrators')
-        $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
-        $mockSqlAnalysisTempDirectory= 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
-        $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
-        $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
-        $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
-
-        $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
-        $mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
-        $mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
-        $mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
-        $mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
-        $mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
-        $mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
-
-        $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-        $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
-        $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
-        $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
-
-        $mockNamedInstance_InstanceName = 'TEST'
-        $mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
-        $mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
-
-        $mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-        $mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
-        $mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
-
-        $mockmockSetupCredentialUserName = "COMPANY\sqladmin"
-
-        $mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-        $mockSetupCredential = New-Object System.Management.Automation.PSCredential( $mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword )
-
-        $mockSqlServiceAccount = 'COMPANY\SqlAccount'
-        $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
-        $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-        $mockAgentServiceAccount = 'COMPANY\AgentAccount'
-        $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
-        $mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount,($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-        $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
-        $mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
-        $mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-
-        $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
-
-        $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
-        $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
-        $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
-        $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
-        $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
-        $mockSqlBackupPath = 'O:\MSSQL\Backup'
-
-        $mockClusterDiskMap = {
-            @{
-                SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
-                UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
-                UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
-                TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
-                TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
-                Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
-            }
-        }
-
-        $mockCSVClusterDiskMap = @{
-            SysData = @{Path='C:\ClusterStorage\SysData';Name="Cluster Virtual Disk (SQL System Data Disk)"}
-            UserData = @{Path='C:\ClusterStorage\SQLData';Name="Cluster Virtual Disk (SQL Data Disk)"}
-            UserLogs = @{Path='C:\ClusterStorage\SQLLogs';Name="Cluster Virtual Disk (SQL Log Disk)"}
-            TempDbData = @{Path='C:\ClusterStorage\TempDBData';Name="Cluster Virtual Disk (SQL TempDBData Disk)"}
-            TempDbLogs = @{Path='C:\ClusterStorage\TempDBLogs';Name="Cluster Virtual Disk (SQL TempDBLog Disk)"}
-            Backup = @{Path='C:\ClusterStorage\SQLBackup';Name="Cluster Virtual Disk (SQL Backup Disk)"}
-        }
-
-        $mockClusterSites = @(
-            @{
-                Name = 'SiteA'
-                Address = $mockDefaultInstance_FailoverClusterIPAddress
-                Mask = '255.255.255.0'
-            },
-            @{
-                Name = 'SiteB'
-                Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
-                Mask = '255.255.255.0'
-            }
-        )
-
-        #region Function mocks
-        $mockGetSqlMajorVersion = {
-            return $mockSqlMajorVersion
-        }
-
-        $mockEmptyHashtable = {
-            return @()
-        }
-
-        $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
-        $mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
-        $mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
-        $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
-        $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
-        $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
-
-        $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
-
-        $mockGetItemProperty_UninstallProducts2008R2 = {
-            return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber  # Mock product ADV_SSMS 2012
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts2012 = {
-            return @(
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber    # Mock product SSMS 2014
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts2014 = {
-            return @(
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts = {
-            return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber,  # Mock product ADV_SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber,    # Mock product SSMS 2014
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_DatabaseService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_AgentService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_FullTextService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_ReportingService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_IntegrationService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_AnalysisService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetService_DefaultInstance = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_DatabaseService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_AgentService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_FullTextService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_ReportingService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_IntegrationService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_AnalysisService = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetService_NamedInstance = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ConfigurationState = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_DQFeature = {
+	Invoke-TestSetup
+	
+	InModuleScope $script:DSCResourceName {
+		# Testing each supported SQL Server version
+		$testProductVersion = @(
+			14, # SQL Server "2017"
+			13, # SQL Server 2016
+			12, # SQL Server 2014
+			11, # SQL Server 2012
+			10 # SQL Server 2008 and 2008 R2
+		)
+		
+		$mockSqlDatabaseEngineName = 'MSSQL'
+		$mockSqlAgentName = 'SQLAgent'
+		$mockSqlFullTextName = 'MSSQLFDLauncher'
+		$mockSqlReportingName = 'ReportServer'
+		$mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
+		$mockSqlAnalysisName = 'MSOLAP'
+		
+		$mockSqlCollation = 'Finnish_Swedish_CI_AS'
+		$mockSqlLoginMode = 'Integrated'
+		
+		$mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
+		$mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
+		$mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
+		$mockSqlSystemAdministrator = 'COMPANY\Stacy'
+		
+		$mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
+		$mockSqlAnalysisAdmins = @('COMPANY\Stacy', 'COMPANY\SSAS Administrators')
+		$mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
+		$mockSqlAnalysisTempDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
+		$mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
+		$mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
+		$mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
+		
+		$mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+		$mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
+		$mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
+		$mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
+		$mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
+		$mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
+		$mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
+		
+		$mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+		$mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+		$mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
+		$mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
+		$mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
+		$mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
+		
+		$mockNamedInstance_InstanceName = 'TEST'
+		$mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
+		$mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
+		$mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
+		$mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
+		$mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
+		$mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
+		
+		$mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+		$mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
+		$mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
+		
+		$mockmockSetupCredentialUserName = "COMPANY\sqladmin"
+		
+		$mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+		$mockSetupCredential = New-Object System.Management.Automation.PSCredential($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
+		
+		$mockSqlServiceAccount = 'COMPANY\SqlAccount'
+		$mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
+		$mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+		$mockAgentServiceAccount = 'COMPANY\AgentAccount'
+		$mockAgentServicePassword = 'Ag3ntP@ssw0rd'
+		$mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount, ($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+		$mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
+		$mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
+		$mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+		
+		$mockClusterNodes = @($env:COMPUTERNAME, 'SQL01', 'SQL02')
+		
+		$mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
+		$mockSqlUserDatabasePath = 'K:\MSSQL\Data'
+		$mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
+		$mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
+		$mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
+		$mockSqlBackupPath = 'O:\MSSQL\Backup'
+		
+		$mockClusterDiskMap = {
+			@{
+				SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
+				UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
+				UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
+				TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
+				TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
+				Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
+			}
+		}
+		
+		$mockCSVClusterDiskMap = @{
+			SysData = @{ Path = 'C:\ClusterStorage\SysData'; Name = "Cluster Virtual Disk (SQL System Data Disk)" }
+			UserData = @{ Path = 'C:\ClusterStorage\SQLData'; Name = "Cluster Virtual Disk (SQL Data Disk)" }
+			UserLogs = @{ Path = 'C:\ClusterStorage\SQLLogs'; Name = "Cluster Virtual Disk (SQL Log Disk)" }
+			TempDbData = @{ Path = 'C:\ClusterStorage\TempDBData'; Name = "Cluster Virtual Disk (SQL TempDBData Disk)" }
+			TempDbLogs = @{ Path = 'C:\ClusterStorage\TempDBLogs'; Name = "Cluster Virtual Disk (SQL TempDBLog Disk)" }
+			Backup = @{ Path = 'C:\ClusterStorage\SQLBackup'; Name = "Cluster Virtual Disk (SQL Backup Disk)" }
+		}
+		
+		$mockClusterSites = @(
+			@{
+				Name = 'SiteA'
+				Address = $mockDefaultInstance_FailoverClusterIPAddress
+				Mask = '255.255.255.0'
+			},
+			@{
+				Name = 'SiteB'
+				Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
+				Mask = '255.255.255.0'
+			}
+		)
+		
+		#region Function mocks
+		$mockGetSqlMajorVersion = {
+			return $mockSqlMajorVersion
+		}
+		
+		$mockEmptyHashtable = {
+			return @()
+		}
+		
+		$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
+		$mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
+		$mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
+		$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
+		$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
+		$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
+		
+		$mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+		
+		$mockGetItemProperty_UninstallProducts2008R2 = {
+			return @(
+				$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
+				$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber # Mock product ADV_SSMS 2012
+			)
+		}
+		
+		$mockGetItemProperty_UninstallProducts2012 = {
+			return @(
+				$mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+				$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber # Mock product SSMS 2014
+			)
+		}
+		
+		$mockGetItemProperty_UninstallProducts2014 = {
+			return @(
+				$mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
+				$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+			)
+		}
+		
+		$mockGetItemProperty_UninstallProducts = {
+			return @(
+				$mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
+				$mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+				$mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
+				$mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber, # Mock product ADV_SSMS 2012
+				$mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber, # Mock product SSMS 2014
+				$mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_DatabaseService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_AgentService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_FullTextService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_ReportingService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_IntegrationService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_DefaultInstance_AnalysisService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetService_DefaultInstance = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_DatabaseService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_AgentService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_FullTextService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_ReportingService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_IntegrationService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_NamedInstance_AnalysisService = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetService_NamedInstance = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_ConfigurationState = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_DQFeature = {
 			return @(
 				(
 					New-Object Object |
@@ -410,4211 +410,4157 @@ try
 				)
 			)
 		}
-
-        $mockGetItemProperty_BOLFeature = {
+		
+		$mockGetItemProperty_BOLandDQCFeature = {
 			return @(
 				(
 					New-Object Object |
-					Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru -Force
-				)
-			)
-		}
-
-
-        $mockGetItemProperty_DQCFeature = {
-			return @(
-				(
-					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru -Force |
 					Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru -Force
 				)
 			)
 		}
-
-        $mockGetItemProperty_ClientComponentsFull_FeatureList = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
-                )
-            )
-        }
-        
-
-        $mockGetItemProperty_SQL = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
-                ),
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SharedDirectory = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItem_SharedDirectory = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SharedWowDirectory = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItem_SharedWowDirectory = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_Setup = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ServicesAnalysis = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQL = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                        Add-Member ScriptProperty Logins {
-                            return @( ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member ScriptMethod ListMembers {
-                                        return @('sysadmin')
-                                    } -PassThru -Force
-                                ) )
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQLCluster = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
-                        Add-Member ScriptProperty Logins {
-                            return @( ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member ScriptMethod ListMembers {
-                                        return @('sysadmin')
-                                    } -PassThru -Force
-                                ) )
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQLAnalysis = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member ScriptProperty ServerProperties  {
-                            return @{
-                                'CollationName' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
-                                'DataDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
-                                'TempDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
-                                'LogDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
-                                'BackupDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
-                            }
-                        } -PassThru |
-                        Add-Member ScriptProperty Roles  {
-                            return @{
-                                'Administrators' = @( New-Object Object |
-                                    Add-Member ScriptProperty Members {
-                                        return New-Object Object |
-                                            Add-Member ScriptProperty Name {
-                                                return $mockSqlAnalysisAdmins
-                                            } -PassThru -Force
-                                    } -PassThru -Force
+		
+		$mockGetItemProperty_ClientComponentsFull_FeatureList = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
+				)
+			)
+		}
+		
+		
+		$mockGetItemProperty_SQL = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
+				),
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_SharedDirectory = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItem_SharedDirectory = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_SharedWowDirectory = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItem_SharedWowDirectory = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_Setup = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetItemProperty_ServicesAnalysis = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
+				)
+			)
+		}
+		
+		$mockConnectSQL = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+					Add-Member ScriptProperty Logins {
+						return @((New-Object Object |
+								Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+								Add-Member ScriptMethod ListMembers {
+									return @('sysadmin')
+								} -PassThru -Force
+							))
+					} -PassThru -Force
+				)
+			)
+		}
+		
+		$mockConnectSQLCluster = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+					Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
+					Add-Member ScriptProperty Logins {
+						return @((New-Object Object |
+								Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+								Add-Member ScriptMethod ListMembers {
+									return @('sysadmin')
+								} -PassThru -Force
+							))
+					} -PassThru -Force
+				)
+			)
+		}
+		
+		$mockConnectSQLAnalysis = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member ScriptProperty ServerProperties  {
+						return @{
+							'CollationName' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force)
+							'DataDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force)
+							'TempDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force)
+							'LogDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force)
+							'BackupDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force)
+						}
+					} -PassThru |
+					Add-Member ScriptProperty Roles  {
+						return @{
+							'Administrators' = @(New-Object Object |
+								Add-Member ScriptProperty Members {
+									return New-Object Object |
+									Add-Member ScriptProperty Name {
+										return $mockSqlAnalysisAdmins
+									} -PassThru -Force
+								} -PassThru -Force
                                 ) }
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockRobocopyExecutableName = 'Robocopy.exe'
-        $mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
-        $mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
-        $mockRobocopyExectuableVersion = ''     # Set dynamically during runtime
-        $mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
-        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
-        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
-        $mockRobocopyArgumentUseUnbufferedIO = '/J'
-        $mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
-        $mockRobocopyArgumentDestinationPath = 'D:\Temp'
-
-        $mockGetCommand = {
-            return @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
-                        Add-Member ScriptProperty FileVersionInfo {
-                            return @( ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
-                                ) )
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockStartProcessExpectedArgument = ''  # Set dynamically during runtime
-        $mockStartProcessExitCode = 0  # Set dynamically during runtime
-
-        $mockStartProcess = {
-            if ( $ArgumentList -cne $mockStartProcessExpectedArgument )
-            {
-                throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
-            }
-
-            return New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
-        }
-
-        $mockStartProcess_WithExitCode = {
-            return New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
-        }
-
-        $mockSourcePathUNCWithoutLeaf = '\\server\share'
-        $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
-        $mockNewGuid = {
-            return New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
-        }
-
-        $mockGetTemporaryFolder = {
-            return $mockSourcePathUNC
-        }
-
-        $mockGetCimInstance_MSClusterResource = {
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_MSClusterNetwork = {
-            return @(
-                (
-                    $mockClusterSites | ForEach-Object {
-                        $network = $_
-
-                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
-            return @(
-                (
-                    @('Network Name','IP Address') | ForEach-Object {
-                        $resourceType = $_
-
-                        $propertyValue = @{
-                            MemberType = 'NoteProperty'
-                            Name = 'PrivateProperties'
-                            Value = $null
-                        }
-
-                        switch ($resourceType)
-                        {
-                            'Network Name'
-                            {
-                                $propertyValue.Value = @{ DnsName = $mockDefaultInstance_FailoverClusterNetworkName }
-                            }
-
-                            'IP Address'
-                            {
-                                $propertyValue.Value = @{ Address = $mockDefaultInstance_FailoverClusterIPAddress }
-                            }
-                        }
-
-                        return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
-                            Add-Member @propertyValue -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        # Mock to return physical disks that are part of the "Available Storage" cluster role
-        $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
-            return @(
-                (
-                    # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-                    (& $mockClusterDiskMap).Keys | ForEach-Object {
-                        $diskName = $_
-                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
-            return @(
-                (
-                    $mockClusterNodes | ForEach-Object {
-                        $node = $_
-                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
-            $clusterDiskName = $InputObject.Name
-
-            # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-            $clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
-
-            return @(
-                (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition','root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
-                )
-            )
-        }
-
+					} -PassThru -Force
+				)
+			)
+		}
+		
+		$mockRobocopyExecutableName = 'Robocopy.exe'
+		$mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
+		$mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
+		$mockRobocopyExectuableVersion = '' # Set dynamically during runtime
+		$mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
+		$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
+		$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
+		$mockRobocopyArgumentUseUnbufferedIO = '/J'
+		$mockRobocopyArgumentSourcePath = 'C:\Source\SQL2016'
+		$mockRobocopyArgumentDestinationPath = 'D:\Temp'
+		
+		$mockGetCommand = {
+			return @(
+				(
+					New-Object Object |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
+					Add-Member ScriptProperty FileVersionInfo {
+						return @((New-Object Object |
+								Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
+							))
+					} -PassThru -Force
+				)
+			)
+		}
+		
+		$mockStartProcessExpectedArgument = '' # Set dynamically during runtime
+		$mockStartProcessExitCode = 0 # Set dynamically during runtime
+		
+		$mockStartProcess = {
+			if ($ArgumentList -cne $mockStartProcessExpectedArgument)
+			{
+				throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
+			}
+			
+			return New-Object Object |
+			Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
+		}
+		
+		$mockStartProcess_WithExitCode = {
+			return New-Object Object |
+			Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
+		}
+		
+		$mockSourcePathUNCWithoutLeaf = '\\server\share'
+		$mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
+		$mockNewGuid = {
+			return New-Object Object |
+			Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
+		}
+		
+		$mockGetTemporaryFolder = {
+			return $mockSourcePathUNC
+		}
+		
+		$mockGetCimInstance_MSClusterResource = {
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Name }) -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Name }) -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Name }) -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Name }) -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Name }) -PassThru -Force
+				),
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Path }) -PassThru -Force |
+					Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Name }) -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimInstance_MSClusterNetwork = {
+			return @(
+				(
+					$mockClusterSites | ForEach-Object {
+						$network = $_
+						
+						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
+						Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
+						Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
+						Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
+					}
+				)
+			)
+		}
+		
+		$mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
+				)
+			)
+		}
+		
+		$mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
+			return @(
+				(
+					@('Network Name', 'IP Address') | ForEach-Object {
+						$resourceType = $_
+						
+						$propertyValue = @{
+							MemberType = 'NoteProperty'
+							Name = 'PrivateProperties'
+							Value = $null
+						}
+						
+						switch ($resourceType)
+						{
+							'Network Name'
+							{
+								$propertyValue.Value = @{ DnsName = $mockDefaultInstance_FailoverClusterNetworkName }
+							}
+							
+							'IP Address'
+							{
+								$propertyValue.Value = @{ Address = $mockDefaultInstance_FailoverClusterIPAddress }
+							}
+						}
+						
+						return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+						Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
+						Add-Member @propertyValue -PassThru -Force
+					}
+				)
+			)
+		}
+		
+		# Mock to return physical disks that are part of the "Available Storage" cluster role
+		$mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
+			return @(
+				(
+					# $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+					(& $mockClusterDiskMap).Keys | ForEach-Object {
+						$diskName = $_
+						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
+						Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
+						Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
+					}
+				)
+			)
+		}
+		
+		$mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
+			return @(
+				(
+					$mockClusterNodes | ForEach-Object {
+						$node = $_
+						New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
+						Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
+					}
+				)
+			)
+		}
+		
+		$mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
+			$clusterDiskName = $InputObject.Name
+			
+			# $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+			$clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
+			
+			return @(
+				(
+					New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition', 'root/MSCluster' |
+					Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
+				)
+			)
+		}
+		
         <#
         Needed a way to see into the Set-method for the arguments the Set-method is building and sending to 'setup.exe', and fail
         the test if the arguments is different from the expected arguments.
         Solved this by dynamically set the expected arguments before each It-block. If the arguments differs the mock of
         StartWin32Process throws an error message, similiar to what Pester would have reported (expected -> but was).
         #>
-        $mockStartWin32ProcessExpectedArgument = @{}
-
-        $mockStartWin32ProcessExpectedArgumentClusterDefault = @{
-            IAcceptSQLServerLicenseTerms = 'True'
-            Quiet = 'True'
-            InstanceName = 'MSSQLSERVER'
-            Features = 'SQLENGINE'
-            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-        }
-
-        $mockStartWin32Process = {
-            $argumentHashTable = @{}
-
-            # Break the argument string into a hash table
-            ($Arguments -split ' ?/') | ForEach-Object {
-                if ($_ -imatch '(\w+)="?([^/]+)"?')
-                {
-                    $key = $Matches[1]
-                    if ($key -in ('FailoverClusterDisks','FailoverClusterIPAddresses'))
-                    {
-                        $value = ($Matches[2] -replace '" "','; ') -replace '"',''
-                    }
-                    else
-                    {
-                        $value = ($Matches[2] -replace '" "',' ') -replace '"',''
-                    }
-
-                    $null = $argumentHashTable.Add($key, $value)
-                }
-            }
-
-            # Start by checking whether we have the same number of parameters
-            Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
-            Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',') ) -Verbose
-            Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
-
-            $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
-
-            Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
-            foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
-            {
-                $argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
-                $argumentKeyName | Should Be $argumentKey
-
-                $argumentValue = $argumentHashTable.$argumentKey
-                $argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
-            }
-
-            return 'Process Started'
-        }
-        #endregion Function mocks
-
-        # Default parameters that are used for the It-blocks
-        $mockDefaultParameters = @{
-            SetupCredential = $mockSetupCredential
+		$mockStartWin32ProcessExpectedArgument = @{ }
+		
+		$mockStartWin32ProcessExpectedArgumentClusterDefault = @{
+			IAcceptSQLServerLicenseTerms = 'True'
+			Quiet = 'True'
+			InstanceName = 'MSSQLSERVER'
+			Features = 'SQLENGINE'
+			SQLSysAdminAccounts = 'COMPANY\sqladmin'
+			FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+		}
+		
+		$mockStartWin32Process = {
+			$argumentHashTable = @{ }
+			
+			# Break the argument string into a hash table
+			($Arguments -split ' ?/') | ForEach-Object {
+				if ($_ -imatch '(\w+)="?([^/]+)"?')
+				{
+					$key = $Matches[1]
+					if ($key -in ('FailoverClusterDisks', 'FailoverClusterIPAddresses'))
+					{
+						$value = ($Matches[2] -replace '" "', '; ') -replace '"', ''
+					}
+					else
+					{
+						$value = ($Matches[2] -replace '" "', ' ') -replace '"', ''
+					}
+					
+					$null = $argumentHashTable.Add($key, $value)
+				}
+			}
+			
+			# Start by checking whether we have the same number of parameters
+			Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
+			Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',')) -Verbose
+			Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
+			
+			$argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
+			
+			Write-Verbose 'Verifying actual setup arguments against expected setup arguments' -Verbose
+			foreach ($argumentKey in $mockStartWin32ProcessExpectedArgument.Keys)
+			{
+				$argumentKeyName = $argumentHashTable.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq $argumentKey } | Select-Object -ExpandProperty Name
+				$argumentKeyName | Should Be $argumentKey
+				
+				$argumentValue = $argumentHashTable.$argumentKey
+				$argumentValue | Should Be $mockStartWin32ProcessExpectedArgument.$argumentKey
+			}
+			
+			return 'Process Started'
+		}
+		#endregion Function mocks
+		
+		# Default parameters that are used for the It-blocks
+		$mockDefaultParameters = @{
+			SetupCredential = $mockSetupCredential
             <#
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
-        }
-
-        $mockDefaultClusterParameters = @{
-            SetupCredential = $mockSetupCredential
-
-            # Feature support is tested elsewhere, so just include the minimum
-            Features = 'SQLEngine'
-
-        }
-
-        Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
-            #region Setting up TestDrive:\
-
-            # Local path to TestDrive:\
-            $mockSourcePath = $TestDrive.FullName
-
-            # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
-            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-
-            #endregion Setting up TestDrive:\
-
-            BeforeEach {
-                # General mocks
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-                } -MockWith $mockGetItemProperty_SQL -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    (
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-                    ) -and
-                    $Name -eq 'ImagePath'
-                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-
-                # Mocking SharedDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItem_SharedDirectory -Verifiable
-
-                # Mocking SharedWowDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-            }
-
-            $testProductVersion | ForEach-Object -Process {
-                $mockSqlMajorVersion = $_
-
-                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+			Features = 'SQLEngine,Replication,Conn,Bc,FullText,Rs,As,Is,Ssms,Adv_Ssms,SDK,DQ,DQC,BOL'
+		}
+		
+		$mockDefaultClusterParameters = @{
+			SetupCredential = $mockSetupCredential
+			
+			# Feature support is tested elsewhere, so just include the minimum
+			Features = 'SQLEngine'
+			
+		}
+		
+		Describe "xSQLServerSetup\Get-TargetResource" -Tag 'Get' {
+			#region Setting up TestDrive:\
+			
+			# Local path to TestDrive:\
+			$mockSourcePath = $TestDrive.FullName
+			
+			# UNC path to TestDrive:\
+			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+			
+			#endregion Setting up TestDrive:\
+			
+			BeforeEach {
+				# General mocks
+				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+				} -MockWith $mockGetItemProperty_SQL -Verifiable
+				
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					(
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+					) -and
+					$Name -eq 'ImagePath'
+				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+				
+				# Mocking SharedDirectory
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+				} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+				
+				Mock -CommandName Get-Item -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+				} -MockWith $mockGetItem_SharedDirectory -Verifiable
+				
+				# Mocking SharedWowDirectory
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+				} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+				
+				Mock -CommandName Get-Item -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+				} -MockWith $mockGetItem_SharedWowDirectory -Verifiable
+				
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+				} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+			}
+			
+			$testProductVersion | ForEach-Object -Process {
+				$mockSqlMajorVersion = $_
+				
+				$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+				
+				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+				$mockDynamicSqlTempDatabasePath = ''
+				$mockDynamicSqlTempDatabaseLogPath = ''
+				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+						}
+						else
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockEmptyHashtable -Verifiable
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                    }
-
-                    It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        $result.Features | Should Be ''
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePath
-                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstanceID | Should BeNullOrEmpty
-                        $result.InstallSharedDir | Should BeNullOrEmpty
-                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
-                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
-                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
-                        $result.SqlCollation | Should BeNullOrEmpty
-                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
-                        $result.SecurityMode | Should BeNullOrEmpty
-                        $result.InstallSQLDataDir | Should BeNullOrEmpty
-                        $result.SQLUserDBDir | Should BeNullOrEmpty
-                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
-                        $result.SQLBackupDir | Should BeNullOrEmpty
-                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
-                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASCollation | Should BeNullOrEmpty
-                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
-                        $result.ASDataDir | Should BeNullOrEmpty
-                        $result.ASLogDir | Should BeNullOrEmpty
-                        $result.ASBackupDir | Should BeNullOrEmpty
-                        $result.ASTempDir | Should BeNullOrEmpty
-                        $result.ASConfigDir | Should BeNullOrEmpty
-                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
-                    }
-                }
-
-                Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $mockSetupCredential
-                            SourcePath = $mockSourcePathUNC
-                        }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+					}
+					
+					It 'Should not return any names of installed features' {
+						$result = Get-TargetResource @testParameters
+						$result.Features | Should Be ''
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePath
+						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+						$result.InstanceID | Should BeNullOrEmpty
+						$result.InstallSharedDir | Should BeNullOrEmpty
+						$result.InstallSharedWOWDir | Should BeNullOrEmpty
+						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
+						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
+						$result.SqlCollation | Should BeNullOrEmpty
+						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
+						$result.SecurityMode | Should BeNullOrEmpty
+						$result.InstallSQLDataDir | Should BeNullOrEmpty
+						$result.SQLUserDBDir | Should BeNullOrEmpty
+						$result.SQLUserDBLogDir | Should BeNullOrEmpty
+						$result.SQLBackupDir | Should BeNullOrEmpty
+						$result.FTSvcAccountUsername | Should BeNullOrEmpty
+						$result.RSSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASCollation | Should BeNullOrEmpty
+						$result.ASSysAdminAccounts | Should BeNullOrEmpty
+						$result.ASDataDir | Should BeNullOrEmpty
+						$result.ASLogDir | Should BeNullOrEmpty
+						$result.ASBackupDir | Should BeNullOrEmpty
+						$result.ASTempDir | Should BeNullOrEmpty
+						$result.ASConfigDir | Should BeNullOrEmpty
+						$result.ISSvcAccountUsername | Should BeNullOrEmpty
+					}
+				}
+				
+				Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $mockSetupCredential
+							SourcePath = $mockSourcePathUNC
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+						}
+						else
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockEmptyHashtable -Verifiable
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                    }
-
-                    It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        $result.Features | Should Be ''
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePathUNC
-                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstanceID | Should BeNullOrEmpty
-                        $result.InstallSharedDir | Should BeNullOrEmpty
-                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
-                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
-                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
-                        $result.SqlCollation | Should BeNullOrEmpty
-                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
-                        $result.SecurityMode | Should BeNullOrEmpty
-                        $result.InstallSQLDataDir | Should BeNullOrEmpty
-                        $result.SQLUserDBDir | Should BeNullOrEmpty
-                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
-                        $result.SQLBackupDir | Should BeNullOrEmpty
-                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
-                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASCollation | Should BeNullOrEmpty
-                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
-                        $result.ASDataDir | Should BeNullOrEmpty
-                        $result.ASLogDir | Should BeNullOrEmpty
-                        $result.ASBackupDir | Should BeNullOrEmpty
-                        $result.ASTempDir | Should BeNullOrEmpty
-                        $result.ASConfigDir | Should BeNullOrEmpty
-                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN' and 'BC'" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+					}
+					
+					It 'Should not return any names of installed features' {
+						$result = Get-TargetResource @testParameters
+						$result.Features | Should Be ''
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePathUNC
+						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+						$result.InstanceID | Should BeNullOrEmpty
+						$result.InstallSharedDir | Should BeNullOrEmpty
+						$result.InstallSharedWOWDir | Should BeNullOrEmpty
+						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
+						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
+						$result.SqlCollation | Should BeNullOrEmpty
+						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
+						$result.SecurityMode | Should BeNullOrEmpty
+						$result.InstallSQLDataDir | Should BeNullOrEmpty
+						$result.SQLUserDBDir | Should BeNullOrEmpty
+						$result.SQLUserDBLogDir | Should BeNullOrEmpty
+						$result.SQLBackupDir | Should BeNullOrEmpty
+						$result.FTSvcAccountUsername | Should BeNullOrEmpty
+						$result.RSSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASCollation | Should BeNullOrEmpty
+						$result.ASSysAdminAccounts | Should BeNullOrEmpty
+						$result.ASDataDir | Should BeNullOrEmpty
+						$result.ASLogDir | Should BeNullOrEmpty
+						$result.ASBackupDir | Should BeNullOrEmpty
+						$result.ASTempDir | Should BeNullOrEmpty
+						$result.ASConfigDir | Should BeNullOrEmpty
+						$result.ISSvcAccountUsername | Should BeNullOrEmpty
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN' and 'BC'" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						if ($mockSqlMajorVersion -eq 10)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 11)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 12)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+						
+						#region Mock Get-CimInstance
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+						
+						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+						Mock -CommandName Get-CimInstance -MockWith {
+							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+						} -Verifiable
+						#endregion Mock Get-CimInstance
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
-                    }
-
-                    It 'Should return correct names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,FULLTEXT,RS,AS,IS'
-                        }
-                        else
-                        {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
-                        }
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
+					}
+					
+					It 'Should return correct names of installed features' {
+						$result = Get-TargetResource @testParameters
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,ADV_SDK'
+						}
+						else
+						{
+							$result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS,ADV_SDK'
+						}
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						if ($mockSqlMajorVersion -eq 10)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 11)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 12)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+						
+						#region Mock Get-CimInstance
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+						
+						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+						Mock -CommandName Get-CimInstance -MockWith {
+							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+						} -Verifiable
+						#endregion Mock Get-CimInstance
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
-                    }
-
-                    It 'Should return correct names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should Be $featuresForSqlServer2016
-                        }
-                        else
-                        {
-                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-                        }
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePath
-                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstanceID | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-                        $result.SqlCollation | Should Be $mockSqlCollation
-                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-                        $result.SecurityMode | Should Be 'Windows'
-                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
-                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-                    }
-                }
-
-                Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $mockSetupCredential
-                            SourcePath = $mockSourcePathUNC
-                        }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 1 -Scope It
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 0 -Scope It
+						}
+						else
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 2 -Scope It
+						}
+						
+						#region Assert Get-CimInstance
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+						} -Exactly -Times 1 -Scope It
+						#endregion Assert Get-CimInstance
+					}
+					
+					It 'Should return correct names of installed features' {
+						$result = Get-TargetResource @testParameters
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+							$result.Features | Should Be $featuresForSqlServer2016
+						}
+						else
+						{
+							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+						}
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePath
+						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+						$result.InstanceID | Should Be $mockDefaultInstance_InstanceName
+						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+						$result.SqlCollation | Should Be $mockSqlCollation
+						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+						$result.SecurityMode | Should Be 'Windows'
+						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASCollation | Should Be $mockSqlAnalysisCollation
+						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+					}
+				}
+				
+				Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $mockSetupCredential
+							SourcePath = $mockSourcePathUNC
+						}
+						
+						if ($mockSqlMajorVersion -eq 10)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 11)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 12)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+						
+						#region Mock Get-CimInstance
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+						} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+						
+						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+						Mock -CommandName Get-CimInstance -MockWith {
+							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+						} -Verifiable
+						#endregion Mock Get-CimInstance
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
-                    }
-
-                    It 'Should return correct names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should Be $featuresForSqlServer2016
-                        }
-                        else
-                        {
-                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-                        }
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePathUNC
-                        $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstanceID | Should Be $mockDefaultInstance_InstanceName
-                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-                        $result.SqlCollation | Should Be $mockSqlCollation
-                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-                        $result.SecurityMode | Should Be 'Windows'
-                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
-                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-                    }
-                }
-
-                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockNamedInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 1 -Scope It
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 0 -Scope It
+						}
+						else
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 2 -Scope It
+						}
+						
+						#region Assert Get-CimInstance
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+						} -Exactly -Times 1 -Scope It
+						#endregion Assert Get-CimInstance
+					}
+					
+					It 'Should return correct names of installed features' {
+						$result = Get-TargetResource @testParameters
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+							$result.Features | Should Be $featuresForSqlServer2016
+						}
+						else
+						{
+							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+						}
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePathUNC
+						$result.InstanceName | Should Be $mockDefaultInstance_InstanceName
+						$result.InstanceID | Should Be $mockDefaultInstance_InstanceName
+						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+						$result.SqlCollation | Should Be $mockSqlCollation
+						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+						$result.SecurityMode | Should Be 'Windows'
+						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASCollation | Should Be $mockSqlAnalysisCollation
+						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+					}
+				}
+				
+				$mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+				
+				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+				$mockDynamicSqlTempDatabasePath = ''
+				$mockDynamicSqlTempDatabaseLogPath = ''
+				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockNamedInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							# Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+						}
+						else
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockEmptyHashtable -Verifiable
+						}
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                    }
-
-                    It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        $result.Features | Should Be ''
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePath
-                        $result.InstanceName | Should Be $mockNamedInstance_InstanceName
-                        $result.InstanceID | Should BeNullOrEmpty
-                        $result.InstallSharedDir | Should BeNullOrEmpty
-                        $result.InstallSharedWOWDir | Should BeNullOrEmpty
-                        $result.SQLSvcAccountUsername | Should BeNullOrEmpty
-                        $result.AgtSvcAccountUsername | Should BeNullOrEmpty
-                        $result.SqlCollation | Should BeNullOrEmpty
-                        $result.SQLSysAdminAccounts | Should BeNullOrEmpty
-                        $result.SecurityMode | Should BeNullOrEmpty
-                        $result.InstallSQLDataDir | Should BeNullOrEmpty
-                        $result.SQLUserDBDir | Should BeNullOrEmpty
-                        $result.SQLUserDBLogDir | Should BeNullOrEmpty
-                        $result.SQLBackupDir | Should BeNullOrEmpty
-                        $result.FTSvcAccountUsername | Should BeNullOrEmpty
-                        $result.RSSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASSvcAccountUsername | Should BeNullOrEmpty
-                        $result.ASCollation | Should BeNullOrEmpty
-                        $result.ASSysAdminAccounts | Should BeNullOrEmpty
-                        $result.ASDataDir | Should BeNullOrEmpty
-                        $result.ASLogDir | Should BeNullOrEmpty
-                        $result.ASBackupDir | Should BeNullOrEmpty
-                        $result.ASTempDir | Should BeNullOrEmpty
-                        $result.ASConfigDir | Should BeNullOrEmpty
-                        $result.ISSvcAccountUsername | Should BeNullOrEmpty
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
-                            InstanceName = $mockNamedInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+					}
+					
+					It 'Should not return any names of installed features' {
+						$result = Get-TargetResource @testParameters
+						$result.Features | Should Be ''
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePath
+						$result.InstanceName | Should Be $mockNamedInstance_InstanceName
+						$result.InstanceID | Should BeNullOrEmpty
+						$result.InstallSharedDir | Should BeNullOrEmpty
+						$result.InstallSharedWOWDir | Should BeNullOrEmpty
+						$result.SQLSvcAccountUsername | Should BeNullOrEmpty
+						$result.AgtSvcAccountUsername | Should BeNullOrEmpty
+						$result.SqlCollation | Should BeNullOrEmpty
+						$result.SQLSysAdminAccounts | Should BeNullOrEmpty
+						$result.SecurityMode | Should BeNullOrEmpty
+						$result.InstallSQLDataDir | Should BeNullOrEmpty
+						$result.SQLUserDBDir | Should BeNullOrEmpty
+						$result.SQLUserDBLogDir | Should BeNullOrEmpty
+						$result.SQLBackupDir | Should BeNullOrEmpty
+						$result.FTSvcAccountUsername | Should BeNullOrEmpty
+						$result.RSSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASSvcAccountUsername | Should BeNullOrEmpty
+						$result.ASCollation | Should BeNullOrEmpty
+						$result.ASSysAdminAccounts | Should BeNullOrEmpty
+						$result.ASDataDir | Should BeNullOrEmpty
+						$result.ASLogDir | Should BeNullOrEmpty
+						$result.ASBackupDir | Should BeNullOrEmpty
+						$result.ASTempDir | Should BeNullOrEmpty
+						$result.ASConfigDir | Should BeNullOrEmpty
+						$result.ISSvcAccountUsername | Should BeNullOrEmpty
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters += @{
+							InstanceName = $mockNamedInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						if ($mockSqlMajorVersion -eq 10)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 11)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+						}
+						
+						if ($mockSqlMajorVersion -eq 12)
+						{
+							Mock -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+						}
+						
+						Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
+						
+						#region Mock Get-CimInstance
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
+						} -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
+						} -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
+						} -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
+						} -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
+						
+						Mock -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
+						} -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
+						
+						# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+						Mock -CommandName Get-CimInstance -MockWith {
+							throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+						} -Verifiable
+						#endregion Mock Get-CimInstance
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-                    }
-
-                    It 'Should return the same values as passed as parameters' {
-                        $result = Get-TargetResource @testParameters
-                        $result.InstanceName | Should Be $testParameters.InstanceName
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
-                    }
-
-                    It 'Should return correct names of installed features' {
-                        $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should Be $featuresForSqlServer2016
-                        }
-                        else
-                        {
-                            $result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
-                        }
-                    }
-
-                    It 'Should return the correct values in the hash table' {
-                        $result = Get-TargetResource @testParameters
-                        $result.SourcePath | Should Be $mockSourcePath
-                        $result.InstanceName | Should Be $mockNamedInstance_InstanceName
-                        $result.InstanceID | Should Be $mockNamedInstance_InstanceName
-                        $result.InstallSharedDir | Should Be $mockSqlSharedDirectory
-                        $result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
-                        $result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
-                        $result.SqlCollation | Should Be $mockSqlCollation
-                        $result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
-                        $result.SecurityMode | Should Be 'Windows'
-                        $result.InstallSQLDataDir | Should Be $mockSqlInstallPath
-                        $result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
-                        $result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
-                        $result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
-                        $result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
-                        $result.ASCollation | Should Be $mockSqlAnalysisCollation
-                        $result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
-                        $result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
-                        $result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
-                        $result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
-                        $result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
-                        $result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
-                        $result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
-
-                    BeforeAll {
-                        $testParams = $mockDefaultParameters.Clone()
-                        $testParams.Remove('Features')
-                        $testParams += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith {} -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should not attempt to collect cluster information for a standalone instance' {
-
-                        $currentState = Get-TargetResource @testParams
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
-
-                        $currentState.FailoverClusterGroupName | Should BeNullOrEmpty
-                        $currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
-                        $currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
-
-                    BeforeEach {
-                        $testParams = $mockDefaultParameters.Clone()
-                        $testParams.Remove('Features')
-                        $testParams += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                        }
-
-                        $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-
-                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-                            $Filter -eq "Type = 'SQL Server'"
-                        }
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                    }
-
-                    It 'Should collect information for a clustered instance' {
-                        $currentState = Get-TargetResource @testParams
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                        $currentState.InstanceName | Should Be $testParams.InstanceName
-                    }
-
-                    It 'Should return correct cluster information' {
-                        $currentState = Get-TargetResource @testParams
-
-                        $currentState.FailoverClusterGroupName | Should Be $mockDefaultInstance_FailoverClusterGroupName
-                        $currentState.FailoverClusterIPAddress | Should Be $mockDefaultInstance_FailoverClusterIPAddress
-                        $currentSTate.FailoverClusterNetworkName | Should Be $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "xSQLServerSetup\Test-TargetResource" -Tag 'Test' {
-            #region Setting up TestDrive:\
-
-            # Local path to TestDrive:\
-            $mockSourcePath = $TestDrive.FullName
-
-            # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
-            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-
-            #endregion Setting up TestDrive:\
-
-            BeforeEach {
-                # General mocks
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-                } -MockWith $mockGetItemProperty_SQL -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    (
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-                    ) -and
-                    $Name -eq 'ImagePath'
-                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-
-                # Mocking SharedDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItem_SharedDirectory -Verifiable
-
-                # Mocking SharedWowDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-            }
-
-            # For this test we only need to test one SQL Server version. Mocking SQL Server 2016 for the 'not in the desired state' test.
-            $mockSqlMajorVersion = 13
-
-            $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-
-            $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-            $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-            $mockDynamicSqlTempDatabasePath = ''
-            $mockDynamicSqlTempDatabaseLogPath = ''
-            $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-            $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-
-            Context 'When the system is not in the desired state' {
-                BeforeEach {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        InstanceName = $mockDefaultInstance_InstanceName
-                        SourceCredential = $null
-                        SourcePath = $mockSourcePath
-                    }
-
-                    # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -MockWith $mockGetItemProperty_Setup -Verifiable
-                }
-
-                It 'Should return that the desired state is absent when no products are installed' {
-                    Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                    Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -Exactly -Times 0 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -Exactly -Times 0 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -Exactly -Times 6 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                }
-
-                It 'Should return that the desired state is asbent when SSMS product is missing' {
-                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                    #region Mock Get-CimInstance
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                    Mock -CommandName Get-CimInstance -MockWith {
-                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                    } -Verifiable
-                    #endregion Mock Get-CimInstance
-
-                    # Change the default features for this test.
-                    $testParameters.Features = 'SSMS'
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -Exactly -Times 6 -Scope It
-
-                    #region Assert Get-CimInstance
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -Exactly -Times 1 -Scope It
-                    #endregion Assert Get-CimInstance
-                }
-
-                It 'Should return that the desired state is asbent when ADV_SSMS product is missing' {
-                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                    #region Mock Get-CimInstance
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                    Mock -CommandName Get-CimInstance -MockWith {
-                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                    } -Verifiable
-                    #endregion Mock Get-CimInstance
-
-                    # Change the default features for this test.
-                    $testParameters.Features = 'ADV_SSMS'
-
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -Exactly -Times 6 -Scope It
-
-                    #region Assert Get-CimInstance
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -Exactly -Times 1 -Scope It
-                    #endregion Assert Get-CimInstance
-                }
-
-                It 'Should return that the desired state is absent when a clustered instance cannot be found' {
-                    $testClusterParameters = $testParameters.Clone()
-
-                    $testClusterParameters += @{
-                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-
-                    $result = Test-TargetResource @testClusterParameters
-
-                    $result | Should Be $false
-                }
-
-                # This is a test for regression testing of issue #432
-                It 'Should return false if a SQL Server failover cluster is missing features' {
-                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        return @{
-                                Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
-                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            }
-                    } -Verifiable
-
-                    $testClusterParameters = $testParameters.Clone()
-                    $testClusterParameters['Features'] = 'SQLEngine,AS'
-
-                    $testClusterParameters += @{
-                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-
-                    $result = Test-TargetResource @testClusterParameters
-                    $result | Should Be $false
-                }
-            }
-
-            # For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.
-            $mockSqlMajorVersion = 12
-
-            Context "When the system is in the desired state" {
-                BeforeEach {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        InstanceName = $mockDefaultInstance_InstanceName
-                        SourceCredential = $null
-                        SourcePath = $mockSourcePath
-                    }
-
-                    # Mock all SSMS products.
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                    } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                    } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-
-                    Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                    #region Mock Get-CimInstance
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                    Mock -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                    # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                    Mock -CommandName Get-CimInstance -MockWith {
-                        throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                    } -Verifiable
-                    #endregion Mock Get-CimInstance
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                    } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-
-                    Mock -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -MockWith $mockGetItemProperty_Setup -Verifiable
-                }
-
-                It 'Should return that the desired state is present' {
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                        $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                    } -Exactly -Times 6 -Scope It
-
-                    #region Assert Get-CimInstance
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                    } -Exactly -Times 1 -Scope It
-
-                    Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and
-                        $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                    } -Exactly -Times 1 -Scope It
-                    #endregion Assert Get-CimInstance
-                }
-
-                It 'Should return that the desired state is present when the correct clustered instance was found' {
-                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-
-                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-                        $Filter -eq "Type = 'SQL Server'"
-                    }
-
-                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-
-                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                    $testClusterParameters = $testParameters.Clone()
-
-                    $testClusterParameters += @{
-                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-
-                    $result = Test-TargetResource @testClusterParameters
-
-                    $result | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                    Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
-                }
-
-                It 'Should not return false after a clustered install due to the presence of a variable called "FailoverClusterDisks"' {
-                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
-
-                    Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-                        $Filter -eq "Type = 'SQL Server'"
-                    }
-
-                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-
-                    Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                    $testClusterParameters = $testParameters.Clone()
-
-                    $testClusterParameters += @{
-                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-
-                    $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-                    $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-                    $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-                    $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-                    $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-                    $mockDynamicSqlBackupPath = $mockSqlBackupPath
-
-                    New-Variable -Name 'FailoverClusterDisks' -Value (& $mockClusterDiskMap)['UserData']
-
-                    $result = Test-TargetResource @testClusterParameters
-
-                    $result | Should Be $true
-                }
-
-                # This is a test for regression testing of issue #432
-                It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
-                    $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
-
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        return @{
-                                Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
-                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            }
-                    } -Verifiable
-
-                    $testClusterParameters = $testParameters.Clone()
-                    $testClusterParameters['Features'] = 'SQLEngine,AS'
-
-                    $testClusterParameters += @{
-                        FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                        FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                        FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                    }
-
-                    $result = Test-TargetResource @testClusterParameters
-                    $result | Should Be $true
-                }
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        Describe "xSQLServerSetup\Set-TargetResource" -Tag 'Set' {
-            #region Setting up TestDrive:\
-
-            # Local path to TestDrive:\
-            $mockSourcePath = $TestDrive.FullName
-
-            # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
-            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+					}
+					
+					It 'Should return the same values as passed as parameters' {
+						$result = Get-TargetResource @testParameters
+						$result.InstanceName | Should Be $testParameters.InstanceName
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -Exactly -Times 1 -Scope It
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 0 -Scope It
+						}
+						else
+						{
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 2 -Scope It
+						}
+						
+						#region Assert Get-CimInstance
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+						} -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							$ClassName -eq 'Win32_Service' -and
+							$Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
+						} -Exactly -Times 1 -Scope It
+						#endregion Assert Get-CimInstance
+					}
+					
+					It 'Should return correct names of installed features' {
+						$result = Get-TargetResource @testParameters
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+							$result.Features | Should Be $featuresForSqlServer2016
+						}
+						else
+						{
+							$result.Features | Should Be $mockDefaultParameters.Features.ToUpper()
+						}
+					}
+					
+					It 'Should return the correct values in the hash table' {
+						$result = Get-TargetResource @testParameters
+						$result.SourcePath | Should Be $mockSourcePath
+						$result.InstanceName | Should Be $mockNamedInstance_InstanceName
+						$result.InstanceID | Should Be $mockNamedInstance_InstanceName
+						$result.InstallSharedDir | Should Be $mockSqlSharedDirectory
+						$result.InstallSharedWOWDir | Should Be $mockSqlSharedWowDirectory
+						$result.SQLSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.AgtSvcAccountUsername | Should Be $mockAgentServiceAccount
+						$result.SqlCollation | Should Be $mockSqlCollation
+						$result.SQLSysAdminAccounts | Should Be $mockSqlSystemAdministrator
+						$result.SecurityMode | Should Be 'Windows'
+						$result.InstallSQLDataDir | Should Be $mockSqlInstallPath
+						$result.SQLUserDBDir | Should Be $mockSqlDefaultDatabaseFilePath
+						$result.SQLUserDBLogDir | Should Be $mockSqlDefaultDatabaseLogPath
+						$result.SQLBackupDir | Should Be $mockDynamicSqlBackupPath
+						$result.FTSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.RSSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASSvcAccountUsername | Should Be $mockSqlServiceAccount
+						$result.ASCollation | Should Be $mockSqlAnalysisCollation
+						$result.ASSysAdminAccounts | Should Be $mockSqlAnalysisAdmins
+						$result.ASDataDir | Should Be $mockSqlAnalysisDataDirectory
+						$result.ASLogDir | Should Be $mockSqlAnalysisLogDirectory
+						$result.ASBackupDir | Should Be $mockSqlAnalysisBackupDirectory
+						$result.ASTempDir | Should Be $mockSqlAnalysisTempDirectory
+						$result.ASConfigDir | Should Be $mockSqlAnalysisConfigDirectory
+						$result.ISSvcAccountUsername | Should Be $mockSqlServiceAccount
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
+					
+					BeforeAll {
+						$testParams = $mockDefaultParameters.Clone()
+						$testParams.Remove('Features')
+						$testParams += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith { } -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should not attempt to collect cluster information for a standalone instance' {
+						
+						$currentState = Get-TargetResource @testParams
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
+						
+						$currentState.FailoverClusterGroupName | Should BeNullOrEmpty
+						$currentState.FailoverClusterNetworkName | Should BeNullOrEmpty
+						$currentState.FailoverClusterIPAddress | Should BeNullOrEmpty
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
+					
+					BeforeEach {
+						$testParams = $mockDefaultParameters.Clone()
+						$testParams.Remove('Features')
+						$testParams += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+						}
+						
+						$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+						
+						Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+							$Filter -eq "Type = 'SQL Server'"
+						}
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+						
+						Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+					}
+					
+					It 'Should collect information for a clustered instance' {
+						$currentState = Get-TargetResource @testParams
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+						
+						$currentState.InstanceName | Should Be $testParams.InstanceName
+					}
+					
+					It 'Should return correct cluster information' {
+						$currentState = Get-TargetResource @testParams
+						
+						$currentState.FailoverClusterGroupName | Should Be $mockDefaultInstance_FailoverClusterGroupName
+						$currentState.FailoverClusterIPAddress | Should Be $mockDefaultInstance_FailoverClusterIPAddress
+						$currentSTate.FailoverClusterNetworkName | Should Be $mockDefaultInstance_FailoverClusterNetworkName
+					}
+				}
+			}
+			
+			Assert-VerifiableMocks
+		}
+		
+		Describe "xSQLServerSetup\Test-TargetResource" -Tag 'Test' {
+			#region Setting up TestDrive:\
+			
+			# Local path to TestDrive:\
+			$mockSourcePath = $TestDrive.FullName
+			
+			# UNC path to TestDrive:\
+			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+			
+			#endregion Setting up TestDrive:\
+			
+			BeforeEach {
+				# General mocks
+				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+				} -MockWith $mockGetItemProperty_SQL -Verifiable
+				
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					(
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+					) -and
+					$Name -eq 'ImagePath'
+				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+				
+				# Mocking SharedDirectory
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+				} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+				
+				Mock -CommandName Get-Item -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+				} -MockWith $mockGetItem_SharedDirectory -Verifiable
+				
+				# Mocking SharedWowDirectory
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+				} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+				
+				Mock -CommandName Get-Item -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+				} -MockWith $mockGetItem_SharedWowDirectory -Verifiable
+			}
+			
+			# For this test we only need to test one SQL Server version. Mocking SQL Server 2016 for the 'not in the desired state' test.
+			$mockSqlMajorVersion = 13
+			
+			$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+			
+			$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+			$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+			$mockDynamicSqlTempDatabasePath = ''
+			$mockDynamicSqlTempDatabaseLogPath = ''
+			$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+			$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+			
+			Context 'When the system is not in the desired state' {
+				BeforeEach {
+					$testParameters = $mockDefaultParameters
+					$testParameters += @{
+						InstanceName = $mockDefaultInstance_InstanceName
+						SourceCredential = $null
+						SourcePath = $mockSourcePath
+					}
+					
+					# Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+					} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+					} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -MockWith $mockGetItemProperty_Setup -Verifiable
+				}
+				
+				It 'Should return that the desired state is absent when no products are installed' {
+					Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+					
+					Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+					
+					$result = Test-TargetResource @testParameters
+					$result | Should Be $false
+					
+					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -Exactly -Times 0 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -Exactly -Times 0 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -Exactly -Times 6 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+				}
+				
+				It 'Should return that the desired state is asbent when SSMS product is missing' {
+					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+					
+					#region Mock Get-CimInstance
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+					
+					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+					Mock -CommandName Get-CimInstance -MockWith {
+						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+					} -Verifiable
+					#endregion Mock Get-CimInstance
+					
+					# Change the default features for this test.
+					$testParameters.Features = 'SSMS'
+					
+					$result = Test-TargetResource @testParameters
+					$result | Should Be $false
+					
+					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -Exactly -Times 6 -Scope It
+					
+					#region Assert Get-CimInstance
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -Exactly -Times 1 -Scope It
+					#endregion Assert Get-CimInstance
+				}
+				
+				It 'Should return that the desired state is asbent when ADV_SSMS product is missing' {
+					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+					
+					#region Mock Get-CimInstance
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+					
+					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+					Mock -CommandName Get-CimInstance -MockWith {
+						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+					} -Verifiable
+					#endregion Mock Get-CimInstance
+					
+					# Change the default features for this test.
+					$testParameters.Features = 'ADV_SSMS'
+					
+					$result = Test-TargetResource @testParameters
+					$result | Should Be $false
+					
+					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -Exactly -Times 6 -Scope It
+					
+					#region Assert Get-CimInstance
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -Exactly -Times 1 -Scope It
+					#endregion Assert Get-CimInstance
+				}
+				
+				It 'Should return that the desired state is absent when a clustered instance cannot be found' {
+					$testClusterParameters = $testParameters.Clone()
+					
+					$testClusterParameters += @{
+						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+					}
+					
+					$result = Test-TargetResource @testClusterParameters
+					
+					$result | Should Be $false
+				}
+				
+				# This is a test for regression testing of issue #432
+				It 'Should return false if a SQL Server failover cluster is missing features' {
+					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+					
+					Mock -CommandName Get-TargetResource -MockWith {
+						return @{
+							Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
+							FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+						}
+					} -Verifiable
+					
+					$testClusterParameters = $testParameters.Clone()
+					$testClusterParameters['Features'] = 'SQLEngine,AS'
+					
+					$testClusterParameters += @{
+						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+					}
+					
+					$result = Test-TargetResource @testClusterParameters
+					$result | Should Be $false
+				}
+			}
+			
+			# For this test we only need to test one SQL Server version. Mocking SQL Server 2014 for the 'in the desired state' test.
+			$mockSqlMajorVersion = 12
+			
+			Context "When the system is in the desired state" {
+				BeforeEach {
+					$testParameters = $mockDefaultParameters
+					$testParameters += @{
+						InstanceName = $mockDefaultInstance_InstanceName
+						SourceCredential = $null
+						SourcePath = $mockSourcePath
+					}
+					
+					# Mock all SSMS products.
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+					} -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+					} -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
+					
+					Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
+					
+					#region Mock Get-CimInstance
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
+					
+					Mock -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
+					
+					# If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+					Mock -CommandName Get-CimInstance -MockWith {
+						throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
+					} -Verifiable
+					#endregion Mock Get-CimInstance
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
+					} -MockWith $mockGetItemProperty_DQFeature -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+					} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+					} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+					
+					Mock -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -MockWith $mockGetItemProperty_Setup -Verifiable
+				}
+				
+				It 'Should return that the desired state is present' {
+					$result = Test-TargetResource @testParameters
+					$result | Should Be $true
+					
+					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+						$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+					} -Exactly -Times 6 -Scope It
+					
+					#region Assert Get-CimInstance
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
+					} -Exactly -Times 1 -Scope It
+					
+					Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+						$ClassName -eq 'Win32_Service' -and
+						$Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
+					} -Exactly -Times 1 -Scope It
+					#endregion Assert Get-CimInstance
+				}
+				
+				It 'Should return that the desired state is present when the correct clustered instance was found' {
+					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+					
+					Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+					
+					Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+						$Filter -eq "Type = 'SQL Server'"
+					}
+					
+					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+					
+					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+					
+					$testClusterParameters = $testParameters.Clone()
+					
+					$testClusterParameters += @{
+						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+					}
+					
+					$result = Test-TargetResource @testClusterParameters
+					
+					$result | Should Be $true
+					
+					Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+					Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
+				}
+				
+				It 'Should not return false after a clustered install due to the presence of a variable called "FailoverClusterDisks"' {
+					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+					
+					Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+					
+					Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
+						$Filter -eq "Type = 'SQL Server'"
+					}
+					
+					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+					
+					Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+					
+					$testClusterParameters = $testParameters.Clone()
+					
+					$testClusterParameters += @{
+						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+					}
+					
+					$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+					$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+					$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+					$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+					$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+					$mockDynamicSqlBackupPath = $mockSqlBackupPath
+					
+					New-Variable -Name 'FailoverClusterDisks' -Value (& $mockClusterDiskMap)['UserData']
+					
+					$result = Test-TargetResource @testClusterParameters
+					
+					$result | Should Be $true
+				}
+				
+				# This is a test for regression testing of issue #432
+				It 'Should return true if a SQL Server failover cluster has all features and is in desired state' {
+					$mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+					
+					Mock -CommandName Get-TargetResource -MockWith {
+						return @{
+							Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
+							FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+						}
+					} -Verifiable
+					
+					$testClusterParameters = $testParameters.Clone()
+					$testClusterParameters['Features'] = 'SQLEngine,AS'
+					
+					$testClusterParameters += @{
+						FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+						FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+						FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+					}
+					
+					$result = Test-TargetResource @testClusterParameters
+					$result | Should Be $true
+				}
+			}
+			
+			Assert-VerifiableMocks
+		}
+		
+		Describe "xSQLServerSetup\Set-TargetResource" -Tag 'Set' {
+			#region Setting up TestDrive:\
+			
+			# Local path to TestDrive:\
+			$mockSourcePath = $TestDrive.FullName
+			
+			# UNC path to TestDrive:\
+			$testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+			$mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+			
             <#
                 Mocking folder structure. This takes the leaf from the $mockSourcePath (the Guid in this case) and
                 uses that to create a mock folder to mimic the temp folder that would be created in, for example,
                 temp folder 'C:\Windows\Temp'.
                 This folder is used when SourcePath is called with a leaf, for example '\\server\share\folder'.
             #>
-            $mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
-            if (-not (Test-Path $mediaTempSourcePathWithLeaf))
-            {
-                New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
-            }
-
+			$mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
+			if (-not (Test-Path $mediaTempSourcePathWithLeaf))
+			{
+				New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
+			}
+			
             <#
                 Mocking folder structure. This takes the leaf from the New-Guid mock and uses that
                 to create a mock folder to mimic the temp folder that would be created in, for example,
                 temp folder 'C:\Windows\Temp'.
                 This folder is used when SourcePath is called without a leaf, for example '\\server\share'.
             #>
-            $mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
-            if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
-            {
-                New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
-            }
-
-            # Mocking executable setup.exe which will be used for tests without parameter SourceCredential
-            Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
-            Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
-            Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            #endregion Setting up TestDrive:\
-
-            BeforeEach {
-                # General mocks
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-                } -MockWith $mockGetItemProperty_SQL -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    (
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-                    ) -and
-                    $Name -eq 'ImagePath'
-                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
-
-                # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
-                Mock -CommandName Get-ItemProperty -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-
-                Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
-                Mock -CommandName WaitForWin32ProcessEnd -Verifiable
-                Mock -CommandName Test-TargetResource -MockWith {
-                    return $true
-                } -Verifiable
-            }
-
-            $testProductVersion | ForEach-Object -Process {
-                $mockSqlMajorVersion = $_
-
-                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-                    BeforeEach {
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Start-Process -Verifiable
-                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                            ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-                            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
-                            ASSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
-                            InstanceDir = 'D:'
-                            InstallSQLDataDir = 'E:'
-                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
-                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
-                        }
-
-                        if ( $mockSqlMajorVersion -in (13,14) )
-                        {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
-                        }
-
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            Quiet = 'True'
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            Action = 'Install'
-                            AGTSVCSTARTUPTYPE = 'Automatic'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = $testParameters.Features
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-                            ASSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-                            PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-                            InstanceDir = 'D:\'
-                            InstallSQLDataDir = 'E:\'
-                            InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
-                            InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                            ($Name -eq $mockDefaultInstance_InstanceName)
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    }
-
-                    if( $mockSqlMajorVersion -in (13,14) )
-                    {
-                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-                            $testParameters = $mockDefaultParameters.Clone()
-                            $testParameters += @{
-                                InstanceName = $mockDefaultInstance_InstanceName
-                                SourceCredential = $null
-                                SourcePath = $mockSourcePath
-                            }
-
-                            $testParameters.Features = 'SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-
-                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-                            $testParameters = $mockDefaultParameters.Clone()
-                            $testParameters += @{
-                                InstanceName = $mockDefaultInstance_InstanceName
-                                SourceCredential = $null
-                                SourcePath = $mockSourcePath
-                            }
-
-                            $testParameters.Features = 'ADV_SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-                    }
-                    else
-                    {
-                        It 'Should set the system in the desired state when feature is SSMS' {
-                            $testParameters = $mockDefaultParameters.Clone()
-                            $testParameters += @{
-                                InstanceName = $mockDefaultInstance_InstanceName
-                                SourceCredential = $null
-                                SourcePath = $mockSourcePath
-                            }
-
-                            $testParameters.Features = 'SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-
-                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
-                            $testParameters = $mockDefaultParameters.Clone()
-                            $testParameters += @{
-                                InstanceName = $mockDefaultInstance_InstanceName
-                                SourceCredential = $null
-                                SourcePath = $mockSourcePath
-                            }
-
-                            $testParameters.Features = 'ADV_SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'ADV_SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-                    }
-                }
-
-                Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $mockSetupCredential
-                            SourcePath = $mockSourcePathUNC
-                        }
-
-                        if ( $mockSqlMajorVersion -in (13,14) )
-                        {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
-                        }
-
-                        # Mocking SharedDirectory (when previously installed and should not be installed again).
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
-                        } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
-
-                        # Mocking SharedWowDirectory (when previously installed and should not be installed again).
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                        } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Start-Process -Verifiable
-                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
-
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            Quiet = 'True'
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            Action = 'Install'
-                            AgtSvcStartupType = 'Automatic'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = $testParameters.Features
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            ASSysAdminAccounts = 'COMPANY\sqladmin'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
-                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                            ($Name -eq $mockDefaultInstance_InstanceName)
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-
-                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    }
-
-                    if( $mockSqlMajorVersion -in (13,14) )
-                    {
-                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = 'SSMS'
-                            $mockStartWin32ProcessExpectedArgument = ''
-
-                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-
-                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = 'ADV_SSMS'
-                            $mockStartWin32ProcessExpectedArgument = ''
-
-                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-                    }
-                    else
-                    {
-                        It 'Should set the system in the desired state when feature is SSMS' {
-                            $testParameters.Features = 'SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-
-                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
-                            $testParameters.Features = 'ADV_SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'ADV_SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-                    }
-                }
-
-                Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = $mockDefaultInstance_InstanceName
-                            SourceCredential = $mockSetupCredential
-                            SourcePath = $mockSourcePathUNCWithoutLeaf
-                            ForceReboot = $true
-                            SuppressReboot = $true
-                        }
-
-                        if ( $mockSqlMajorVersion -in (13,14) )
-                        {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
-                        }
-
-                        Mock -CommandName New-SmbMapping -Verifiable
-                        Mock -CommandName Remove-SmbMapping -Verifiable
-                        Mock -CommandName Start-Process -Verifiable
-                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-                        Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            Quiet = 'True'
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            Action = 'Install'
-                            AGTSVCSTARTUPTYPE = 'Automatic'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = $testParameters.Features
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            ASSysAdminAccounts = 'COMPANY\sqladmin'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-
-                        Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
-                        Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
-                        Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName New-Guid -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                            ($Name -eq $mockDefaultInstance_InstanceName)
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-
-                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    }
-
-                    if( $mockSqlMajorVersion -in (13,14) )
-                    {
-                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = 'SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-
-                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = 'ADV_SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-                    }
-                    else
-                    {
-                        It 'Should set the system in the desired state when feature is SSMS' {
-                            $testParameters.Features = 'SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-
-                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
-                            $testParameters.Features = 'ADV_SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'MSSQLSERVER'
-                                Features = 'ADV_SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-                    }
-                }
-
-                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = $mockNamedInstance_InstanceName
-                            SourceCredential = $null
-                            SourcePath = $mockSourcePath
-                            ForceReboot = $true
-                        }
-
-                        if ( $mockSqlMajorVersion -in (13,14) )
-                        {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
-                        }
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            Quiet = 'True'
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            Action = 'Install'
-                            AGTSVCSTARTUPTYPE = 'Automatic'
-                            InstanceName = 'TEST'
-                            Features = $testParameters.Features
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            ASSysAdminAccounts = 'COMPANY\sqladmin'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                            ($Name -eq $mockDefaultInstance_InstanceName)
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    }
-
-                    if( $mockSqlMajorVersion -in (13,14) )
-                    {
-                        It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-
-                        It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
-                            $testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
-                            $mockStartWin32ProcessExpectedArgument = @{}
-
-                            { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
-                        }
-                    }
-                    else
-                    {
-                        It 'Should set the system in the desired state when feature is SSMS' {
-                            $testParameters.Features = 'SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'TEST'
-                                Features = 'SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-
-                        It 'Should set the system in the desired state when feature is ADV_SSMS' {
-                            $testParameters.Features = 'ADV_SSMS'
-
-                            $mockStartWin32ProcessExpectedArgument = @{
-                                Quiet = 'True'
-                                IAcceptSQLServerLicenseTerms = 'True'
-                                Action = 'Install'
-                                InstanceName = 'TEST'
-                                Features = 'ADV_SSMS'
-                            }
-
-                            { Set-TargetResource @testParameters } | Should Not Throw
-
-                            Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                                ($Name -eq $mockDefaultInstance_InstanceName)
-                            } -Exactly -Times 0 -Scope It
-
-                            Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 6 -Scope It
-
-                            Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                            Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                        }
-                    }
-                }
-
-                # For testing AddNode action
-                Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
-                    BeforeAll {
-                        $testParameters = $mockDefaultClusterParameters.Clone()
-                        $testParameters['Features'] += 'AS'
-                        $testParameters += @{
-                            InstanceName = 'MSSQLSERVER'
-                            SourcePath = $mockSourcePath
-                            Action = 'AddNode'
-                            AgtSvcAccount = $mockSQLAgentCredential
-                            SqlSvcAccount = $mockSQLServiceCredential
-                            ASSvcAccount = $mockAnalysisServiceCredential
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                        }
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-                            $Filter -eq "Name = 'Available Storage'"
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-                            $ResultClassName -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-                        } -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                    }
-
-                    It 'Should pass proper parameters to setup' {
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            Quiet = 'True'
-                            Action = 'AddNode'
-                            InstanceName = 'MSSQLSERVER'
-                            AgtSvcAccount = $mockAgentServiceAccount
-                            AgtSvcPassword = $mockSqlAgentCredential.GetNetworkCredential().Password
-                            SqlSvcAccount = $mockSqlServiceAccount
-                            SqlSvcPassword = $mockSQLServiceCredential.GetNetworkCredential().Password
-                            AsSvcAccount = $mockAnalysisServiceAccount
-                            AsSvcPassword = $mockAnalysisServiceCredential.GetNetworkCredential().Password
-                            SkipRules = 'Cluster_VerifyForErrors'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass the SetupCredential object to the StartWin32Process function' {
-                        $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not BeNullOrEmpty
-                            return 'Process started.'
-                        }
-
-                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-                }
-
-                # For testing InstallFailoverCluster action
-                Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
-                    BeforeAll {
-                        $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-                        $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-                        $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-                        $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-                        $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-                        $mockDynamicSqlBackupPath = $mockSqlBackupPath
-
-                        $testParameters = $mockDefaultClusterParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = 'MSSQLSERVER'
-                            SourcePath = $mockSourcePath
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-
-                            # Ensure we use "clustered" disks for our paths
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDbDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                        }
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-                            $Filter -eq "Name = 'Available Storage'"
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-                            $ResultClassName -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+			$mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
+			if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
+			{
+				New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
+			}
+			
+			# Mocking executable setup.exe which will be used for tests without parameter SourceCredential
+			Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
+			
+			# Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
+			Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+			
+			# Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
+			Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+			
+			#endregion Setting up TestDrive:\
+			
+			BeforeEach {
+				# General mocks
+				Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+				Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+				Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+					($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
+				} -MockWith $mockGetItemProperty_SQL -Verifiable
+				
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					(
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
+						$Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
+					) -and
+					$Name -eq 'ImagePath'
+				} -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+				
+				# Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
+				Mock -CommandName Get-ItemProperty -Verifiable
+				
+				Mock -CommandName Get-ItemProperty -ParameterFilter {
+					$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+				} -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+				
+				Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
+				Mock -CommandName WaitForWin32ProcessEnd -Verifiable
+				Mock -CommandName Test-TargetResource -MockWith {
+					return $true
+				} -Verifiable
+			}
+			
+			$testProductVersion | ForEach-Object -Process {
+				$mockSqlMajorVersion = $_
+				
+				$mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+				
+				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+				$mockDynamicSqlTempDatabasePath = ''
+				$mockDynamicSqlTempDatabaseLogPath = ''
+				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+					BeforeEach {
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Start-Process -Verifiable
+						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should set the system in the desired state when feature is SQLENGINE' {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+							ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+							SQLSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
+							ASSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
+							InstanceDir = 'D:'
+							InstallSQLDataDir = 'E:'
+							InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+							InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+						}
+						
+						$mockStartWin32ProcessExpectedArgument = @{
+							Quiet = 'True'
+							IAcceptSQLServerLicenseTerms = 'True'
+							Action = 'Install'
+							AGTSVCSTARTUPTYPE = 'Automatic'
+							InstanceName = 'MSSQLSERVER'
+							Features = $testParameters.Features
+							SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+							ASSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+							PID = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
+							InstanceDir = 'D:\'
+							InstallSQLDataDir = 'E:\'
+							InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
+							InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Start-Process -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+							($Name -eq $mockDefaultInstance_InstanceName)
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+					}
+					
+					if ($mockSqlMajorVersion -in (13, 14))
+					{
+						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+							$testParameters = $mockDefaultParameters.Clone()
+							$testParameters += @{
+								InstanceName = $mockDefaultInstance_InstanceName
+								SourceCredential = $null
+								SourcePath = $mockSourcePath
+							}
+							
+							$testParameters.Features = 'SSMS'
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+						
+						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+							$testParameters = $mockDefaultParameters.Clone()
+							$testParameters += @{
+								InstanceName = $mockDefaultInstance_InstanceName
+								SourceCredential = $null
+								SourcePath = $mockSourcePath
+							}
+							
+							$testParameters.Features = 'ADV_SSMS'
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+					}
+					else
+					{
+						It 'Should set the system in the desired state when feature is SSMS' {
+							$testParameters = $mockDefaultParameters.Clone()
+							$testParameters += @{
+								InstanceName = $mockDefaultInstance_InstanceName
+								SourceCredential = $null
+								SourcePath = $mockSourcePath
+							}
+							
+							$testParameters.Features = 'SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+						
+						It 'Should set the system in the desired state when feature is ADV_SSMS' {
+							$testParameters = $mockDefaultParameters.Clone()
+							$testParameters += @{
+								InstanceName = $mockDefaultInstance_InstanceName
+								SourceCredential = $null
+								SourcePath = $mockSourcePath
+							}
+							
+							$testParameters.Features = 'ADV_SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'ADV_SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+					}
+				}
+				
+				Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $mockSetupCredential
+							SourcePath = $mockSourcePathUNC
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+						}
+						
+						# Mocking SharedDirectory (when previously installed and should not be installed again).
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
+						} -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+						
+						# Mocking SharedWowDirectory (when previously installed and should not be installed again).
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
+						} -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Start-Process -Verifiable
+						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should set the system in the desired state when feature is SQLENGINE' {
+						
+						$mockStartWin32ProcessExpectedArgument = @{
+							Quiet = 'True'
+							IAcceptSQLServerLicenseTerms = 'True'
+							Action = 'Install'
+							AgtSvcStartupType = 'Automatic'
+							InstanceName = 'MSSQLSERVER'
+							Features = $testParameters.Features
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							ASSysAdminAccounts = 'COMPANY\sqladmin'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
+						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName New-Guid -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+							($Name -eq $mockDefaultInstance_InstanceName)
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						
+						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+					}
+					
+					if ($mockSqlMajorVersion -in (13, 14))
+					{
+						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = 'SSMS'
+							$mockStartWin32ProcessExpectedArgument = ''
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+						
+						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = 'ADV_SSMS'
+							$mockStartWin32ProcessExpectedArgument = ''
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+					}
+					else
+					{
+						It 'Should set the system in the desired state when feature is SSMS' {
+							$testParameters.Features = 'SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+						
+						It 'Should set the system in the desired state when feature is ADV_SSMS' {
+							$testParameters.Features = 'ADV_SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'ADV_SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+					}
+				}
+				
+				Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters += @{
+							InstanceName = $mockDefaultInstance_InstanceName
+							SourceCredential = $mockSetupCredential
+							SourcePath = $mockSourcePathUNCWithoutLeaf
+							ForceReboot = $true
+							SuppressReboot = $true
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+						}
+						
+						Mock -CommandName New-SmbMapping -Verifiable
+						Mock -CommandName Remove-SmbMapping -Verifiable
+						Mock -CommandName Start-Process -Verifiable
+						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+						Mock -CommandName New-Guid -MockWith $mockNewGuid -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should set the system in the desired state when feature is SQLENGINE' {
+						$mockStartWin32ProcessExpectedArgument = @{
+							Quiet = 'True'
+							IAcceptSQLServerLicenseTerms = 'True'
+							Action = 'Install'
+							AGTSVCSTARTUPTYPE = 'Automatic'
+							InstanceName = 'MSSQLSERVER'
+							Features = $testParameters.Features
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							ASSysAdminAccounts = 'COMPANY\sqladmin'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+						
+						Assert-MockCalled -CommandName New-SmbMapping -Exactly -Times 2 -Scope It
+						Assert-MockCalled -CommandName Remove-SmbMapping -Exactly -Times 2 -Scope It
+						Assert-MockCalled -CommandName Get-TemporaryFolder -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName New-Guid -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+							($Name -eq $mockDefaultInstance_InstanceName)
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						
+						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+					}
+					
+					if ($mockSqlMajorVersion -in (13, 14))
+					{
+						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = 'SSMS'
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+						
+						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = 'ADV_SSMS'
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+					}
+					else
+					{
+						It 'Should set the system in the desired state when feature is SSMS' {
+							$testParameters.Features = 'SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+						
+						It 'Should set the system in the desired state when feature is ADV_SSMS' {
+							$testParameters.Features = 'ADV_SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'MSSQLSERVER'
+								Features = 'ADV_SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+					}
+				}
+				
+				$mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+				
+				$mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+				$mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+				$mockDynamicSqlTempDatabasePath = ''
+				$mockDynamicSqlTempDatabaseLogPath = ''
+				$mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+				$mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
+					BeforeEach {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters += @{
+							InstanceName = $mockNamedInstance_InstanceName
+							SourceCredential = $null
+							SourcePath = $mockSourcePath
+							ForceReboot = $true
+						}
+						
+						if ($mockSqlMajorVersion -in (13, 14))
+						{
+							$testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+						}
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should set the system in the desired state when feature is SQLENGINE' {
+						$mockStartWin32ProcessExpectedArgument = @{
+							Quiet = 'True'
+							IAcceptSQLServerLicenseTerms = 'True'
+							Action = 'Install'
+							AGTSVCSTARTUPTYPE = 'Automatic'
+							InstanceName = 'TEST'
+							Features = $testParameters.Features
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							ASSysAdminAccounts = 'COMPANY\sqladmin'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+							($Name -eq $mockDefaultInstance_InstanceName)
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+							$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+						} -Exactly -Times 6 -Scope It
+						
+						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+					}
+					
+					if ($mockSqlMajorVersion -in (13, 14))
+					{
+						It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+						
+						It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
+							$testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
+							$mockStartWin32ProcessExpectedArgument = @{ }
+							
+							{ Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
+						}
+					}
+					else
+					{
+						It 'Should set the system in the desired state when feature is SSMS' {
+							$testParameters.Features = 'SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'TEST'
+								Features = 'SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+						
+						It 'Should set the system in the desired state when feature is ADV_SSMS' {
+							$testParameters.Features = 'ADV_SSMS'
+							
+							$mockStartWin32ProcessExpectedArgument = @{
+								Quiet = 'True'
+								IAcceptSQLServerLicenseTerms = 'True'
+								Action = 'Install'
+								InstanceName = 'TEST'
+								Features = 'ADV_SSMS'
+							}
+							
+							{ Set-TargetResource @testParameters } | Should Not Throw
+							
+							Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+								($Name -eq $mockDefaultInstance_InstanceName)
+							} -Exactly -Times 0 -Scope It
+							
+							Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+							Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
+								$Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+							} -Exactly -Times 6 -Scope It
+							
+							Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+							Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						}
+					}
+				}
+				
+				# For testing AddNode action
+				Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
+					BeforeAll {
+						$testParameters = $mockDefaultClusterParameters.Clone()
+						$testParameters['Features'] += 'AS'
+						$testParameters += @{
+							InstanceName = 'MSSQLSERVER'
+							SourcePath = $mockSourcePath
+							Action = 'AddNode'
+							AgtSvcAccount = $mockSQLAgentCredential
+							SqlSvcAccount = $mockSQLServiceCredential
+							ASSvcAccount = $mockAnalysisServiceCredential
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+						}
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+							$Filter -eq "Name = 'Available Storage'"
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+						} -Verfiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+							$Association -eq 'MSCluster_ResourceToPossibleOwner'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+							$ResultClassName -eq 'MSCluster_DiskPartition'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolume'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+						} -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+					}
+					
+					It 'Should pass proper parameters to setup' {
+						$mockStartWin32ProcessExpectedArgument = @{
+							IAcceptSQLServerLicenseTerms = 'True'
+							Quiet = 'True'
+							Action = 'AddNode'
+							InstanceName = 'MSSQLSERVER'
+							AgtSvcAccount = $mockAgentServiceAccount
+							AgtSvcPassword = $mockSqlAgentCredential.GetNetworkCredential().Password
+							SqlSvcAccount = $mockSqlServiceAccount
+							SqlSvcPassword = $mockSQLServiceCredential.GetNetworkCredential().Password
+							AsSvcAccount = $mockAnalysisServiceAccount
+							AsSvcPassword = $mockAnalysisServiceCredential.GetNetworkCredential().Password
+							SkipRules = 'Cluster_VerifyForErrors'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should pass the SetupCredential object to the StartWin32Process function' {
+						$mockStartWin32Process_SetupCredential = {
+							$Credential | Should Not BeNullOrEmpty
+							return 'Process started.'
+						}
+						
+						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+				}
+				
+				# For testing InstallFailoverCluster action
+				Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
+					BeforeAll {
+						$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+						$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+						$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+						$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+						$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+						$mockDynamicSqlBackupPath = $mockSqlBackupPath
+						
+						$testParameters = $mockDefaultClusterParameters.Clone()
+						$testParameters += @{
+							InstanceName = 'MSSQLSERVER'
+							SourcePath = $mockSourcePath
+							Action = 'InstallFailoverCluster'
+							FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+							
+							# Ensure we use "clustered" disks for our paths
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDbDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+						}
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+							$Filter -eq "Name = 'Available Storage'"
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+						} -Verfiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+							$Association -eq 'MSCluster_ResourceToPossibleOwner'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+							$ResultClassName -eq 'MSCluster_DiskPartition'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolume'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+						} -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                    }
-
-                    It 'Should pass proper parameters to setup' {
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass proper parameters to setup when only InstallSQLDataDir is assigned a path' {
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterDisks = 'SysData'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                        }
-
-                        $setTargetResourceParameters = $testParameters.Clone()
-                        $setTargetResourceParameters.Remove('SQLUserDBDir')
-                        $setTargetResourceParameters.Remove('SQLUserDBLogDir')
-                        $setTargetResourceParameters.Remove('SQLTempDbDir')
-                        $setTargetResourceParameters.Remove('SQLTempDbLogDir')
-                        $setTargetResourceParameters.Remove('SQLBackupDir')
-
-                        { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass proper parameters to setup when three variables are assigned the same drive, but different paths' {
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterDisks = 'SysData'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            InstallSQLDataDir = 'E:\SQLData'
-                            SQLUserDBDir = 'E:\SQLData\UserDb'
-                            SQLUserDBLogDir = 'E:\SQLData\UserDbLogs'
-                        }
-
-                        $setTargetResourceParameters = $testParameters.Clone()
-                        $setTargetResourceParameters.Remove('SQLTempDbDir')
-                        $setTargetResourceParameters.Remove('SQLTempDbLogDir')
-                        $setTargetResourceParameters.Remove('SQLBackupDir')
-
-                        $setTargetResourceParameters['InstallSQLDataDir'] = 'E:\SQLData\' # This ends with \ to test removal of paths ending with \
-                        $setTargetResourceParameters['SQLUserDBDir'] = 'E:\SQLData\UserDb'
-                        $setTargetResourceParameters['SQLUserDBLogDir'] = 'E:\SQLData\UserDbLogs'
-
-                        { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass the SetupCredential object to the StartWin32Process function' {
-                        $mockStartWin32Process_SetupCredential = {
-                            $Credential | Should Not BeNullOrEmpty
-                            return 'Process started.'
-                        }
-
-                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should throw an error when one or more paths are not resolved to clustered storage' {
-                        $badPathParameters = $testParameters.Clone()
-
-                        # Pass in a bad path
-                        $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-
-                        { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
-                    }
-
-                    It 'Should properly map paths to clustered disk resources' {
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should build a DEFAULT address string when no network is specified' {
-                        $missingNetworkParams = $testParameters.Clone()
-                        $missingNetworkParams.Remove('FailoverClusterIPAddress')
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'InstallFailoverCluster'
-                            FailoverClusterIPAddresses = 'DEFAULT'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                        }
-
-                        { Set-TargetResource @missingNetworkParams } | Should Not Throw
-                    }
-
-                    It 'Should throw an error when an invalid IP Address is specified' {
-                        $invalidAddressParameters = $testParameters.Clone()
-
-                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
-                        $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = '192.168.0.100'
-                        }
-
-                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-                    }
-
-                    It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
-                        $invalidAddressParameters = $testParameters.Clone()
-
-                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
-                        $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = @('10.0.0.100','192.168.0.100')
-                        }
-
-                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-                    }
-
-                    It 'Should build a valid IP address string for a single address' {
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Action = 'InstallFailoverCluster'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should build a valid IP address string for a multi-subnet cluster' {
-                        $multiSubnetParameters = $testParameters.Clone()
-                        $multiSubnetParameters.Remove('FailoverClusterIPAddress')
-                        $multiSubnetParameters += @{
-                            FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
-                        }
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Action = 'InstallFailoverCluster'
-                        }
-
-                        { Set-TargetResource @multiSubnetParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
-                        $csvTestParameters = $testParameters.Clone()
-
-                        $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['SysData'].Path
-                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
-                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
-                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
-                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
-                        $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path
-
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Quiet = 'True'
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            Action = 'InstallFailoverCluster'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = 'SQLEngine'
-                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name); $($mockCSVClusterDiskMap['UserLogs'].Name); $($mockCSVClusterDiskMap['SysData'].Name); $($mockCSVClusterDiskMap['TempDBData'].Name); $($mockCSVClusterDiskMap['TempDBLogs'].Name)"
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockCSVClusterDiskMap['SysData'].Path
-                            SQLUserDBDir = $mockCSVClusterDiskMap['UserData'].Path
-                            SQLUserDBLogDir = $mockCSVClusterDiskMap['UserLogs'].Path
-                            SQLTempDBDir = $mockCSVClusterDiskMap['TempDBData'].Path
-                            SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
-                            SQLBackupDir = $mockCSVClusterDiskMap['Backup'].Path
-                        }
-
-                        { Set-TargetResource @csvTestParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
-                        $csvTestParameters = $testParameters.Clone()
-
-                        $csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
-                        $csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
-                        $csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
-                        $csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
-                        $csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
-                        $csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
-
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Quiet = 'True'
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-                            Action = 'InstallFailoverCluster'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = 'SQLEngine'
-                            FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name)"
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
-                            SQLUserDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
-                            SQLUserDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Logs"
-                            SQLTempDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDB"
-                            SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
-                            SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
-                        }
-
-                        { Set-TargetResource @csvTestParameters } | Should Not Throw
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
-                    BeforeAll {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters.Remove('SourceCredential')
-                        $testParameters.Remove('ASSysAdminAccounts')
-
-                        $testParameters += @{
-                            Features = 'SQLENGINE'
-                            InstanceName = 'MSSQLSERVER'
-                            SourcePath = $mockSourcePath
-                            Action = 'PrepareFailoverCluster'
-                        }
-
-                        Mock -CommandName NetUse -Verifiable
-                        Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
-                        Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+					}
+					
+					It 'Should pass proper parameters to setup' {
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'InstallFailoverCluster'
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							SkipRules = 'Cluster_VerifyForErrors'
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should pass proper parameters to setup when only InstallSQLDataDir is assigned a path' {
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'InstallFailoverCluster'
+							FailoverClusterDisks = 'SysData'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							SkipRules = 'Cluster_VerifyForErrors'
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+						}
+						
+						$setTargetResourceParameters = $testParameters.Clone()
+						$setTargetResourceParameters.Remove('SQLUserDBDir')
+						$setTargetResourceParameters.Remove('SQLUserDBLogDir')
+						$setTargetResourceParameters.Remove('SQLTempDbDir')
+						$setTargetResourceParameters.Remove('SQLTempDbLogDir')
+						$setTargetResourceParameters.Remove('SQLBackupDir')
+						{ Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+					}
+					
+					It 'Should pass proper parameters to setup when three variables are assigned the same drive, but different paths' {
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'InstallFailoverCluster'
+							FailoverClusterDisks = 'SysData'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							SkipRules = 'Cluster_VerifyForErrors'
+							InstallSQLDataDir = 'E:\SQLData'
+							SQLUserDBDir = 'E:\SQLData\UserDb'
+							SQLUserDBLogDir = 'E:\SQLData\UserDbLogs'
+						}
+						
+						$setTargetResourceParameters = $testParameters.Clone()
+						$setTargetResourceParameters.Remove('SQLTempDbDir')
+						$setTargetResourceParameters.Remove('SQLTempDbLogDir')
+						$setTargetResourceParameters.Remove('SQLBackupDir')
+						
+						$setTargetResourceParameters['InstallSQLDataDir'] = 'E:\SQLData\' # This ends with \ to test removal of paths ending with \
+						$setTargetResourceParameters['SQLUserDBDir'] = 'E:\SQLData\UserDb'
+						$setTargetResourceParameters['SQLUserDBLogDir'] = 'E:\SQLData\UserDbLogs'
+						
+						{ Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+					}
+					
+					It 'Should pass the SetupCredential object to the StartWin32Process function' {
+						$mockStartWin32Process_SetupCredential = {
+							$Credential | Should Not BeNullOrEmpty
+							return 'Process started.'
+						}
+						
+						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process_SetupCredential
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should throw an error when one or more paths are not resolved to clustered storage' {
+						$badPathParameters = $testParameters.Clone()
+						
+						# Pass in a bad path
+						$badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
+						
+						{ Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
+					}
+					
+					It 'Should properly map paths to clustered disk resources' {
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'InstallFailoverCluster'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							SkipRules = 'Cluster_VerifyForErrors'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should build a DEFAULT address string when no network is specified' {
+						$missingNetworkParams = $testParameters.Clone()
+						$missingNetworkParams.Remove('FailoverClusterIPAddress')
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'InstallFailoverCluster'
+							FailoverClusterIPAddresses = 'DEFAULT'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+						}
+						
+						{ Set-TargetResource @missingNetworkParams } | Should Not Throw
+					}
+					
+					It 'Should throw an error when an invalid IP Address is specified' {
+						$invalidAddressParameters = $testParameters.Clone()
+						
+						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
+						$invalidAddressParameters += @{
+							FailoverClusterIPAddress = '192.168.0.100'
+						}
+						
+						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+					}
+					
+					It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
+						$invalidAddressParameters = $testParameters.Clone()
+						
+						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
+						$invalidAddressParameters += @{
+							FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+						}
+						
+						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+					}
+					
+					It 'Should build a valid IP address string for a single address' {
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Action = 'InstallFailoverCluster'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should build a valid IP address string for a multi-subnet cluster' {
+						$multiSubnetParameters = $testParameters.Clone()
+						$multiSubnetParameters.Remove('FailoverClusterIPAddress')
+						$multiSubnetParameters += @{
+							FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
+						}
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Action = 'InstallFailoverCluster'
+						}
+						
+						{ Set-TargetResource @multiSubnetParameters } | Should Not Throw
+					}
+					
+					It 'Should pass proper parameters to setup when Cluster Shared volumes are specified' {
+						$csvTestParameters = $testParameters.Clone()
+						
+						$csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['SysData'].Path
+						$csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path
+						$csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserLogs'].Path
+						$csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['TempDBData'].Path
+						$csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['TempDBLogs'].Path
+						$csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path
+						
+						$mockStartWin32ProcessExpectedArgument = @{
+							IAcceptSQLServerLicenseTerms = 'True'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Quiet = 'True'
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							Action = 'InstallFailoverCluster'
+							InstanceName = 'MSSQLSERVER'
+							Features = 'SQLEngine'
+							FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name); $($mockCSVClusterDiskMap['UserLogs'].Name); $($mockCSVClusterDiskMap['SysData'].Name); $($mockCSVClusterDiskMap['TempDBData'].Name); $($mockCSVClusterDiskMap['TempDBLogs'].Name)"
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockCSVClusterDiskMap['SysData'].Path
+							SQLUserDBDir = $mockCSVClusterDiskMap['UserData'].Path
+							SQLUserDBLogDir = $mockCSVClusterDiskMap['UserLogs'].Path
+							SQLTempDBDir = $mockCSVClusterDiskMap['TempDBData'].Path
+							SQLTempDBLogDir = $mockCSVClusterDiskMap['TempDBLogs'].Path
+							SQLBackupDir = $mockCSVClusterDiskMap['Backup'].Path
+						}
+						
+						{ Set-TargetResource @csvTestParameters } | Should Not Throw
+					}
+					
+					It 'Should pass proper parameters to setup when Cluster Shared volumes are specified and are the same for one or more parameter values' {
+						$csvTestParameters = $testParameters.Clone()
+						
+						$csvTestParameters['InstallSQLDataDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
+						$csvTestParameters['SQLUserDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Data'
+						$csvTestParameters['SQLUserDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\Logs'
+						$csvTestParameters['SQLTempDBDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDB'
+						$csvTestParameters['SQLTempDBLogDir'] = $mockCSVClusterDiskMap['UserData'].Path + '\TEMPDBLOG'
+						$csvTestParameters['SQLBackupDir'] = $mockCSVClusterDiskMap['Backup'].Path + '\Backup'
+						
+						$mockStartWin32ProcessExpectedArgument = @{
+							IAcceptSQLServerLicenseTerms = 'True'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Quiet = 'True'
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							Action = 'InstallFailoverCluster'
+							InstanceName = 'MSSQLSERVER'
+							Features = 'SQLEngine'
+							FailoverClusterDisks = "$($mockCSVClusterDiskMap['Backup'].Name); $($mockCSVClusterDiskMap['UserData'].Name)"
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
+							SQLUserDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Data"
+							SQLUserDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\Logs"
+							SQLTempDBDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDB"
+							SQLTempDBLogDir = "$($mockCSVClusterDiskMap['UserData'].Path)\TEMPDBLOG"
+							SQLBackupDir = "$($mockCSVClusterDiskMap['Backup'].Path)\Backup"
+						}
+						
+						{ Set-TargetResource @csvTestParameters } | Should Not Throw
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
+					BeforeAll {
+						$testParameters = $mockDefaultParameters.Clone()
+						$testParameters.Remove('Features')
+						$testParameters.Remove('SourceCredential')
+						$testParameters.Remove('ASSysAdminAccounts')
+						
+						$testParameters += @{
+							Features = 'SQLENGINE'
+							InstanceName = 'MSSQLSERVER'
+							SourcePath = $mockSourcePath
+							Action = 'PrepareFailoverCluster'
+						}
+						
+						Mock -CommandName NetUse -Verifiable
+						Mock -CommandName Copy-ItemWithRoboCopy -Verifiable
+						Mock -CommandName Get-TemporaryFolder -MockWith $mockGetTemporaryFolder -Verifiable
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+						} -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
 						} -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
 							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_BOLFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-						} -MockWith $mockGetItemProperty_DQCFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
-                            $ResultClass -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-                    }
-
-                    It 'Should pass correct arguments to the setup process' {
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'PrepareFailoverCluster'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                        }
-                        $mockStartWin32ProcessExpectedArgument.Remove('FailoverClusterGroup')
-                        $mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
-
-                        { Set-TargetResource @testParameters } | Should Not throw
-
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                            ($Name -eq $mockDefaultInstance_InstanceName)
-                        } -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            $ResultClass -eq 'MSCluster_DiskPartition'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Exactly -Times 0 -Scope It
-                    }
-                }
-
-                Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
-                    BeforeEach {
-                        $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
-                        $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
-                        $mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
-                        $mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
-                        $mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
-                        $mockDynamicSqlBackupPath = $mockSqlBackupPath
-
-                        $testParameters = $mockDefaultClusterParameters.Clone()
-                        $testParameters += @{
-                            InstanceName = 'MSSQLSERVER'
-                            SourcePath = $mockSourcePath
-                            Action = 'CompleteFailoverCluster'
-                            FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-
-                            # Ensure we use "clustered" disks for our paths
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDbDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                        }
-                    }
-
-                    BeforeAll {
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-                            $Filter -eq "Name = 'Available Storage'"
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-                            $ResultClassName -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-                        } -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                    }
-
-                    It 'Should throw an error when one or more paths are not resolved to clustered storage' {
-                        $badPathParameters = $testParameters.Clone()
-
-                        # Pass in a bad path
-                        $badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
-
-                        { Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
-                    }
-
-                    It 'Should properly map paths to clustered disk resources' {
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'CompleteFailoverCluster'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should build a DEFAULT address string when no network is specified' {
-                        $missingNetworkParams = $testParameters.Clone()
-                        $missingNetworkParams.Remove('FailoverClusterIPAddress')
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            Action = 'CompleteFailoverCluster'
-                            FailoverClusterIPAddresses = 'DEFAULT'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                        }
-
-                        { Set-TargetResource @missingNetworkParams } | Should Not Throw
-                    }
-
-                    It 'Should throw an error when an invalid IP Address is specified' {
-                        $invalidAddressParameters = $testParameters.Clone()
-
-                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
-                        $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = '192.168.0.100'
-                        }
-
-                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-                    }
-
-                    It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
-                        $invalidAddressParameters = $testParameters.Clone()
-
-                        $invalidAddressParameters.Remove('FailoverClusterIPAddress')
-                        $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = @('10.0.0.100','192.168.0.100')
-                        }
-
-                        { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
-                    }
-
-                    It 'Should build a valid IP address string for a single address' {
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Action = 'CompleteFailoverCluster'
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-
-                    It 'Should build a valid IP address string for a multi-subnet cluster' {
-                        $multiSubnetParameters = $testParameters.Clone()
-                        $multiSubnetParameters.Remove('FailoverClusterIPAddress')
-                        $multiSubnetParameters += @{
-                            FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
-                        }
-
-                        $mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
-                        $mockStartWin32ProcessExpectedArgument += @{
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Action = 'CompleteFailoverCluster'
-                        }
-
-                        { Set-TargetResource @multiSubnetParameters } | Should Not Throw
-                    }
-
-                    It 'Should pass proper parameters to setup' {
-                        $mockStartWin32ProcessExpectedArgument = @{
-                            IAcceptSQLServerLicenseTerms = 'True'
-                            SkipRules = 'Cluster_VerifyForErrors'
-                            Quiet = 'True'
-                            SQLSysAdminAccounts = 'COMPANY\sqladmin'
-
-                            Action = 'CompleteFailoverCluster'
-                            InstanceName = 'MSSQLSERVER'
-                            Features = 'SQLEngine'
-                            FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
-                            FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
-                            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                            InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
-                            SQLUserDBDir = $mockDynamicSqlUserDatabasePath
-                            SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
-                            SQLTempDBDir = $mockDynamicSqlTempDatabasePath
-                            SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
-                            SQLBackupDir = $mockDynamicSqlBackupPath
-                        }
-
-                        { Set-TargetResource @testParameters } | Should Not Throw
-                    }
-                }
-
-            }
-
-            Assert-VerifiableMocks
-        }
-
-        # Tests only the parts of the code that does not already get tested thru the other tests.
-        Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
-            Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
-                BeforeEach {
-                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-                    Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
-                }
-
-
-                It 'Should use Unbuffered IO when copying' {
-                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-
-                    $mockStartProcessExpectedArgument =
-                        $mockRobocopyArgumentSourcePath,
-                        $mockRobocopyArgumentDestinationPath,
-                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-                        $mockRobocopyArgumentUseUnbufferedIO,
-                        $mockRobocopyArgumentSilent -join ' '
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-
-                It 'Should not use Unbuffered IO when copying' {
-                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
-
-                    $mockStartProcessExpectedArgument =
-                        $mockRobocopyArgumentSourcePath,
-                        $mockRobocopyArgumentDestinationPath,
-                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-                        '',
-                        $mockRobocopyArgumentSilent -join ' '
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-            }
-
-            Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
-                BeforeEach {
-                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-
-                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
-                }
-
-                It 'Should throw the correct error message when error code is 8' {
-                    $mockStartProcessExitCode = 8
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-
-                It 'Should throw the correct error message when error code is 16' {
-                    $mockStartProcessExitCode = 16
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-
-                It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
-                    $mockStartProcessExitCode = 9
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-            }
-
-            Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
-                BeforeEach {
-                    $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
-
-                    Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
-                    Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
-                }
-
-                It 'Should finish succesfully with exit code 1' {
-                    $mockStartProcessExitCode = 1
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-
-                It 'Should finish succesfully with exit code 2' {
-                    $mockStartProcessExitCode = 2
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-
-                It 'Should finish succesfully with exit code 3' {
-                    $mockStartProcessExitCode = 3
-
-                    $copyItemWithRoboCopyParameter = @{
-                        Path = $mockRobocopyArgumentSourcePath
-                        DestinationPath = $mockRobocopyArgumentDestinationPath
-                    }
-
-                    { Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
-                }
-            }
-        }
-
-        Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
-            $serviceTypes = @('SQL','AGT','IS','RS','AS','FT')
-
-            BeforeAll {
-                $mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
-
-                $mockSystemServiceAccount = (
-                    New-Object System.Management.Automation.PSCredential 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
-                )
-
-                $mockVirtualServiceAccount = (
-                    New-Object System.Management.Automation.PSCredential 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
-                )
-
-                $mockManagedServiceAccount = (
-                    New-Object System.Management.Automation.PSCredential 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
-                )
-
-                $mockDomainServiceAccount = (
-                    New-Object System.Management.Automation.PSCredential 'COMPANY\sql.service', $mockServiceAccountPassword
-                )
-            }
-
-            $serviceTypes | ForEach-Object {
-
-                $serviceType = $_
-
-                Context "When service type is $serviceType" {
-
-                    It "Should return the correct parameters when the account is a system account." {
-                        $result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
-
-                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                    }
-
-                    It "Should return the correct parameters when the account is a virtual service account" {
-                        $result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
-
-                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                    }
-
-                    It "Should return the correct parameters when the account is a managed service account" {
-                        $result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
-
-                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
-                        $result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
-                    }
-
-                    It "Should return the correct parameters when the account is a domain account" {
-                        $result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
-
-                        $result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
-                        $result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
-                    }
-                }
-            }
-        }
-
-        Describe 'Get-TemporaryFolder' -Tag 'Helper' {
-            BeforeAll {
-                $mockExpectedTempPath = [IO.Path]::GetTempPath()
-            }
-
-            Context "When using Get-TemporaryFolder" {
-                It "Should return the correct temporary path." {
-                    Get-TemporaryFolder | Should BeExactly $mockExpectedTempPath
-                }
-            }
-        }
-    }
+						} -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+						
+						Mock -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
+						} -MockWith $mockGetItemProperty_Setup -Verifiable
+						
+						Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+						} -Verfiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+							$Association -eq 'MSCluster_ResourceToPossibleOwner'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+							$ResultClass -eq 'MSCluster_DiskPartition'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+						} -Verifiable
+					}
+					
+					It 'Should pass correct arguments to the setup process' {
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'PrepareFailoverCluster'
+							SkipRules = 'Cluster_VerifyForErrors'
+						}
+						$mockStartWin32ProcessExpectedArgument.Remove('FailoverClusterGroup')
+						$mockStartWin32ProcessExpectedArgument.Remove('SQLSysAdminAccounts')
+
+						{ Set-TargetResource @testParameters } | Should Not throw
+						
+						Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+							$Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
+							($Name -eq $mockDefaultInstance_InstanceName)
+						} -Exactly -Times 0 -Scope It
+						Assert-MockCalled -CommandName StartWin32Process -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName WaitForWin32ProcessEnd -Exactly -Times 1 -Scope It
+						Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+							$Association -eq 'MSCluster_ResourceToPossibleOwner'
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimAssociatedInstance -ParameterFilter {
+							$ResultClass -eq 'MSCluster_DiskPartition'
+						} -Exactly -Times 0 -Scope It
+						
+						Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+						} -Exactly -Times 0 -Scope It
+					}
+				}
+				
+				Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
+					BeforeEach {
+						$mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
+						$mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
+						$mockDynamicSqlUserDatabaseLogPath = $mockSqlUserDatabaseLogPath
+						$mockDynamicSqlTempDatabasePath = $mockSqlTempDatabasePath
+						$mockDynamicSqlTempDatabaseLogPath = $mockSqlTempDatabaseLogPath
+						$mockDynamicSqlBackupPath = $mockSqlBackupPath
+						
+						$testParameters = $mockDefaultClusterParameters.Clone()
+						$testParameters += @{
+							InstanceName = 'MSSQLSERVER'
+							SourcePath = $mockSourcePath
+							Action = 'CompleteFailoverCluster'
+							FailoverClusterGroupName = 'SQL Server (MSSQLSERVER)'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+							
+							# Ensure we use "clustered" disks for our paths
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDbDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+						}
+					}
+					
+					BeforeAll {
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+							$Filter -eq "Name = 'Available Storage'"
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+							($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+						} -Verfiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+							$Association -eq 'MSCluster_ResourceToPossibleOwner'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+							$ResultClassName -eq 'MSCluster_DiskPartition'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+							($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolume'
+						} -Verifiable
+						
+						Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+							$ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+						} -Verifiable
+						
+						Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+					}
+					
+					It 'Should throw an error when one or more paths are not resolved to clustered storage' {
+						$badPathParameters = $testParameters.Clone()
+						
+						# Pass in a bad path
+						$badPathParameters.SQLUserDBDir = 'C:\MSSQL\'
+						
+						{ Set-TargetResource @badPathParameters } | Should Throw 'Unable to map the specified paths to valid cluster storage. Drives mapped: Backup; SysData; TempDbData; TempDbLogs; UserLogs'
+					}
+					
+					It 'Should properly map paths to clustered disk resources' {
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'CompleteFailoverCluster'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							SkipRules = 'Cluster_VerifyForErrors'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should build a DEFAULT address string when no network is specified' {
+						$missingNetworkParams = $testParameters.Clone()
+						$missingNetworkParams.Remove('FailoverClusterIPAddress')
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							Action = 'CompleteFailoverCluster'
+							FailoverClusterIPAddresses = 'DEFAULT'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+						}
+						
+						{ Set-TargetResource @missingNetworkParams } | Should Not Throw
+					}
+					
+					It 'Should throw an error when an invalid IP Address is specified' {
+						$invalidAddressParameters = $testParameters.Clone()
+						
+						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
+						$invalidAddressParameters += @{
+							FailoverClusterIPAddress = '192.168.0.100'
+						}
+						
+						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+					}
+					
+					It 'Should throw an error when an invalid IP Address is specified for a multi-subnet instance' {
+						$invalidAddressParameters = $testParameters.Clone()
+						
+						$invalidAddressParameters.Remove('FailoverClusterIPAddress')
+						$invalidAddressParameters += @{
+							FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+						}
+						
+						{ Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
+					}
+					
+					It 'Should build a valid IP address string for a single address' {
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Action = 'CompleteFailoverCluster'
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+					
+					It 'Should build a valid IP address string for a multi-subnet cluster' {
+						$multiSubnetParameters = $testParameters.Clone()
+						$multiSubnetParameters.Remove('FailoverClusterIPAddress')
+						$multiSubnetParameters += @{
+							FailoverClusterIPAddress = ($mockClusterSites | ForEach-Object { $_.Address })
+						}
+						
+						$mockStartWin32ProcessExpectedArgument = $mockStartWin32ProcessExpectedArgumentClusterDefault.Clone()
+						$mockStartWin32ProcessExpectedArgument += @{
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Action = 'CompleteFailoverCluster'
+						}
+						
+						{ Set-TargetResource @multiSubnetParameters } | Should Not Throw
+					}
+					
+					It 'Should pass proper parameters to setup' {
+						$mockStartWin32ProcessExpectedArgument = @{
+							IAcceptSQLServerLicenseTerms = 'True'
+							SkipRules = 'Cluster_VerifyForErrors'
+							Quiet = 'True'
+							SQLSysAdminAccounts = 'COMPANY\sqladmin'
+							
+							Action = 'CompleteFailoverCluster'
+							InstanceName = 'MSSQLSERVER'
+							Features = 'SQLEngine'
+							FailoverClusterDisks = 'Backup; SysData; TempDbData; TempDbLogs; UserData; UserLogs'
+							FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
+							FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+							FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+							InstallSQLDataDir = $mockDynamicSqlDataDirectoryPath
+							SQLUserDBDir = $mockDynamicSqlUserDatabasePath
+							SQLUserDBLogDir = $mockDynamicSqlUserDatabaseLogPath
+							SQLTempDBDir = $mockDynamicSqlTempDatabasePath
+							SQLTempDBLogDir = $mockDynamicSqlTempDatabaseLogPath
+							SQLBackupDir = $mockDynamicSqlBackupPath
+						}
+						
+						{ Set-TargetResource @testParameters } | Should Not Throw
+					}
+				}
+				
+			}
+			
+			Assert-VerifiableMocks
+		}
+		
+		# Tests only the parts of the code that does not already get tested thru the other tests.
+		Describe 'Copy-ItemWithRoboCopy' -Tag 'Helper' {
+			Context 'When Copy-ItemWithRoboCopy is called it should return the correct arguments' {
+				BeforeEach {
+					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+					Mock -CommandName Start-Process -MockWith $mockStartProcess -Verifiable
+				}
+				
+				
+				It 'Should use Unbuffered IO when copying' {
+					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+					
+					$mockStartProcessExpectedArgument =
+					$mockRobocopyArgumentSourcePath,
+					$mockRobocopyArgumentDestinationPath,
+					$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+					$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+					$mockRobocopyArgumentUseUnbufferedIO,
+					$mockRobocopyArgumentSilent -join ' '
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+				
+				It 'Should not use Unbuffered IO when copying' {
+					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
+					
+					$mockStartProcessExpectedArgument =
+					$mockRobocopyArgumentSourcePath,
+					$mockRobocopyArgumentDestinationPath,
+					$mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+					$mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+					'',
+					$mockRobocopyArgumentSilent -join ' '
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+			}
+			
+			Context 'When Copy-ItemWithRoboCopy throws an exception it should return the correct error messages' {
+				BeforeEach {
+					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+					
+					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+					Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+				}
+				
+				It 'Should throw the correct error message when error code is 8' {
+					$mockStartProcessExitCode = 8
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+				
+				It 'Should throw the correct error message when error code is 16' {
+					$mockStartProcessExitCode = 16
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported errors when copying files. Error code: $mockStartProcessExitCode."
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+				
+				It 'Should throw the correct error message when error code is greater than 7 (but not 8 or 16)' {
+					$mockStartProcessExitCode = 9
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Throw "Robocopy reported that failures occured when copying files. Error code: $mockStartProcessExitCode."
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+			}
+			
+			Context 'When Copy-ItemWithRoboCopy is called and finishes succesfully it should return the correct exit code' {
+				BeforeEach {
+					$mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
+					
+					Mock -CommandName Get-Command -MockWith $mockGetCommand -Verifiable
+					Mock -CommandName Start-Process -MockWith $mockStartProcess_WithExitCode -Verifiable
+				}
+				
+				It 'Should finish succesfully with exit code 1' {
+					$mockStartProcessExitCode = 1
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+				
+				It 'Should finish succesfully with exit code 2' {
+					$mockStartProcessExitCode = 2
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+				
+				It 'Should finish succesfully with exit code 3' {
+					$mockStartProcessExitCode = 3
+					
+					$copyItemWithRoboCopyParameter = @{
+						Path = $mockRobocopyArgumentSourcePath
+						DestinationPath = $mockRobocopyArgumentDestinationPath
+					}
+					
+					{ Copy-ItemWithRoboCopy @copyItemWithRoboCopyParameter } | Should Not Throw
+					
+					Assert-MockCalled -CommandName Get-Command -Exactly -Times 1 -Scope It
+					Assert-MockCalled -CommandName Start-Process -Exactly -Times 1 -Scope It
+				}
+			}
+		}
+		
+		Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
+			$serviceTypes = @('SQL', 'AGT', 'IS', 'RS', 'AS', 'FT')
+			
+			BeforeAll {
+				$mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force
+				
+				$mockSystemServiceAccount = (
+					New-Object System.Management.Automation.PSCredential 'NT AUTHORITY\SYSTEM', $mockServiceAccountPassword
+				)
+				
+				$mockVirtualServiceAccount = (
+					New-Object System.Management.Automation.PSCredential 'NT SERVICE\MSSQLSERVER', $mockServiceAccountPassword
+				)
+				
+				$mockManagedServiceAccount = (
+					New-Object System.Management.Automation.PSCredential 'COMPANY\ManagedAccount$', $mockServiceAccountPassword
+				)
+				
+				$mockDomainServiceAccount = (
+					New-Object System.Management.Automation.PSCredential 'COMPANY\sql.service', $mockServiceAccountPassword
+				)
+			}
+			
+			$serviceTypes | ForEach-Object {
+				
+				$serviceType = $_
+				
+				Context "When service type is $serviceType" {
+					
+					It "Should return the correct parameters when the account is a system account." {
+						$result = Get-ServiceAccountParameters -ServiceAccount $mockSystemServiceAccount -ServiceType $serviceType
+						
+						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockSystemServiceAccount.UserName
+						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+					}
+					
+					It "Should return the correct parameters when the account is a virtual service account" {
+						$result = Get-ServiceAccountParameters -ServiceAccount $mockVirtualServiceAccount -ServiceType $serviceType
+						
+						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockVirtualServiceAccount.UserName
+						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+					}
+					
+					It "Should return the correct parameters when the account is a managed service account" {
+						$result = Get-ServiceAccountParameters -ServiceAccount $mockManagedServiceAccount -ServiceType $serviceType
+						
+						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockManagedServiceAccount.UserName
+						$result.ContainsKey("$($serviceType)SVCPASSWORD") | Should Be $false
+					}
+					
+					It "Should return the correct parameters when the account is a domain account" {
+						$result = Get-ServiceAccountParameters -ServiceAccount $mockDomainServiceAccount -ServiceType $serviceType
+						
+						$result.$("$($serviceType)SVCACCOUNT") | Should BeExactly $mockDomainServiceAccount.UserName
+						$result.$("$($serviceType)SVCPASSWORD") | Should BeExactly $mockDomainServiceAccount.GetNetworkCredential().Password
+					}
+				}
+			}
+		}
+		
+		Describe 'Get-TemporaryFolder' -Tag 'Helper' {
+			BeforeAll {
+				$mockExpectedTempPath = [IO.Path]::GetTempPath()
+			}
+			
+			Context "When using Get-TemporaryFolder" {
+				It "Should return the correct temporary path." {
+					Get-TemporaryFolder | Should BeExactly $mockExpectedTempPath
+				}
+			}
+		}
+	}
 }
 finally
 {
-    Invoke-TestCleanup
+	Invoke-TestCleanup
 }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1,26 +1,26 @@
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-param ()
+param()
 
-$script:DSCModuleName = 'xSQLServer'
-$script:DSCResourceName = 'MSFT_xSQLServerSetup'
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerSetup'
 
 #region HEADER
 
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-if ((-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))))
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 $TestEnvironment = Initialize-TestEnvironment `
-                                              -DSCModuleName $script:DSCModuleName `
-                                              -DSCResourceName $script:DSCResourceName `
-                                              -TestType Unit
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
 
 #endregion HEADER
 
@@ -43,7 +43,7 @@ try
             13, # SQL Server 2016
             12, # SQL Server 2014
             11, # SQL Server 2012
-            10 # SQL Server 2008 and 2008 R2
+            10  # SQL Server 2008 and 2008 R2
         )
 
         $mockSqlDatabaseEngineName = 'MSSQL'
@@ -62,9 +62,9 @@ try
         $mockSqlSystemAdministrator = 'COMPANY\Stacy'
 
         $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
-        $mockSqlAnalysisAdmins = @('COMPANY\Stacy', 'COMPANY\SSAS Administrators')
+        $mockSqlAnalysisAdmins = @('COMPANY\Stacy','COMPANY\SSAS Administrators')
         $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
-        $mockSqlAnalysisTempDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
+        $mockSqlAnalysisTempDirectory= 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
         $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
         $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
         $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
@@ -99,19 +99,19 @@ try
         $mockmockSetupCredentialUserName = "COMPANY\sqladmin"
 
         $mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-        $mockSetupCredential = New-Object System.Management.Automation.PSCredential($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
+        $mockSetupCredential = New-Object System.Management.Automation.PSCredential( $mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword )
 
         $mockSqlServiceAccount = 'COMPANY\SqlAccount'
         $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
-        $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        $mockSQLServiceCredential = New-Object System.Management.Automation.PSCredential($mockSqlServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
         $mockAgentServiceAccount = 'COMPANY\AgentAccount'
         $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
-        $mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount, ($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        $mockSQLAgentCredential = New-Object System.Management.Automation.PSCredential($mockAgentServiceAccount,($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
         $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
         $mockAnslysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
-        $mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount, ($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+        $mockAnalysisServiceCredential = New-Object System.Management.Automation.PSCredential($mockAnalysisServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
 
-        $mockClusterNodes = @($env:COMPUTERNAME, 'SQL01', 'SQL02')
+        $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
 
         $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
         $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
@@ -132,12 +132,12 @@ try
         }
 
         $mockCSVClusterDiskMap = @{
-            SysData = @{ Path = 'C:\ClusterStorage\SysData'; Name = "Cluster Virtual Disk (SQL System Data Disk)" }
-            UserData = @{ Path = 'C:\ClusterStorage\SQLData'; Name = "Cluster Virtual Disk (SQL Data Disk)" }
-            UserLogs = @{ Path = 'C:\ClusterStorage\SQLLogs'; Name = "Cluster Virtual Disk (SQL Log Disk)" }
-            TempDbData = @{ Path = 'C:\ClusterStorage\TempDBData'; Name = "Cluster Virtual Disk (SQL TempDBData Disk)" }
-            TempDbLogs = @{ Path = 'C:\ClusterStorage\TempDBLogs'; Name = "Cluster Virtual Disk (SQL TempDBLog Disk)" }
-            Backup = @{ Path = 'C:\ClusterStorage\SQLBackup'; Name = "Cluster Virtual Disk (SQL Backup Disk)" }
+            SysData = @{Path='C:\ClusterStorage\SysData';Name="Cluster Virtual Disk (SQL System Data Disk)"}
+            UserData = @{Path='C:\ClusterStorage\SQLData';Name="Cluster Virtual Disk (SQL Data Disk)"}
+            UserLogs = @{Path='C:\ClusterStorage\SQLLogs';Name="Cluster Virtual Disk (SQL Log Disk)"}
+            TempDbData = @{Path='C:\ClusterStorage\TempDBData';Name="Cluster Virtual Disk (SQL TempDBData Disk)"}
+            TempDbLogs = @{Path='C:\ClusterStorage\TempDBLogs';Name="Cluster Virtual Disk (SQL TempDBLog Disk)"}
+            Backup = @{Path='C:\ClusterStorage\SQLBackup';Name="Cluster Virtual Disk (SQL Backup Disk)"}
         }
 
         $mockClusterSites = @(
@@ -173,33 +173,33 @@ try
 
         $mockGetItemProperty_UninstallProducts2008R2 = {
             return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber # Mock product ADV_SSMS 2012
+                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
+                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber  # Mock product ADV_SSMS 2012
             )
         }
 
         $mockGetItemProperty_UninstallProducts2012 = {
             return @(
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber # Mock product SSMS 2014
+                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber    # Mock product SSMS 2014
             )
         }
 
         $mockGetItemProperty_UninstallProducts2014 = {
             return @(
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
             )
         }
 
         $mockGetItemProperty_UninstallProducts = {
             return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber, # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber, # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber, # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber, # Mock product ADV_SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber, # Mock product SSMS 2014
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber # Mock product ADV_SSMS 2014
+                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
+                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
+                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber,  # Mock product ADV_SSMS 2012
+                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber,    # Mock product SSMS 2014
+                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
             )
         }
 
@@ -207,8 +207,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -217,8 +217,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 )
             )
         }
@@ -227,8 +227,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -237,8 +237,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -247,8 +247,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -257,8 +257,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -267,33 +267,33 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -302,8 +302,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -312,8 +312,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 )
             )
         }
@@ -322,8 +322,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -332,8 +332,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -342,8 +342,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -352,8 +352,8 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -362,33 +362,33 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
                 )
             )
         }
@@ -397,7 +397,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
                 )
             )
         }
@@ -425,7 +425,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SDK_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SDK_FNS=3 Tools_Legacy_FNS=3' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SQL_SSMS_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SQL_Tools_Standard_FNS=3 Tools_Legacy_FNS=3 SDK_Full=3 SDK_FNS=3' -PassThru -Force
                 )
             )
         }
@@ -434,21 +434,20 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
                 )
             )
         }
-
 
         $mockGetItemProperty_SQL = {
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
                 ),
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
                 )
             )
         }
@@ -457,7 +456,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
                 )
             )
         }
@@ -466,7 +465,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
                 )
             )
         }
@@ -475,7 +474,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
                 )
             )
         }
@@ -484,7 +483,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
                 )
             )
         }
@@ -493,7 +492,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
                 )
             )
         }
@@ -502,7 +501,7 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
                 )
             )
         }
@@ -511,22 +510,22 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                    Add-Member ScriptProperty Logins {
-                        return @((New-Object Object |
-                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                Add-Member ScriptMethod ListMembers {
-                                    return @('sysadmin')
-                                } -PassThru -Force
-                            ))
-                    } -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+                        Add-Member ScriptProperty Logins {
+                            return @( ( New-Object Object |
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+                                    Add-Member ScriptMethod ListMembers {
+                                        return @('sysadmin')
+                                    } -PassThru -Force
+                                ) )
+                        } -PassThru -Force
                 )
             )
         }
@@ -535,23 +534,23 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
-                    Add-Member ScriptProperty Logins {
-                        return @((New-Object Object |
-                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                Add-Member ScriptMethod ListMembers {
-                                    return @('sysadmin')
-                                } -PassThru -Force
-                            ))
-                    } -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
+                        Add-Member ScriptProperty Logins {
+                            return @( ( New-Object Object |
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
+                                    Add-Member ScriptMethod ListMembers {
+                                        return @('sysadmin')
+                                    } -PassThru -Force
+                                ) )
+                        } -PassThru -Force
                 )
             )
         }
@@ -560,26 +559,26 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member ScriptProperty ServerProperties  {
-                        return @{
-                            'CollationName' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force)
-                            'DataDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force)
-                            'TempDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force)
-                            'LogDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force)
-                            'BackupDir' = @(New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force)
-                        }
-                    } -PassThru |
-                    Add-Member ScriptProperty Roles  {
-                        return @{
-                            'Administrators' = @(New-Object Object |
-                                Add-Member ScriptProperty Members {
-                                    return New-Object Object |
-                                    Add-Member ScriptProperty Name {
-                                        return $mockSqlAnalysisAdmins
+                        Add-Member ScriptProperty ServerProperties  {
+                            return @{
+                                'CollationName' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
+                                'DataDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
+                                'TempDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
+                                'LogDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
+                                'BackupDir' = @( New-Object Object | Add-Member NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
+                            }
+                        } -PassThru |
+                        Add-Member ScriptProperty Roles  {
+                            return @{
+                                'Administrators' = @( New-Object Object |
+                                    Add-Member ScriptProperty Members {
+                                        return New-Object Object |
+                                            Add-Member ScriptProperty Name {
+                                                return $mockSqlAnalysisAdmins
+                                            } -PassThru -Force
                                     } -PassThru -Force
-                                } -PassThru -Force
                                 ) }
-                    } -PassThru -Force
+                        } -PassThru -Force
                 )
             )
         }
@@ -587,7 +586,7 @@ try
         $mockRobocopyExecutableName = 'Robocopy.exe'
         $mockRobocopyExectuableVersionWithoutUnbufferedIO = '6.2.9200.00000'
         $mockRobocopyExectuableVersionWithUnbufferedIO = '6.3.9600.16384'
-        $mockRobocopyExectuableVersion = '' # Set dynamically during runtime
+        $mockRobocopyExectuableVersion = ''     # Set dynamically during runtime
         $mockRobocopyArgumentSilent = '/njh /njs /ndl /nc /ns /nfl'
         $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty = '/e'
         $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource = '/purge'
@@ -599,39 +598,39 @@ try
             return @(
                 (
                     New-Object Object |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
-                    Add-Member ScriptProperty FileVersionInfo {
-                        return @((New-Object Object |
-                                Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
-                            ))
-                    } -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockRobocopyExecutableName -PassThru |
+                        Add-Member ScriptProperty FileVersionInfo {
+                            return @( ( New-Object Object |
+                                    Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value $mockRobocopyExectuableVersion -PassThru -Force
+                                ) )
+                        } -PassThru -Force
                 )
             )
         }
 
-        $mockStartProcessExpectedArgument = '' # Set dynamically during runtime
-        $mockStartProcessExitCode = 0 # Set dynamically during runtime
+        $mockStartProcessExpectedArgument = ''  # Set dynamically during runtime
+        $mockStartProcessExitCode = 0  # Set dynamically during runtime
 
         $mockStartProcess = {
-            if ($ArgumentList -cne $mockStartProcessExpectedArgument)
+            if ( $ArgumentList -cne $mockStartProcessExpectedArgument )
             {
                 throw "Expected arguments was not the same as the arguments in the function call.`nExpected: '$mockStartProcessExpectedArgument' `n But was: '$ArgumentList'"
             }
 
             return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value 0 -PassThru -Force
         }
 
         $mockStartProcess_WithExitCode = {
             return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'ExitCode' -Value $mockStartProcessExitCode -PassThru -Force
         }
 
         $mockSourcePathUNCWithoutLeaf = '\\server\share'
         $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
         $mockNewGuid = {
             return New-Object Object |
-            Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Guid' -Value $mockSourcePathGuid -PassThru -Force
         }
 
         $mockGetTemporaryFolder = {
@@ -641,10 +640,10 @@ try
         $mockGetCimInstance_MSClusterResource = {
             return @(
                 (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{ InstanceName = $mockCurrentInstanceName } -PassThru -Force
                 )
             )
         }
@@ -653,7 +652,7 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
                 )
             )
         }
@@ -662,27 +661,27 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
                 )
             )
         }
@@ -691,33 +690,33 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['SysData'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserData'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['UserLogs'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBData'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['TempDBLogs'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
                 ),
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Path }) -PassThru -Force |
-                    Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{ Name = $mockCSVClusterDiskMap['Backup'].Name }) -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
+                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
                 )
             )
         }
@@ -729,10 +728,10 @@ try
                         $network = $_
 
                         New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
                     }
                 )
             )
@@ -742,7 +741,7 @@ try
             return @(
                 (
                     New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
+                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
                 )
             )
         }
@@ -750,7 +749,7 @@ try
         $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
             return @(
                 (
-                    @('Network Name', 'IP Address') | ForEach-Object {
+                    @('Network Name','IP Address') | ForEach-Object {
                         $resourceType = $_
 
                         $propertyValue = @{
@@ -773,8 +772,8 @@ try
                         }
 
                         return New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
-                        Add-Member @propertyValue -PassThru -Force
+                            Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
+                            Add-Member @propertyValue -PassThru -Force
                     }
                 )
             )
@@ -787,10 +786,10 @@ try
                     # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
                     (& $mockClusterDiskMap).Keys | ForEach-Object {
                         $diskName = $_
-                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
+                        New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
                     }
                 )
             )
@@ -802,7 +801,7 @@ try
                     $mockClusterNodes | ForEach-Object {
                         $node = $_
                         New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
                     }
                 )
             )
@@ -816,8 +815,8 @@ try
 
             return @(
                 (
-                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition', 'root/MSCluster' |
-                    Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
+                    New-Object Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition','root/MSCluster' |
+                        Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
                 )
             )
         }
@@ -828,7 +827,7 @@ try
         Solved this by dynamically set the expected arguments before each It-block. If the arguments differs the mock of
         StartWin32Process throws an error message, similiar to what Pester would have reported (expected -> but was).
         #>
-        $mockStartWin32ProcessExpectedArgument = @{ }
+        $mockStartWin32ProcessExpectedArgument = @{}
 
         $mockStartWin32ProcessExpectedArgumentClusterDefault = @{
             IAcceptSQLServerLicenseTerms = 'True'
@@ -840,20 +839,20 @@ try
         }
 
         $mockStartWin32Process = {
-            $argumentHashTable = @{ }
+            $argumentHashTable = @{}
 
             # Break the argument string into a hash table
             ($Arguments -split ' ?/') | ForEach-Object {
                 if ($_ -imatch '(\w+)="?([^/]+)"?')
                 {
                     $key = $Matches[1]
-                    if ($key -in ('FailoverClusterDisks', 'FailoverClusterIPAddresses'))
+                    if ($key -in ('FailoverClusterDisks','FailoverClusterIPAddresses'))
                     {
-                        $value = ($Matches[2] -replace '" "', '; ') -replace '"', ''
+                        $value = ($Matches[2] -replace '" "','; ') -replace '"',''
                     }
                     else
                     {
-                        $value = ($Matches[2] -replace '" "', ' ') -replace '"', ''
+                        $value = ($Matches[2] -replace '" "',' ') -replace '"',''
                     }
 
                     $null = $argumentHashTable.Add($key, $value)
@@ -862,7 +861,7 @@ try
 
             # Start by checking whether we have the same number of parameters
             Write-Verbose 'Verifying setup argument count (expected vs actual)' -Verbose
-            Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',')) -Verbose
+            Write-Verbose -Message ('Expected: {0}' -f ($mockStartWin32ProcessExpectedArgument.Keys -join ',') ) -Verbose
             Write-Verbose -Message ('Actual: {0}' -f ($argumentHashTable.Keys -join ',')) -Verbose
 
             $argumentHashTable.Keys.Count | Should BeExactly $mockStartWin32ProcessExpectedArgument.Keys.Count
@@ -908,7 +907,7 @@ try
             $mockSourcePath = $TestDrive.FullName
 
             # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
 
             #endregion Setting up TestDrive:\
@@ -981,7 +980,7 @@ try
                             SourcePath = $mockSourcePath
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1104,7 +1103,7 @@ try
                             SourcePath = $mockSourcePathUNC
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1315,7 +1314,7 @@ try
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,BOL,FULLTEXT,RS,AS,IS'
                         }
@@ -1439,7 +1438,7 @@ try
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -1497,9 +1496,9 @@ try
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
                             $result.Features | Should Be $featuresForSqlServer2016
                         }
                         else
@@ -1651,7 +1650,7 @@ try
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -1709,9 +1708,9 @@ try
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
                             $result.Features | Should Be $featuresForSqlServer2016
                         }
                         else
@@ -1769,7 +1768,7 @@ try
                             SourcePath = $mockSourcePath
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             # Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
                             Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1987,7 +1986,7 @@ try
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -Exactly -Times 1 -Scope It
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
                             Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                                 $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
@@ -2045,9 +2044,9 @@ try
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,', '') -replace ',ADV_SSMS', ''
+                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
                             $result.Features | Should Be $featuresForSqlServer2016
                         }
                         else
@@ -2099,9 +2098,9 @@ try
 
                         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
-                        Mock -CommandName Get-CimInstance -MockWith { } -Verifiable
+                        Mock -CommandName Get-CimInstance -MockWith {} -Verifiable
 
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -Verifiable
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
 
@@ -2181,7 +2180,7 @@ try
             $mockSourcePath = $TestDrive.FullName
 
             # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
 
             #endregion Setting up TestDrive:\
@@ -2525,11 +2524,11 @@ try
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
-                            Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
-                            FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                        }
+                                Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
+                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            }
                     } -Verifiable
 
                     $testClusterParameters = $testParameters.Clone()
@@ -2771,11 +2770,11 @@ try
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
-                            Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
-                            FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                            FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                            FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                        }
+                                Features = 'SQLENGINE,AS' # Must be upper-case since Get-TargetResource returns upper-case.
+                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            }
                     } -Verifiable
 
                     $testClusterParameters = $testParameters.Clone()
@@ -2802,7 +2801,7 @@ try
             $mockSourcePath = $TestDrive.FullName
 
             # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':', '$'
+            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
             $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
 
             <#
@@ -2912,17 +2911,17 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                             ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
-                            SQLSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
-                            ASSysAdminAccounts = 'COMPANY\User1', 'COMPANY\SQLAdmins'
+                            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
+                            ASSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
                             InstanceDir = 'D:'
                             InstallSQLDataDir = 'E:'
                             InstallSharedDir = 'C:\Program Files\Microsoft SQL Server'
                             InstallSharedWOWDir = 'C:\Program Files (x86)\Microsoft SQL Server'
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ( $mockSqlMajorVersion -in (13,14) )
                         {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
 
                         $mockStartWin32ProcessExpectedArgument = @{
@@ -2971,7 +2970,7 @@ try
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
 
-                    if ($mockSqlMajorVersion -in (13, 14))
+                    if( $mockSqlMajorVersion -in (13,14) )
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters = $mockDefaultParameters.Clone()
@@ -2982,7 +2981,7 @@ try
                             }
 
                             $testParameters.Features = 'SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
@@ -2996,7 +2995,7 @@ try
                             }
 
                             $testParameters.Features = 'ADV_SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
@@ -3101,9 +3100,9 @@ try
                             SourcePath = $mockSourcePathUNC
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ( $mockSqlMajorVersion -in (13,14) )
                         {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
 
                         # Mocking SharedDirectory (when previously installed and should not be installed again).
@@ -3181,7 +3180,7 @@ try
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
 
-                    if ($mockSqlMajorVersion -in (13, 14))
+                    if( $mockSqlMajorVersion -in (13,14) )
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'SSMS'
@@ -3284,9 +3283,9 @@ try
                             SuppressReboot = $true
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ( $mockSqlMajorVersion -in (13,14) )
                         {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
 
                         Mock -CommandName New-SmbMapping -Verifiable
@@ -3350,18 +3349,18 @@ try
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
 
-                    if ($mockSqlMajorVersion -in (13, 14))
+                    if( $mockSqlMajorVersion -in (13,14) )
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
 
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = 'ADV_SSMS'
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
@@ -3461,9 +3460,9 @@ try
                             ForceReboot = $true
                         }
 
-                        if ($mockSqlMajorVersion -in (13, 14))
+                        if ( $mockSqlMajorVersion -in (13,14) )
                         {
-                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS', ''
+                            $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -3517,18 +3516,18 @@ try
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
 
-                    if ($mockSqlMajorVersion -in (13, 14))
+                    if( $mockSqlMajorVersion -in (13,14) )
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = $($testParameters.Features), 'SSMS' -join ','
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
 
                         It 'Should throw when feature parameter contains ''ADV_SSMS'' when installing SQL Server 2016' {
                             $testParameters.Features = $($testParameters.Features), 'ADV_SSMS' -join ','
-                            $mockStartWin32ProcessExpectedArgument = @{ }
+                            $mockStartWin32ProcessExpectedArgument = @{}
 
                             { Set-TargetResource @testParameters } | Should Throw "'ADV_SSMS' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information."
                         }
@@ -3742,7 +3741,7 @@ try
                         } -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                                $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -3903,7 +3902,7 @@ try
 
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+                            FailoverClusterIPAddress = @('10.0.0.100','192.168.0.100')
                         }
 
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
@@ -4041,7 +4040,7 @@ try
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
+                                $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
                         } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -4058,23 +4057,23 @@ try
 
                         Mock -CommandName StartWin32Process -MockWith $mockStartWin32Process -Verifiable
 
-                        Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+                        Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
                         } -Verifiable
 
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
                         } -Verfiable
 
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
                         } -Verifiable
 
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith { } -ParameterFilter {
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
                             $ResultClass -eq 'MSCluster_DiskPartition'
                         } -Verifiable
 
-                        Mock -CommandName Get-CimInstance -MockWith { } -ParameterFilter {
+                        Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
                     }
@@ -4251,7 +4250,7 @@ try
 
                         $invalidAddressParameters.Remove('FailoverClusterIPAddress')
                         $invalidAddressParameters += @{
-                            FailoverClusterIPAddress = @('10.0.0.100', '192.168.0.100')
+                            FailoverClusterIPAddress = @('10.0.0.100','192.168.0.100')
                         }
 
                         { Set-TargetResource @invalidAddressParameters } | Should Throw 'Unable to map the specified IP Address(es) to valid cluster networks.'
@@ -4346,12 +4345,12 @@ try
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithUnbufferedIO
 
                     $mockStartProcessExpectedArgument =
-                    $mockRobocopyArgumentSourcePath,
-                    $mockRobocopyArgumentDestinationPath,
-                    $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-                    $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-                    $mockRobocopyArgumentUseUnbufferedIO,
-                    $mockRobocopyArgumentSilent -join ' '
+                        $mockRobocopyArgumentSourcePath,
+                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                        $mockRobocopyArgumentUseUnbufferedIO,
+                        $mockRobocopyArgumentSilent -join ' '
 
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
@@ -4368,12 +4367,12 @@ try
                     $mockRobocopyExectuableVersion = $mockRobocopyExectuableVersionWithoutUnbufferedIO
 
                     $mockStartProcessExpectedArgument =
-                    $mockRobocopyArgumentSourcePath,
-                    $mockRobocopyArgumentDestinationPath,
-                    $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
-                    $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-                    '',
-                    $mockRobocopyArgumentSilent -join ' '
+                        $mockRobocopyArgumentSourcePath,
+                        $mockRobocopyArgumentDestinationPath,
+                        $mockRobocopyArgumentCopySubDirectoriesIncludingEmpty,
+                        $mockRobocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+                        '',
+                        $mockRobocopyArgumentSilent -join ' '
 
                     $copyItemWithRoboCopyParameter = @{
                         Path = $mockRobocopyArgumentSourcePath
@@ -4491,7 +4490,7 @@ try
         }
 
         Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
-            $serviceTypes = @('SQL', 'AGT', 'IS', 'RS', 'AS', 'FT')
+            $serviceTypes = @('SQL','AGT','IS','RS','AS','FT')
 
             BeforeAll {
                 $mockServiceAccountPassword = ConvertTo-SecureString 'Password' -AsPlainText -Force


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please make sure you have read the contributing section at https://github.com/PowerShell/xSQLServer#contributing.

Please prefix the PR title with the resource name, i.e. 'xSQLServerSetup: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xSQLServerSetup: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
 Updated xSQLServerSetup module Get-Resource method to detect DQ, DQC, BOL, SDK features.

**Tested with following DSC:**
```
xSQLServerSetup Instance
{
Action = "Install"
InstanceName = $SqlInstanceName
SetupCredential = $DeployServiceAccount
SourcePath = "C:\Media"
Features = "FULLTEXT,BC,DQ,BOL,SSMS,DQC,ADV_SSMS,AS,SDK,SQLENGINE,CONN,RS"
ProductKey = $ProductKey
}
```

**This Pull Request (PR) fixes the following issues:**
Fixes #516 
Fixes #490 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/521)
<!-- Reviewable:end -->
