### PR TITLE
xSQLServerAlwaysOnService: Fix for issue #519

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Changes to xSQLServer
   - Fixed typos in markdown files; CHANGELOG, CONTRIBUTING, README and ISSUE_TEMPLATE.
 - Changes to xSQLServerAlwaysOnService
-  - Get-TargetResource should no longer fail silently with error 'Index operation failed; the array index evaluated to null.'. Now if the Server.IsHadrEnabled property return neither $true or $false the Get-TargetResource function will throw an error.
+  - Get-TargetResource should no longer fail silently with error 'Index operation failed; the array index evaluated to null.' (issue #519). Now if the Server.IsHadrEnabled property return neither $true or $false the Get-TargetResource function will throw an error.
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - Removed helper function Get-SQLPSInstance and Get-SQLPSInstanceName because there is no resource using it any longer.
 - Changes to xSQLServer
   - Fixed typos in markdown files; CHANGELOG, CONTRIBUTING, README and ISSUE_TEMPLATE.
+- Changes to xSQLServerAlwaysOnService
+  - Get-TargetResource should no longer fail silently with error 'Index operation failed; the array index evaluated to null.'. Now if the Server.IsHadrEnabled property return neither $true or $false the Get-TargetResource function will throw an error.
 
 ## 7.0.0.0
 

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnService.Tests.ps1
@@ -257,7 +257,7 @@ try
             }
         }
 
-        Context 'When HADR is not in the desired state' {
+        Context 'When HADR is in the desired state' {
             Mock -CommandName Connect-SQL -MockWith {
                 return New-Object PSObject -Property @{
                     IsHadrEnabled = $true

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnService.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnService.Tests.ps1
@@ -1,7 +1,7 @@
 $script:DSCModuleName      = 'xSQLServer'
 $script:DSCResourceName    = 'MSFT_xSQLServerAlwaysOnService'
 
-# Unit Test Template Version: 1.1.0 
+# Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
@@ -13,7 +13,7 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 $disableHadr = @{
     Ensure = 'Absent'
@@ -47,26 +47,26 @@ try
         Context 'When HADR is disabled' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{ 
+                return New-Object PSObject -Property @{
                     IsHadrEnabled = $false
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
 
             It 'Should return that HADR is disabled' {
-                
+
                 # Get the current state
                 $result = Get-TargetResource @enableHadr
-                
+
                 $result.IsHadrEnabled | Should Be $false
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
 
             It 'Should return that HADR is disabled' {
-                
+
                 # Get the current state
                 $result = Get-TargetResource @enableHadrNamedInstance
-                
+
                 $result.IsHadrEnabled | Should Be $false
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -76,28 +76,56 @@ try
         Context 'When HADR is enabled' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{ 
+                return New-Object PSObject -Property @{
                     IsHadrEnabled = $true
                 }
             } -ModuleName $script:DSCResourceName -Verifiable
 
             It 'Should return that HADR is enabled' {
-                
+
                 # Get the current state
                 $result = Get-TargetResource @enableHadr
-                
+
                 $result.IsHadrEnabled | Should Be $true
 
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
 
             It 'Should return that HADR is enabled' {
-                
+
                 # Get the current state
                 $result = Get-TargetResource @enableHadrNamedInstance
-                
+
                 $result.IsHadrEnabled | Should Be $true
 
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+            }
+        }
+
+        # This it regression test for issue #519.
+        Context 'When Server.IsHadrEnabled returns $null' {
+            Mock -CommandName Connect-SQL -MockWith {
+                return New-Object PSObject -Property @{
+                    IsHadrEnabled = $null
+                }
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should fail with the correct error message' {
+                { Get-TargetResource @enableHadr } | Should Not Throw 'Index operation failed; the array index evaluated to null'
+                { Get-TargetResource @enableHadr } | Should Throw 'The status of property Server.IsHadrEnabled was netiher $true or $false. Status is ''''. InnerException: Server.IsHadrEnabled was set to $null.'
+                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 2 -Exactly
+            }
+        }
+
+        Context 'When Server.IsHadrEnabled returns unexpected value' {
+            Mock -CommandName Connect-SQL -MockWith {
+                return New-Object PSObject -Property @{
+                    IsHadrEnabled = 'UnknownStatus'
+                }
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should fail with the correct error message' {
+                { Get-TargetResource @enableHadr } | Should Throw 'The status of property Server.IsHadrEnabled was netiher $true or $false. Status is ''UnknownStatus''. InnerException: Server.IsHadrEnabled was set to unexpected value.'
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
             }
         }
@@ -113,23 +141,23 @@ try
         Mock -CommandName Enable-SqlAlwaysOn -MockWith {} -ModuleName $script:DSCResourceName
 
         Mock -CommandName Import-SQLPSModule -MockWith {} -ModuleName $script:DSCResourceName
-        
+
         Mock -CommandName New-TerminatingError { $ErrorType } -ModuleName $script:DSCResourceName
 
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
-        
+
         Mock -CommandName Restart-SqlService -MockWith {} -ModuleName $script:DSCResourceName -Verifiable
 
         Context 'When HADR is not in the desired state' {
 
             It 'Should enable SQL Always On when Ensure is set to Present' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{ 
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 Set-TargetResource @enableHadr
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
@@ -138,13 +166,13 @@ try
             }
 
             It 'Should disable SQL Always On when Ensure is set to Absent' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                return New-Object PSObject -Property @{ 
+                return New-Object PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 Set-TargetResource @disableHadr
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
@@ -153,13 +181,13 @@ try
             }
 
             It 'Should enable SQL Always On on a named instance when Ensure is set to Present' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{ 
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 Set-TargetResource @enableHadrNamedInstance
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
@@ -168,13 +196,13 @@ try
             }
 
             It 'Should disable SQL Always On on a named instance when Ensure is set to Absent' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{ 
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 Set-TargetResource @disableHadrNamedInstance
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
@@ -183,13 +211,13 @@ try
             }
 
             It 'Should throw the correct error message when Ensure is set to Present, but IsHadrEnabled is $false' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{ 
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $false
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 { Set-TargetResource @enableHadr } | Should Throw 'AlterAlwaysOnServiceFailed'
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 0
@@ -199,13 +227,13 @@ try
             }
 
             It 'Should throw the correct error message when Ensure is set to Absent, but IsHadrEnabled is $true' {
-                
+
                 Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object PSObject -Property @{ 
+                    return New-Object PSObject -Property @{
                         IsHadrEnabled = $true
                     }
                 } -ModuleName $script:DSCResourceName -Verifiable
-                
+
                 { Set-TargetResource @disableHadr } | Should Throw 'AlterAlwaysOnServiceFailed'
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Disable-SqlAlwaysOn -Scope It -Times 1
@@ -217,19 +245,28 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        
-        Mock -CommandName Connect-SQL -MockWith {
-            return New-Object PSObject -Property @{ 
-                IsHadrEnabled = $true
+        Context 'When HADR is not in the desired state' {
+            Mock -CommandName Connect-SQL -MockWith {
+                return New-Object PSObject -Property @{
+                    IsHadrEnabled = $true
+                }
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should cause Test-TargetResource to return false when not in the desired state' {
+                Test-TargetResource @disableHadr | Should be $false
             }
-        } -ModuleName $script:DSCResourceName -Verifiable
-        
-        It 'Should cause Test-TargetResource to return false when not in the desired state' {
-            Test-TargetResource @disableHadr | Should be $false
         }
 
-        It 'Should cause Test-TargetResource to return true when in the desired state' {
-            Test-TargetResource @enableHadr | Should be $true
+        Context 'When HADR is not in the desired state' {
+            Mock -CommandName Connect-SQL -MockWith {
+                return New-Object PSObject -Property @{
+                    IsHadrEnabled = $true
+                }
+            } -ModuleName $script:DSCResourceName -Verifiable
+
+            It 'Should cause Test-TargetResource to return true when in the desired state' {
+                Test-TargetResource @enableHadr | Should be $true
+            }
         }
     }
 }

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -48,6 +48,7 @@ ConfigurationRestartRequired = Configuration option '{0}' has been updated, but 
 
 # AlwaysOnService
 AlterAlwaysOnServiceFailed = Failed to ensure Always On is {0} on the instance '{1}'.
+UnexpectedAlwaysOnStatus = The status of property Server.IsHadrEnabled was netiher $true or $false. Status is '{0}'.
 
 # Login
 PasswordValidationFailed = Creation of the login '{0}' failed due to the following error: {1}


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerAlwaysOnService
  - Get-TargetResource should no longer fail silently with error 'Index operation failed; the array index evaluated to null.'. Now if the Server.IsHadrEnabled property return neither $true or $false the Get-TargetResource function will throw an error.

**This Pull Request (PR) fixes the following issues:**
Fixes #519 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/524)
<!-- Reviewable:end -->
