### PR TITLE
xSQLServerLogin: Disable login parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Updated to return the exception raised when an error is thrown.
 - Changes to xSQLServerLogin
-  - Added Disabled parameter.
+  - Added an optional boolean parameter Disabled. It can be used to enable/disable existing logins or create disabled logins (new logins are created as enabled by default).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   - Updated to return the exception raised when an error is thrown.
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Updated to return the exception raised when an error is thrown.
+- Changes to xSQLServerLogin
+  - Added Disabled parameter.
 
 ## 7.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -8,12 +8,12 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
     .PARAMETER Name
     The name of the login to retrieve.
-    
+
     .PARAMETER SQLServer
     Hostname of the SQL Server to retrieve the login from.
-    
+
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to retrieve the login from. 
+    Name of the SQL instance to retrieve the login from.
 #>
 function Get-TargetResource
 {
@@ -33,7 +33,7 @@ function Get-TargetResource
         [System.String]
         $SQLInstanceName
     )
-    
+
     $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
 
     Write-Verbose 'Getting SQL logins'
@@ -77,16 +77,16 @@ function Get-TargetResource
 
     .PARAMETER Ensure
     Specifies if the login to exist. Default is 'Present'.
-    
+
     .PARAMETER Name
     The name of the login to retrieve.
 
     .PARAMETER LoginType
     The type of login to create. Default is 'WindowsUser'
-    
+
     .PARAMETER SQLServer
     Hostname of the SQL Server to create the login on.
-    
+
     .PARAMETER SQLInstanceName
     Name of the SQL instance to create the login on.
 
@@ -160,9 +160,9 @@ function Set-TargetResource
         [bool]
         $Disabled = $false
     )
-    
+
     $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
-    
+
     switch ( $Ensure )
     {
         'Present'
@@ -199,7 +199,7 @@ function Set-TargetResource
                     New-VerboseMessage -Message "Setting IsDisabled to '$Disabled' for the login '$Name' on the '$SQLServer\$SQLInstanceName' instance."
                     if( $Disabled )
                     {
-                        $login.Disable() 
+                        $login.Disable()
                     }
                     else
                     {
@@ -220,9 +220,9 @@ function Set-TargetResource
                 {
                     throw New-TerminatingError -ErrorType LoginCredentialNotFound -FormatArgs $Name -ErrorCategory ObjectNotFound
                 }
-                
+
                 New-VerboseMessage -Message "Adding the login '$Name' to the '$SQLServer\$SQLInstanceName' instance."
-                
+
                 $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $serverObject,$Name
                 $login.LoginType = $LoginType
 
@@ -235,7 +235,7 @@ function Set-TargetResource
                         {
                             throw New-TerminatingError -ErrorType IncorrectLoginMode -FormatArgs $SQLServer,$SQLInstanceName,$serverObject.LoginMode -ErrorCategory NotImplemented
                         }
-                        
+
                         $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
                         $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
                         if ( $LoginMustChangePassword )
@@ -247,7 +247,7 @@ function Set-TargetResource
                             $LoginCreateOptions = [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::None
                         }
 
-                        New-SQLServerLogin -Login $login -LoginCreateOptions $LoginCreateOptions -SecureString $LoginCredential.Password -ErrorAction Stop 
+                        New-SQLServerLogin -Login $login -LoginCreateOptions $LoginCreateOptions -SecureString $LoginCredential.Password -ErrorAction Stop
                     }
 
                     default
@@ -259,7 +259,7 @@ function Set-TargetResource
                 # we can only disable the login once it's been created
                 if( $Disabled )
                 {
-                    $login.Disable() 
+                    $login.Disable()
                     Update-SQLServerLogin -Login $login
                 }
             }
@@ -282,16 +282,16 @@ function Set-TargetResource
 
     .PARAMETER Ensure
     Specifies if the login is supposed to exist. Default is 'Present'.
-    
+
     .PARAMETER Name
     The name of the login.
 
     .PARAMETER LoginType
     The type of login. Default is 'WindowsUser'
-    
+
     .PARAMETER SQLServer
     Hostname of the SQL Server.
-    
+
     .PARAMETER SQLInstanceName
     Name of the SQL instance.
 
@@ -368,7 +368,7 @@ function Test-TargetResource
 
     # Assume the test will pass
     $testPassed = $true
-    
+
     $getParams = @{
         Name = $Name
         SQLServer = $SQLServer
@@ -391,9 +391,9 @@ function Test-TargetResource
             $testPassed = $false
         }
 
-        if ( $Disabled -ne $loginInfo.IsDisabled )
+        if ( $Disabled -ne $loginInfo.Disabled )
         {
-            New-VerboseMessage -Message "The login '$Name' on the instance '$SQLServer\$SQLInstanceName' has IsDisabled set to $($loginInfo.IsDisabled) rather than $Disabled"
+            New-VerboseMessage -Message "The login '$Name' on the instance '$SQLServer\$SQLInstanceName' has IsDisabled set to $($loginInfo.Disabled) rather than $Disabled"
             $testPassed = $false
         }
 
@@ -415,10 +415,10 @@ function Test-TargetResource
             if ( $testPassed -and $LoginCredential )
             {
                 $userCred = [System.Management.Automation.PSCredential]::new($Name, $LoginCredential.Password)
-                
+
                 try
                 {
-                    $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -SetupCredential $userCred    
+                    $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName -SetupCredential $userCred
                 }
                 catch
                 {
@@ -428,7 +428,7 @@ function Test-TargetResource
             }
         }
     }
-    
+
     return $testPassed
 }
 
@@ -455,7 +455,7 @@ function Update-SQLServerLogin
     {
         $originalErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Stop'
-        
+
         $Login.Alter()
     }
     catch
@@ -511,14 +511,14 @@ function New-SQLServerLogin
 
     switch ( $PSCmdlet.ParameterSetName )
     {
-        'SqlLogin' 
-        { 
+        'SqlLogin'
+        {
             try
             {
                 $originalErrorActionPreference = $ErrorActionPreference
                 $ErrorActionPreference = 'Stop'
-                
-                $login.Create($SecureString,$LoginCreateOptions) 
+
+                $login.Create($SecureString,$LoginCreateOptions)
             }
             catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]
             {
@@ -547,7 +547,7 @@ function New-SQLServerLogin
             {
                 $originalErrorActionPreference = $ErrorActionPreference
                 $ErrorActionPreference = 'Stop'
-                
+
                 $login.Create()
             }
             catch
@@ -585,7 +585,7 @@ function Remove-SQLServerLogin
     {
         $originalErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Stop'
-        
+
         $Login.Drop()
     }
     catch
@@ -628,7 +628,7 @@ function Set-SQLServerLoginPassword
     {
         $originalErrorActionPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Stop'
-        
+
         $Login.ChangePassword($SecureString)
     }
     catch [Microsoft.SqlServer.Management.Smo.FailedOperationException]

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -145,20 +145,20 @@ function Set-TargetResource
         $LoginCredential,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginMustChangePassword = $true,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginPasswordExpirationEnabled = $true,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginPasswordPolicyEnforced = $true,
 
         [Parameter()]
-        [bool]
-        $Disabled = $false
+        [System.Boolean]
+        $Disabled
     )
 
     $serverObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
@@ -194,7 +194,7 @@ function Set-TargetResource
                     }
                 }
 
-                if ( $login.IsDisabled -ne $Disabled )
+                if ( $PSBoundParameters.ContainsKey('Disabled') -and ($login.IsDisabled -ne $Disabled) )
                 {
                     New-VerboseMessage -Message "Setting IsDisabled to '$Disabled' for the login '$Name' on the '$SQLServer\$SQLInstanceName' instance."
                     if( $Disabled )
@@ -205,7 +205,6 @@ function Set-TargetResource
                     {
                         $login.Enable()
                     }
-                    Update-SQLServerLogin -Login $login
                 }
             }
             else
@@ -260,7 +259,6 @@ function Set-TargetResource
                 if( $Disabled )
                 {
                     $login.Disable()
-                    Update-SQLServerLogin -Login $login
                 }
             }
         }
@@ -350,20 +348,20 @@ function Test-TargetResource
         $LoginCredential,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginMustChangePassword = $true,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginPasswordExpirationEnabled = $true,
 
         [Parameter()]
-        [bool]
+        [System.Boolean]
         $LoginPasswordPolicyEnforced = $true,
 
         [Parameter()]
-        [bool]
-        $Disabled = $false
+        [System.Boolean]
+        $Disabled
     )
 
     # Assume the test will pass
@@ -391,7 +389,7 @@ function Test-TargetResource
             $testPassed = $false
         }
 
-        if ( $Disabled -ne $loginInfo.Disabled )
+        if ( $PSBoundParameters.ContainsKey('Disabled') -and ($login.IsDisabled -ne $Disabled) )
         {
             New-VerboseMessage -Message "The login '$Name' on the instance '$SQLServer\$SQLInstanceName' has IsDisabled set to $($loginInfo.Disabled) rather than $Disabled"
             $testPassed = $false

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.psm1
@@ -389,7 +389,7 @@ function Test-TargetResource
             $testPassed = $false
         }
 
-        if ( $PSBoundParameters.ContainsKey('Disabled') -and ($login.IsDisabled -ne $Disabled) )
+        if ( $PSBoundParameters.ContainsKey('Disabled') -and ($loginInfo.Disabled -ne $Disabled) )
         {
             New-VerboseMessage -Message "The login '$Name' on the instance '$SQLServer\$SQLInstanceName' has IsDisabled set to $($loginInfo.Disabled) rather than $Disabled"
             $testPassed = $false

--- a/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
+++ b/DSCResources/MSFT_xSQLServerLogin/MSFT_xSQLServerLogin.schema.mof
@@ -12,4 +12,5 @@ class MSFT_xSQLServerLogin : OMI_BaseResource
     [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.")] Boolean LoginMustChangePassword;
     [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.")] Boolean LoginPasswordExpirationEnabled;
     [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.")] Boolean LoginPasswordPolicyEnforced;
+    [Write, Description("Specifies if the login is disabled. Default is $false.")] Boolean Disabled;
 };

--- a/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
+++ b/Examples/Resources/xSQLServerLogin/1-AddLogin.ps1
@@ -34,6 +34,17 @@ Configuration Example
             PsDscRunAsCredential = $SysAdminAccount
         }
 
+        xSQLServerLogin Add_DisabledWindowsUser
+        {
+            Ensure = 'Present'
+            Name = 'CONTOSO\WindowsUser2'
+            LoginType = 'WindowsUser'
+            SQLServer = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            PsDscRunAsCredential = $SysAdminAccount
+            Disabled = $true
+        }
+
         xSQLServerLogin Add_WindowsGroup
         {
             Ensure = 'Present'

--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ No description.
 * **[Boolean] LoginMustChangePassword** _(Write)_: Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.
 * **[Boolean] LoginPasswordExpirationEnabled** _(Write)_: Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.
 * **[Boolean] LoginPasswordPolicyEnforced** _(Write)_: Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.
+* **[Boolean] Disabled** _(Write)_: Specifies if the login is disabled. Default is $false.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -544,7 +544,7 @@ try
                     $script:mockWasLoginClassMethodDisabledCalled | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
@@ -563,7 +563,7 @@ try
                     $script:mockWasLoginClassMethodDisabledCalled | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
@@ -693,7 +693,7 @@ try
                     $script:mockWasLoginClassMethodDisabledCalled | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -6,10 +6,10 @@ $script:DSCResourceName    = 'MSFT_xSQLServerLogin'
 
 #region HEADER
 
-# Unit Test Template Version: 1.1.0
-[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
@@ -23,883 +23,889 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
+function Invoke-TestSetup {
+    Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
+    Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
 # Begin Testing
 try
 {
-    #region Pester Test Initialization
+    Invoke-TestSetup
 
-    Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force
-    Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
+    InModuleScope $script:DSCResourceName {
+        # Create PSCredential object for SQL Logins
+        $mockSqlLoginUser = 'dba'
+        $mockSqlLoginPassword = 'P@ssw0rd-12P@ssw0rd-12' | ConvertTo-SecureString -AsPlainText -Force
+        $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
 
-    # Create PSCredential object for SQL Logins
-    $mockSqlLoginUser = 'dba'
-    $mockSqlLoginPassword = 'P@ssw0rd-12P@ssw0rd-12' | ConvertTo-SecureString -AsPlainText -Force
-    $mockSqlLoginCredential = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginPassword )
+        $mockSqlLoginBadPassword = 'pw' | ConvertTo-SecureString -AsPlainText -Force
+        $mockSqlLoginCredentialBadPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginBadPassword )
 
-    $mockSqlLoginBadPassword = 'pw' | ConvertTo-SecureString -AsPlainText -Force
-    $mockSqlLoginCredentialBadPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginBadPassword )
+        $mockSqlLoginReusedPassword = 'reused' | ConvertTo-SecureString -AsPlainText -Force
+        $mockSqlLoginCredentialReusedPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginReusedPassword )
 
-    $mockSqlLoginReusedPassword = 'reused' | ConvertTo-SecureString -AsPlainText -Force
-    $mockSqlLoginCredentialReusedPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginReusedPassword )
+        $mockSqlLoginOtherPassword = 'other' | ConvertTo-SecureString -AsPlainText -Force
+        $mockSqlLoginCredentialOtherPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginOtherPassword )
 
-    $mockSqlLoginOtherPassword = 'other' | ConvertTo-SecureString -AsPlainText -Force
-    $mockSqlLoginCredentialOtherPassword = New-Object System.Management.Automation.PSCredential( $mockSqlLoginUser, $mockSqlLoginOtherPassword )
-
-    $instanceParameters = @{
-        SQLInstanceName = 'MSSQLSERVER'
-        SQLServer = 'Server1'
-    }
-
-    $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
-    $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
-
-    $getTargetResource_UnknownWindows = $instanceParameters.Clone()
-    $getTargetResource_UnknownWindows.Add( 'Name','Windows\UserOrGroup' )
-
-    $getTargetResource_KnownSqlLogin = $instanceParameters.Clone()
-    $getTargetResource_KnownSqlLogin.Add( 'Name','SqlLogin1' )
-
-    $getTargetResource_KnownWindowsUser = $instanceParameters.Clone()
-    $getTargetResource_KnownWindowsUser.Add( 'Name','Windows\User1' )
-
-    $getTargetResource_KnownWindowsGroup = $instanceParameters.Clone()
-    $getTargetResource_KnownWindowsGroup.Add( 'Name','Windows\Group1' )
-
-    $testTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-    $testTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-    $testTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
-
-    $testTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-    $testTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-    $testTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
-
-    $testTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-    $testTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-    $testTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
-
-    $testTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-    $testTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-    $testTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
-
-    $testTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
-    $testTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
-    $testTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
-
-    $testTargetResource_SqlLoginPresentWithDefaultValues = $instanceParameters.Clone()
-    $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
-    $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
-    $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
-    $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
-
-    $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-    $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-    $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
-
-    $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-    $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-    $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
-
-    $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-    $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
-    $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
-    $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-    $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-    $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
-
-    $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
-    $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
-    $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
-
-    $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
-    $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
-    $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
-
-    $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
-    $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
-    $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
-
-    $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
-    $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
-    $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
-    $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
-
-    $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
-    $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
-    $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
-
-    $setTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
-    $setTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
-    $setTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
-
-    $setTargetResource_SqlLoginPresent = $instanceParameters.Clone()
-    $setTargetResource_SqlLoginPresent.Add( 'Name','SqlLogin1' )
-    $setTargetResource_SqlLoginPresent.Add( 'LoginType','SqlLogin' )
-
-    <#
-        Must use $global here because the tests are not in module scope.
-        When that changes this should be changed back to $script.
-    #>
-    $global:mockWasLoginClassMethodEnableCalled = $false
-    $global:mockWasLoginClassMethodDisabledCalled = $false
-
-    $mockConnectSql = {
-        $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
-        $windowsUser.LoginType = 'WindowsUser'
-        $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
-            $global:mockWasLoginClassMethodDisabledCalled = $true
-        } -PassThru -Force
-
-        $windowsGroup = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\Group1' )
-        $windowsGroup.LoginType = 'windowsGroup'
-
-        $sqlLogin = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'SqlLogin1' )
-        $sqlLogin.LoginType = 'SqlLogin'
-        $sqlLogin.MustChangePassword = $false
-        $sqlLogin.PasswordPolicyEnforced = $true
-        $sqlLogin.PasswordExpirationEnabled = $true
-
-        $sqlLoginDisabled = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\UserDisabled' )
-        $sqlLoginDisabled.LoginType = 'WindowsUser'
-        $sqlLoginDisabled.IsDisabled = $true
-        $sqlLoginDisabled = $sqlLoginDisabled | Add-Member -Name 'Enable' -MemberType ScriptMethod {
-            $global:mockWasLoginClassMethodEnableCalled = $true
-        } -PassThru -Force
-
-        $mock = New-Object PSObject -Property @{
-            LoginMode = 'Mixed'
-            Logins = @{
-                $windowsUser.Name = $windowsUser
-                $windowsGroup.Name = $windowsGroup
-                $sqlLogin.Name = $sqlLogin
-                $sqlLoginDisabled.Name = $sqlLoginDisabled
-            }
+        $instanceParameters = @{
+            SQLInstanceName = 'MSSQLSERVER'
+            SQLServer = 'Server1'
         }
 
-        return $mock
-    }
+        $getTargetResource_UnknownSqlLogin = $instanceParameters.Clone()
+        $getTargetResource_UnknownSqlLogin.Add( 'Name','UnknownSqlLogin' )
 
-    #endregion Pester Test Initialization
+        $getTargetResource_UnknownWindows = $instanceParameters.Clone()
+        $getTargetResource_UnknownWindows.Add( 'Name','Windows\UserOrGroup' )
 
-    Describe "$($script:DSCResourceName)\Get-TargetResource" {
-        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Verifiable -Scope Describe
+        $getTargetResource_KnownSqlLogin = $instanceParameters.Clone()
+        $getTargetResource_KnownSqlLogin.Add( 'Name','SqlLogin1' )
 
-        Context 'When the login is Absent' {
+        $getTargetResource_KnownWindowsUser = $instanceParameters.Clone()
+        $getTargetResource_KnownWindowsUser.Add( 'Name','Windows\User1' )
 
-            It 'Should be Absent when an unknown SQL Login is provided' {
-                ( Get-TargetResource @getTargetResource_UnknownSqlLogin ).Ensure | Should Be 'Absent'
+        $getTargetResource_KnownWindowsGroup = $instanceParameters.Clone()
+        $getTargetResource_KnownWindowsGroup.Add( 'Name','Windows\Group1' )
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+        $testTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+        $testTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+        $testTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+        $testTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+        $testTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+        $testTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+        $testTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+        $testTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+        $testTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+
+        $testTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+        $testTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+        $testTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
+        $testTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
+        $testTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
+        $testTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+
+        $testTargetResource_SqlLoginPresentWithDefaultValues = $instanceParameters.Clone()
+        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'Name','SqlLogin1' )
+        $testTargetResource_SqlLoginPresentWithDefaultValues.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
+        $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+
+        $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+        $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+        $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+        $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+        $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+        $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+        $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+        $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+        $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
+        $setTargetResource_CertificateAbsent = $instanceParameters.Clone()
+        $setTargetResource_CertificateAbsent.Add( 'Name','Certificate' )
+        $setTargetResource_CertificateAbsent.Add( 'LoginType','Certificate' )
+
+        $setTargetResource_WindowsUserAbsent = $instanceParameters.Clone()
+        $setTargetResource_WindowsUserAbsent.Add( 'Name','Windows\UserAbsent' )
+        $setTargetResource_WindowsUserAbsent.Add( 'LoginType','WindowsUser' )
+
+        $setTargetResource_WindowsGroupAbsent = $instanceParameters.Clone()
+        $setTargetResource_WindowsGroupAbsent.Add( 'Name','Windows\GroupAbsent' )
+        $setTargetResource_WindowsGroupAbsent.Add( 'LoginType','WindowsGroup' )
+
+        $setTargetResource_SqlLoginAbsent = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsent.Add( 'Name','SqlLoginAbsent' )
+        $setTargetResource_SqlLoginAbsent.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_SqlLoginAbsentExisting = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'Name','Existing' )
+        $setTargetResource_SqlLoginAbsentExisting.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_SqlLoginAbsentUnknown = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'Name','Unknown' )
+        $setTargetResource_SqlLoginAbsentUnknown.Add( 'LoginType','SqlLogin' )
+
+        $setTargetResource_WindowsUserPresent = $instanceParameters.Clone()
+        $setTargetResource_WindowsUserPresent.Add( 'Name','Windows\User1' )
+        $setTargetResource_WindowsUserPresent.Add( 'LoginType','WindowsUser' )
+
+        $setTargetResource_WindowsGroupPresent = $instanceParameters.Clone()
+        $setTargetResource_WindowsGroupPresent.Add( 'Name','Windows\Group1' )
+        $setTargetResource_WindowsGroupPresent.Add( 'LoginType','WindowsGroup' )
+
+        $setTargetResource_SqlLoginPresent = $instanceParameters.Clone()
+        $setTargetResource_SqlLoginPresent.Add( 'Name','SqlLogin1' )
+        $setTargetResource_SqlLoginPresent.Add( 'LoginType','SqlLogin' )
+
+        <#
+            These are set when the mocked methods Enable() and Disabled() are called.
+            Can be used to verify that the method was actually called or not called.
+        #>
+        $script:mockWasLoginClassMethodEnableCalled = $false
+        $script:mockWasLoginClassMethodDisabledCalled = $false
+
+        $mockConnectSql = {
+            $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
+            $windowsUser.LoginType = 'WindowsUser'
+            $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
+                $script:mockWasLoginClassMethodDisabledCalled = $true
+            } -PassThru -Force
+
+            $windowsGroup = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\Group1' )
+            $windowsGroup.LoginType = 'windowsGroup'
+
+            $sqlLogin = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'SqlLogin1' )
+            $sqlLogin.LoginType = 'SqlLogin'
+            $sqlLogin.MustChangePassword = $false
+            $sqlLogin.PasswordPolicyEnforced = $true
+            $sqlLogin.PasswordExpirationEnabled = $true
+
+            $sqlLoginDisabled = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\UserDisabled' )
+            $sqlLoginDisabled.LoginType = 'WindowsUser'
+            $sqlLoginDisabled.IsDisabled = $true
+            $sqlLoginDisabled = $sqlLoginDisabled | Add-Member -Name 'Enable' -MemberType ScriptMethod {
+                $script:mockWasLoginClassMethodEnableCalled = $true
+            } -PassThru -Force
+
+            $mock = New-Object PSObject -Property @{
+                LoginMode = 'Mixed'
+                Logins = @{
+                    $windowsUser.Name = $windowsUser
+                    $windowsGroup.Name = $windowsGroup
+                    $sqlLogin.Name = $sqlLogin
+                    $sqlLoginDisabled.Name = $sqlLoginDisabled
+                }
             }
 
-            It 'Should be Absent when an unknown Windows User or Group is provided' {
-                ( Get-TargetResource @getTargetResource_UnknownWindows ).Ensure | Should Be 'Absent'
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
+            return $mock
         }
 
-        Context 'When the login is Present' {
-            It 'Should be Present when a known SQL Login is provided' {
-                $result = Get-TargetResource @getTargetResource_KnownSqlLogin
+        #endregion Pester Test Initialization
 
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'SqlLogin'
-                $result.LoginMustChangePassword | Should Not BeNullOrEmpty
-                $result.LoginPasswordExpirationEnabled | Should Not BeNullOrEmpty
-                $result.LoginPasswordPolicyEnforced | Should Not BeNullOrEmpty
+        Describe 'MSFT_xSQLServerLogin\Get-TargetResource' {
+            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable -Scope Describe
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
+            Context 'When the login is Absent' {
 
-            It 'Should be Present when a known Windows User is provided' {
-                $result = Get-TargetResource @getTargetResource_KnownWindowsUser
+                It 'Should be Absent when an unknown SQL Login is provided' {
+                    ( Get-TargetResource @getTargetResource_UnknownSqlLogin ).Ensure | Should Be 'Absent'
 
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'WindowsUser'
-                $result.LoginMustChangePassword | Should BeNullOrEmpty
-                $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
-                $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should be Present when a known Windows Group is provided' {
-                $result = Get-TargetResource @getTargetResource_KnownWindowsGroup
-
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'WindowsGroup'
-                $result.LoginMustChangePassword | Should BeNullOrEmpty
-                $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
-                $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should be return the correct values when a login is disabled' {
-                $mockGetTargetResourceParameters = $instanceParameters.Clone()
-                $mockGetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
-                $result = Get-TargetResource @mockGetTargetResourceParameters
-
-                $result.Ensure | Should Be 'Present'
-                $result.LoginType | Should Be 'WindowsUser'
-                $result.LoginMustChangePassword | Should BeNullOrEmpty
-                $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
-                $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
-                $result.Disabled | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-        }
-    }
-
-    Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-        Context 'When the desired state is Absent' {
-            It 'Should return $true when the specified Windows user is Absent' {
-                $testTargetResource_WindowsUserAbsent_EnsureAbsent = $testTargetResource_WindowsUserAbsent.Clone()
-                $testTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsureAbsent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified Windows group is Absent' {
-                $testTargetResource_WindowsGroupAbsent_EnsureAbsent = $testTargetResource_WindowsGroupAbsent.Clone()
-                $testTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsureAbsent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified SQL Login is Absent' {
-                $testTargetResource_SqlLoginAbsent_EnsureAbsent = $testTargetResource_SqlLoginAbsent.Clone()
-                $testTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsureAbsent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified Windows user is Present' {
-                $testTargetResource_WindowsUserPresent_EnsureAbsent = $testTargetResource_WindowsUserPresent.Clone()
-                $testTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsureAbsent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified Windows group is Present' {
-                $testTargetResource_WindowsGroupPresent_EnsureAbsent = $testTargetResource_WindowsGroupPresent.Clone()
-                $testTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsureAbsent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Present' {
-                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should be return $false when a login should be disabled but are enabled' {
-                $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
-                $mockTestTargetResourceParameters.Add( 'Disabled', $true )
-
-                $result = Test-TargetResource @mockTestTargetResourceParameters
-                $result | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should be return $false when a login should be enabled but are disabled' {
-                $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
-                $mockTestTargetResourceParameters.Add( 'Disabled', $false )
-
-                $result = Test-TargetResource @mockTestTargetResourceParameters
-                $result | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-        }
-
-        Context 'When the desired state is Present' {
-            It 'Should return $false when the specified Windows user is Absent' {
-                $testTargetResource_WindowsUserAbsent_EnsurePresent = $testTargetResource_WindowsUserAbsent.Clone()
-                $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified Windows group is Absent' {
-                $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
-                $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Absent' {
-                $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
-                $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified Windows user is Present' {
-                $testTargetResource_WindowsUserPresent_EnsurePresent = $testTargetResource_WindowsUserPresent.Clone()
-                $testTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified Windows group is Present' {
-                $testTargetResource_WindowsGroupPresent_EnsurePresent = $testTargetResource_WindowsGroupPresent.Clone()
-                $testTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified SQL Login is Present using default parameter values' {
-                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent.Add( 'Ensure','Present' )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified SQL Login is Present and PasswordExpirationEnabled is $true' {
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$true )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Present and PasswordExpirationEnabled is $false' {
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$false )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified SQL Login is Present and PasswordPolicyEnforced is $true' {
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$true )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should return $true when the specified SQL Login is Present using default parameter values and the password is properly configured.' {
-                $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent ) | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 2 -Exactly
-            }
-
-            It 'Should return $false when the specified SQL Login is Present using default parameter values and the password is not properly configured.' {
-                Mock -CommandName Connect-SQL -MockWith { throw } -ModuleName $script:DSCResourceName -Scope It -Verifiable -ParameterFilter { $SetupCredential }
-
-                $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
-                $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'Ensure','Present' )
-                $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadPassword )
-
-                ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent ) | Should Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 2 -Exactly
-            }
-
-            It 'Should be return $true when a login is enabled' {
-                $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
-                $mockTestTargetResourceParameters.Add( 'Disabled', $false )
-
-                $result = Test-TargetResource @mockTestTargetResourceParameters
-                $result | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should be return $true when a login is disabled' {
-                $mockTestTargetResourceParameters = $instanceParameters.Clone()
-                $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
-                $mockTestTargetResourceParameters.Add( 'Disabled', $true )
-
-                $result = Test-TargetResource @mockTestTargetResourceParameters
-                $result | Should Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-            }
-        }
-    }
-
-    Describe "$($script:DSCResourceName)\Set-TargetResource" {
-        Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
-        Mock -CommandName Update-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName New-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName Remove-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
-        Mock -CommandName Set-SQLServerLoginPassword -MockWith {} -ModuleName $script:DSCResourceName
-
-        Context 'When the desired state is Absent' {
-            BeforeEach {
-                $global:mockWasLoginClassMethodEnableCalled = $false
-                $global:mockWasLoginClassMethodDisabledCalled = $false
-            }
-
-            It 'Should drop the specified Windows User when it is Present' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsUserPresent_EnsureAbsent = $setTargetResource_WindowsUserPresent.Clone()
-                $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_WindowsUserPresent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should enable the specified Windows User when it is disabled' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockSetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
-                $mockSetTargetResourceParameters.Add( 'Disabled', $false )
-
-                Set-TargetResource @mockSetTargetResourceParameters
-                $global:mockWasLoginClassMethodEnableCalled | Should -Be $true
-                $global:mockWasLoginClassMethodDisabledCalled | Should -Be $false
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should disable the specified Windows User when it is enabled' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockSetTargetResourceParameters.Add( 'Name','Windows\User1' )
-                $mockSetTargetResourceParameters.Add( 'Disabled', $true )
-
-                Set-TargetResource @mockSetTargetResourceParameters
-                $global:mockWasLoginClassMethodEnableCalled | Should -Be $false
-                $global:mockWasLoginClassMethodDisabledCalled | Should -Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should drop the specified Windows Group when it is Present' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsGroupPresent_EnsureAbsent = $setTargetResource_WindowsGroupPresent.Clone()
-                $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should drop the specified SQL Login when it is Present' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginPresent_EnsureAbsent = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should do nothing when the specified Windows User is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsUserAbsent_EnsureAbsent = $setTargetResource_WindowsUserAbsent.Clone()
-                $setTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should do nothing when the specified Windows Group is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsGroupAbsent_EnsureAbsent = $setTargetResource_WindowsGroupAbsent.Clone()
-                $setTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should do nothing when the specified SQL Login is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginAbsent_EnsureAbsent = $setTargetResource_SqlLoginAbsent.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
-
-                Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsureAbsent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-        }
-
-        Context 'When the desired state is Present' {
-            BeforeEach {
-                $global:mockWasLoginClassMethodEnableCalled = $false
-                $global:mockWasLoginClassMethodDisabledCalled = $false
-            }
-
-            It 'Should add the specified Windows User when it is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsUserAbsent_EnsurePresent = $setTargetResource_WindowsUserAbsent.Clone()
-                $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should add the specified Windows User as disabled when it is Absent' {
-                Mock -CommandName Connect-SQL -MockWith {
-                    return New-Object -TypeName PSObject -Property @{
-                        Logins = @{}
-                    }
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                Mock -CommandName New-Object -MockWith {
-                    $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
-                    $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
-                        $global:mockWasLoginClassMethodDisabledCalled = $true
-                    } -PassThru -Force
-
-                    return $windowsUser
-                } -ParameterFilter {
-                    $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Login' -and $ArgumentList[1] -eq 'Windows\UserAbsent'
-                } -ModuleName $script:DSCResourceName -Verifiable
-
-                $mockSetTargetResourceParameters = $instanceParameters.Clone()
-                $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
-                $mockSetTargetResourceParameters.Add( 'Name','Windows\UserAbsent' )
-                $mockSetTargetResourceParameters.Add( 'Disabled', $true )
-
-                Set-TargetResource @mockSetTargetResourceParameters
-                $global:mockWasLoginClassMethodDisabledCalled | Should -Be $true
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should add the specified Windows Group when it is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsGroupAbsent_EnsurePresent = $setTargetResource_WindowsGroupAbsent.Clone()
-                $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should add the specified SQL Login when it is Absent' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-
-                Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginMustChangePassword',$false )
-
-                Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should throw the correct error when adding an unsupported login type' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_CertificateAbsent_EnsurePresent = $setTargetResource_CertificateAbsent.Clone()
-                $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure','Present' )
-
-                { Set-TargetResource @setTargetResource_CertificateAbsent_EnsurePresent } | Should Throw 'LoginTypeNotImplemented'
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should throw the correct error when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
-
-                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should do nothing if the specified Windows User is Present' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsUserPresent_EnsurePresent = $setTargetResource_WindowsUserPresent.Clone()
-                $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
-
-                Set-TargetResource @setTargetResource_WindowsUserPresent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should do nothing if the specified Windows Group is Present' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_WindowsGroupPresent_EnsurePresent = $setTargetResource_WindowsGroupPresent.Clone()
-                $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
-
-                Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
-            }
-
-            It 'Should update the password of the specified SQL Login if it is Present and all parameters match' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
-
-                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential',$mockSqlLoginCredential )
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginPasswordExpirationEnabled',$false )
-
-                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -ModuleName $script:DSCResourceName -Scope It -Verifiable
-
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced = $setTargetResource_SqlLoginPresent.Clone()
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential',$mockSqlLoginCredential )
-                $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginPasswordPolicyEnforced',$false )
-
-                Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced
-
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 1 -Exactly
-            }
-
-            It 'Should throw the correct error when creating a SQL Login if the LoginMode is not Mixed' {
-                $mockConnectSQL_LoginModeNormal = {
-                    return New-Object Object |
-                        Add-Member ScriptProperty Logins {
-                            return @{
-                                'Windows\User1' = ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                )
-                                'SqlLogin1' = ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                )
-                                'Windows\Group1' = ( New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
-                                )
-                            }
-                        } -PassThru |
-                        Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Normal' -PassThru -Force
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL_LoginModeNormal -ModuleName $script:DSCResourceName -Scope It -Verifiable
+                It 'Should be Absent when an unknown Windows User or Group is provided' {
+                    ( Get-TargetResource @getTargetResource_UnknownWindows ).Ensure | Should Be 'Absent'
 
-                $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
-                $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+            }
 
-                { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
+            Context 'When the login is Present' {
+                It 'Should be Present when a known SQL Login is provided' {
+                    $result = Get-TargetResource @getTargetResource_KnownSqlLogin
 
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Update-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName New-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Remove-SQLServerLogin -Scope It -Times 0 -Exactly
-                Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Set-SQLServerLoginPassword -Scope It -Times 0 -Exactly
+                    $result.Ensure | Should Be 'Present'
+                    $result.LoginType | Should Be 'SqlLogin'
+                    $result.LoginMustChangePassword | Should Not BeNullOrEmpty
+                    $result.LoginPasswordExpirationEnabled | Should Not BeNullOrEmpty
+                    $result.LoginPasswordPolicyEnforced | Should Not BeNullOrEmpty
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be Present when a known Windows User is provided' {
+                    $result = Get-TargetResource @getTargetResource_KnownWindowsUser
+
+                    $result.Ensure | Should Be 'Present'
+                    $result.LoginType | Should Be 'WindowsUser'
+                    $result.LoginMustChangePassword | Should BeNullOrEmpty
+                    $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
+                    $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be Present when a known Windows Group is provided' {
+                    $result = Get-TargetResource @getTargetResource_KnownWindowsGroup
+
+                    $result.Ensure | Should Be 'Present'
+                    $result.LoginType | Should Be 'WindowsGroup'
+                    $result.LoginMustChangePassword | Should BeNullOrEmpty
+                    $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
+                    $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be return the correct values when a login is disabled' {
+                    $mockGetTargetResourceParameters = $instanceParameters.Clone()
+                    $mockGetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $result = Get-TargetResource @mockGetTargetResourceParameters
+
+                    $result.Ensure | Should Be 'Present'
+                    $result.LoginType | Should Be 'WindowsUser'
+                    $result.LoginMustChangePassword | Should BeNullOrEmpty
+                    $result.LoginPasswordExpirationEnabled | Should BeNullOrEmpty
+                    $result.LoginPasswordPolicyEnforced | Should BeNullOrEmpty
+                    $result.Disabled | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
             }
         }
-    }
 
-    InModuleScope -ModuleName $script:DSCResourceName {
-        Describe "$($script:DSCResourceName)\Update-SQLServerLogin" {
+        Describe 'MSFT_xSQLServerLogin\Test-TargetResource' {
+            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+            Context 'When the desired state is Absent' {
+                It 'Should return $true when the specified Windows user is Absent' {
+                    $testTargetResource_WindowsUserAbsent_EnsureAbsent = $testTargetResource_WindowsUserAbsent.Clone()
+                    $testTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsureAbsent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified Windows group is Absent' {
+                    $testTargetResource_WindowsGroupAbsent_EnsureAbsent = $testTargetResource_WindowsGroupAbsent.Clone()
+                    $testTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsureAbsent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified SQL Login is Absent' {
+                    $testTargetResource_SqlLoginAbsent_EnsureAbsent = $testTargetResource_SqlLoginAbsent.Clone()
+                    $testTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsureAbsent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified Windows user is Present' {
+                    $testTargetResource_WindowsUserPresent_EnsureAbsent = $testTargetResource_WindowsUserPresent.Clone()
+                    $testTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsureAbsent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified Windows group is Present' {
+                    $testTargetResource_WindowsGroupPresent_EnsureAbsent = $testTargetResource_WindowsGroupPresent.Clone()
+                    $testTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsureAbsent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified SQL Login is Present' {
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsureAbsent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be return $false when a login should be disabled but are enabled' {
+                    $mockTestTargetResourceParameters = $instanceParameters.Clone()
+                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockTestTargetResourceParameters.Add( 'Disabled', $true )
+
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be return $false when a login should be enabled but are disabled' {
+                    $mockTestTargetResourceParameters = $instanceParameters.Clone()
+                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockTestTargetResourceParameters.Add( 'Disabled', $false )
+
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
+                    $result | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+            }
+
+            Context 'When the desired state is Present' {
+                It 'Should return $false when the specified Windows user is Absent' {
+                    $testTargetResource_WindowsUserAbsent_EnsurePresent = $testTargetResource_WindowsUserAbsent.Clone()
+                    $testTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsUserAbsent_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified Windows group is Absent' {
+                    $testTargetResource_WindowsGroupAbsent_EnsurePresent = $testTargetResource_WindowsGroupAbsent.Clone()
+                    $testTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsGroupAbsent_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified SQL Login is Absent' {
+                    $testTargetResource_SqlLoginAbsent_EnsurePresent = $testTargetResource_SqlLoginAbsent.Clone()
+                    $testTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginAbsent_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified Windows user is Present' {
+                    $testTargetResource_WindowsUserPresent_EnsurePresent = $testTargetResource_WindowsUserPresent.Clone()
+                    $testTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsUserPresent_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified Windows group is Present' {
+                    $testTargetResource_WindowsGroupPresent_EnsurePresent = $testTargetResource_WindowsGroupPresent.Clone()
+                    $testTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_WindowsGroupPresent_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified SQL Login is Present using default parameter values' {
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent.Add( 'Ensure','Present' )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValues_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified SQL Login is Present and PasswordExpirationEnabled is $true' {
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$true )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledTrue_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified SQL Login is Present and PasswordExpirationEnabled is $false' {
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent.Add( 'LoginPasswordExpirationEnabled',$false )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordExpirationEnabledFalse_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified SQL Login is Present and PasswordPolicyEnforced is $true' {
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$true )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedTrue_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $false when the specified SQL Login is Present and PasswordPolicyEnforced is $false' {
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent.Add( 'LoginPasswordPolicyEnforced',$false )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithPasswordPolicyEnforcedFalse_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should return $true when the specified SQL Login is Present using default parameter values and the password is properly configured.' {
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesGoodPw_EnsurePresent ) | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly
+                }
+
+                It 'Should return $false when the specified SQL Login is Present using default parameter values and the password is not properly configured.' {
+                    Mock -CommandName Connect-SQL -MockWith { throw } -Verifiable -ParameterFilter { $SetupCredential }
+
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent = $testTargetResource_SqlLoginPresentWithDefaultValues.Clone()
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'Ensure','Present' )
+                    $testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredentialBadPassword )
+
+                    ( Test-TargetResource @testTargetResource_SqlLoginPresentWithDefaultValuesBadPw_EnsurePresent ) | Should Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly
+                }
+
+                It 'Should be return $true when a login is enabled' {
+                    $mockTestTargetResourceParameters = $instanceParameters.Clone()
+                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockTestTargetResourceParameters.Add( 'Disabled', $false )
+
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should be return $true when a login is disabled' {
+                    $mockTestTargetResourceParameters = $instanceParameters.Clone()
+                    $mockTestTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockTestTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockTestTargetResourceParameters.Add( 'Disabled', $true )
+
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
+                    $result | Should Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                }
+            }
+        }
+
+        Describe 'MSFT_xSQLServerLogin\Set-TargetResource' {
+            Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
+            Mock -CommandName Update-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+            Mock -CommandName New-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+            Mock -CommandName Remove-SQLServerLogin -MockWith {} -ModuleName $script:DSCResourceName
+            Mock -CommandName Set-SQLServerLoginPassword -MockWith {} -ModuleName $script:DSCResourceName
+
+            Context 'When the desired state is Absent' {
+                BeforeEach {
+                    $script:mockWasLoginClassMethodEnableCalled = $false
+                    $script:mockWasLoginClassMethodDisabledCalled = $false
+                }
+
+                It 'Should drop the specified Windows User when it is Present' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsUserPresent_EnsureAbsent = $setTargetResource_WindowsUserPresent.Clone()
+                    $setTargetResource_WindowsUserPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_WindowsUserPresent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should enable the specified Windows User when it is disabled' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $mockSetTargetResourceParameters = $instanceParameters.Clone()
+                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name','Windows\UserDisabled' )
+                    $mockSetTargetResourceParameters.Add( 'Disabled', $false )
+
+                    Set-TargetResource @mockSetTargetResourceParameters
+                    $script:mockWasLoginClassMethodEnableCalled | Should -Be $true
+                    $script:mockWasLoginClassMethodDisabledCalled | Should -Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should disable the specified Windows User when it is enabled' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $mockSetTargetResourceParameters = $instanceParameters.Clone()
+                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name','Windows\User1' )
+                    $mockSetTargetResourceParameters.Add( 'Disabled', $true )
+
+                    Set-TargetResource @mockSetTargetResourceParameters
+                    $script:mockWasLoginClassMethodEnableCalled | Should -Be $false
+                    $script:mockWasLoginClassMethodDisabledCalled | Should -Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should drop the specified Windows Group when it is Present' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsGroupPresent_EnsureAbsent = $setTargetResource_WindowsGroupPresent.Clone()
+                    $setTargetResource_WindowsGroupPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should drop the specified SQL Login when it is Present' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginPresent_EnsureAbsent = $setTargetResource_SqlLoginPresent.Clone()
+                    $setTargetResource_SqlLoginPresent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_SqlLoginPresent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should do nothing when the specified Windows User is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsUserAbsent_EnsureAbsent = $setTargetResource_WindowsUserAbsent.Clone()
+                    $setTargetResource_WindowsUserAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should do nothing when the specified Windows Group is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsGroupAbsent_EnsureAbsent = $setTargetResource_WindowsGroupAbsent.Clone()
+                    $setTargetResource_WindowsGroupAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should do nothing when the specified SQL Login is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginAbsent_EnsureAbsent = $setTargetResource_SqlLoginAbsent.Clone()
+                    $setTargetResource_SqlLoginAbsent_EnsureAbsent.Add( 'Ensure','Absent' )
+
+                    Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsureAbsent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+            }
+
+            Context 'When the desired state is Present' {
+                BeforeEach {
+                    $script:mockWasLoginClassMethodEnableCalled = $false
+                    $script:mockWasLoginClassMethodDisabledCalled = $false
+                }
+
+                It 'Should add the specified Windows User when it is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsUserAbsent_EnsurePresent = $setTargetResource_WindowsUserAbsent.Clone()
+                    $setTargetResource_WindowsUserAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    Set-TargetResource @setTargetResource_WindowsUserAbsent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should add the specified Windows User as disabled when it is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith {
+                        return New-Object -TypeName PSObject -Property @{
+                            Logins = @{}
+                        }
+                    }-Verifiable
+
+                    Mock -CommandName New-Object -MockWith {
+                        $windowsUser = New-Object Microsoft.SqlServer.Management.Smo.Login( 'Server', 'Windows\User1' )
+                        $windowsUser = $windowsUser | Add-Member -Name 'Disable' -MemberType ScriptMethod {
+                            $script:mockWasLoginClassMethodDisabledCalled = $true
+                        } -PassThru -Force
+
+                        return $windowsUser
+                    } -ParameterFilter {
+                        $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Login' -and $ArgumentList[1] -eq 'Windows\UserAbsent'
+                    }-Verifiable
+
+                    $mockSetTargetResourceParameters = $instanceParameters.Clone()
+                    $mockSetTargetResourceParameters.Add( 'Ensure','Present' )
+                    $mockSetTargetResourceParameters.Add( 'Name','Windows\UserAbsent' )
+                    $mockSetTargetResourceParameters.Add( 'Disabled', $true )
+
+                    Set-TargetResource @mockSetTargetResourceParameters
+                    $script:mockWasLoginClassMethodDisabledCalled | Should -Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should add the specified Windows Group when it is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsGroupAbsent_EnsurePresent = $setTargetResource_WindowsGroupAbsent.Clone()
+                    $setTargetResource_WindowsGroupAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    Set-TargetResource @setTargetResource_WindowsGroupAbsent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should add the specified SQL Login when it is Absent' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                    Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should add the specified SQL Login when it is Absent and MustChangePassword is $false' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginMustChangePassword',$false )
+
+                    Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should throw the correct error when adding an unsupported login type' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_CertificateAbsent_EnsurePresent = $setTargetResource_CertificateAbsent.Clone()
+                    $setTargetResource_CertificateAbsent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    { Set-TargetResource @setTargetResource_CertificateAbsent_EnsurePresent } | Should Throw 'LoginTypeNotImplemented'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should throw the correct error when adding the specified SQL Login when it is Absent and is missing the LoginCredential parameter' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred = $setTargetResource_SqlLoginAbsent.Clone()
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred.Add( 'Ensure','Present' )
+
+                    { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent_NoCred } | Should Throw 'LoginCredentialNotFound'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should do nothing if the specified Windows User is Present' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsUserPresent_EnsurePresent = $setTargetResource_WindowsUserPresent.Clone()
+                    $setTargetResource_WindowsUserPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    Set-TargetResource @setTargetResource_WindowsUserPresent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should do nothing if the specified Windows Group is Present' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_WindowsGroupPresent_EnsurePresent = $setTargetResource_WindowsGroupPresent.Clone()
+                    $setTargetResource_WindowsGroupPresent_EnsurePresent.Add( 'Ensure','Present' )
+
+                    Set-TargetResource @setTargetResource_WindowsGroupPresent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should update the password of the specified SQL Login if it is Present and all parameters match' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginPresent_EnsurePresent = $setTargetResource_SqlLoginPresent.Clone()
+                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                    Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should set PasswordExpirationEnabled on the specified SQL Login if it does not match the LoginPasswordExpirationEnabled parameter' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled = $setTargetResource_SqlLoginPresent.Clone()
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled.Add( 'LoginPasswordExpirationEnabled',$false )
+
+                    Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordExpirationEnabled
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should set PasswordPolicyEnforced on the specified SQL Login if it does not match the LoginPasswordPolicyEnforced parameter' {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
+
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced = $setTargetResource_SqlLoginPresent.Clone()
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginCredential',$mockSqlLoginCredential )
+                    $setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced.Add( 'LoginPasswordPolicyEnforced',$false )
+
+                    Set-TargetResource @setTargetResource_SqlLoginPresent_EnsurePresent_LoginPasswordPolicyEnforced
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should throw the correct error when creating a SQL Login if the LoginMode is not Mixed' {
+                    $mockConnectSQL_LoginModeNormal = {
+                        return New-Object Object |
+                            Add-Member ScriptProperty Logins {
+                                return @{
+                                    'Windows\User1' = ( New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\User1' -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsUser' -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                    )
+                                    'SqlLogin1' = ( New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'SqlLogin1' -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'SqlLogin' -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'MustChangePassword' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'PasswordExpirationEnabled' -Value $true -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'PasswordPolicyEnforced' -Value $true -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                    )
+                                    'Windows\Group1' = ( New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Windows\Group1' -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'LoginType' -Value 'WindowsGroup' -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Alter -Value {} -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name Drop -Value {} -PassThru -Force
+                                    )
+                                }
+                            } -PassThru |
+                            Add-Member -MemberType NoteProperty -Name LoginMode -Value 'Normal' -PassThru -Force
+                    }
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL_LoginModeNormal -Verifiable
+
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent = $setTargetResource_SqlLoginAbsent.Clone()
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'Ensure','Present' )
+                    $setTargetResource_SqlLoginAbsent_EnsurePresent.Add( 'LoginCredential',$mockSqlLoginCredential )
+
+                    { Set-TargetResource @setTargetResource_SqlLoginAbsent_EnsurePresent } | Should Throw 'IncorrectLoginMode'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SQLServerLogin  -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Set-SQLServerLoginPassword  -Scope It -Times 0 -Exactly
+                }
+            }
+        }
+
+        Describe 'MSFT_xSQLServerLogin\Update-SQLServerLogin' {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the Login is altered' {
@@ -920,7 +926,7 @@ try
             }
         }
 
-        Describe "$($script:DSCResourceName)\New-SQLServerLogin" {
+        Describe 'MSFT_xSQLServerLogin\New-SQLServerLogin' {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the Login is created' {
@@ -995,7 +1001,7 @@ try
             }
         }
 
-        Describe "$($script:DSCResourceName)\Remove-SQLServerLogin" {
+        Describe 'MSFT_xSQLServerLogin\Remove-SQLServerLogin' {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the Login is dropped' {
@@ -1016,7 +1022,7 @@ try
             }
         }
 
-        Describe "$($script:DSCResourceName)\Set-SQLServerLoginPassword" {
+        Describe 'MSFT_xSQLServerLogin\Set-SQLServerLoginPassword' {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -ModuleName $script:DSCResourceName
 
             Context 'When the password is set on an existing login' {
@@ -1061,9 +1067,5 @@ try
 }
 finally
 {
-    #region FOOTER
-
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
-    #endregion
+    Invoke-TestCleanup
 }

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -303,6 +303,7 @@ namespace Microsoft.SqlServer.Management.Smo
         public bool MustChangePassword = false;
         public bool PasswordPolicyEnforced = false;
         public bool PasswordExpirationEnabled = false;
+        public bool IsDisabled = false;
 
         public string MockName;
         public LoginType MockLoginType;


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please make sure you have read the contributing section at https://github.com/PowerShell/xSQLServer#contributing.

Please prefix the PR title with the resource name, i.e. 'xSQLServerSetup: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xSQLServerSetup: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
This patch adds _Disable_ parameter to xSQLServerLogin resource. The default value is $false. If set to $true, an existing login will be disabled. If creating a new login, it will be created as disabled.

I'm not really familiar with Pester tests, could use some help to update the unit tests :-)

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/531)
<!-- Reviewable:end -->
