### PR TITLE
xSQLServerNetwork: Refactored this resource and added tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - Removed helper function Get-SQLPSInstance and Get-SQLPSInstanceName because there is no resource using it any longer.
   - Added four new helper functions.
     - Register-SqlSmo, Register-SqlWmiManagement and Unregister-SqlAssemblies to handle the creation on the application domain and loading and unloading of the SMO and SqlWmiManagement assemblies.
-    - Get-SqlMajorVersion to get the major SQL version for a specific instance.
+    - Get-SqlInstanceMajorVersion to get the major SQL version for a specific instance.
   - Fixed typos in comment-based help
 - Changes to xSQLServer
   - Fixed typos in markdown files; CHANGELOG, CONTRIBUTING, README and ISSUE_TEMPLATE.
@@ -51,7 +51,7 @@
   - Updated example 1-EnableTcpIpOnCustomStaticPort.
   - Added unit tests (issue #294).
   - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
-  - If both parameter TcpDynamicPort and TcpPort is set at the same time it will now throw an error (issue #535).
+  - If parameter TcpDynamicPort is set to '0' at the same time as TcpPort is set the resource will now throw an error (issue #535).
   - Added examples (issue #536).
   - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   - Updated note in resource description to also mention ConnectSql permission.
 - Changes to xSQLServerHelper module
   - Removed helper function Get-SQLPSInstance and Get-SQLPSInstanceName because there is no resource using it any longer.
+  - Added four new helper functions.
+    - Register-SqlSmo, Register-SqlWmiManagement and Unregister-SqlAssemblies to handle the creation on the application domain and loading and unloading of the SMO and SqlWmiManagement assemblies.
+    - Get-SqlMajorVersion to get the major SQL version for a specific instance.
+  - Fixed typos in comment-based help
 - Changes to xSQLServer
   - Fixed typos in markdown files; CHANGELOG, CONTRIBUTING, README and ISSUE_TEMPLATE.
   - Fixed typos in schema.mof files (and README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
   - Added unit tests (issue #294).
   - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
   - If both parameter TcpDynamicPort and TcpPort is set at the same time it will now throw an error (issue #535).
+  - Added examples (issue #536).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,12 @@
 - Changes to xSQLServerNetwork
   - Added optional parameter SQLServer with default value of $env:COMPUTERNAME (issue #528).
   - Added optional parameter RestartTimeout with default value of 120 seconds.
-  - Now the resource supports restarting a sql server in a cluster (issue #527).
+  - Now the resource supports restarting a sql server in a cluster (issue #527 and issue #455).
   - Now the resource allows to set the parameter TcpDynamicPorts to a blank value (partly fixes issue #534). Setting a blank value for parameter TcpDynamicPorts together with a value for parameter TcpPort means that static port will be used.
   - Now the resource will not call Alter() in the Set-TargetResource when there is no change necessary (issue #537).
   - Updated example 1-EnableTcpIpOnCustomStaticPort.
   - Added unit tests (issue #294).
-
+  - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
   - Added optional parameter SQLServer with default value of $env:COMPUTERNAME (issue #528).
   - Added optional parameter RestartTimeout with default value of 120 seconds.
   - Now the resource supports restarting a sql server in a cluster (issue #527).
+  - Now the resource allows to set the parameter TcpDynamicPorts to a blank value (partly fixes issue #534). Setting a blank value for parameter TcpDynamicPorts together with a value for parameter TcpPort means that static port will be used.
+  - Now the resource will not call Alter() in the Set-TargetResource when there is no change necessary (issue #537).
+  - Updated example 1-EnableTcpIpOnCustomStaticPort.
+  - Added unit tests (issue #294).
+
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
   - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
   - If both parameter TcpDynamicPort and TcpPort is set at the same time it will now throw an error (issue #535).
   - Added examples (issue #536).
+  - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
   - Added an optional boolean parameter Disabled. It can be used to enable/disable existing logins or create disabled logins (new logins are created as enabled by default).
 - Changes to xSQLServerDatabaseRole
   - Updated variable passed to Microsoft.SqlServer.Management.Smo.User constructor to fix issue #530
+- Changes to xSQLServerNetwork
+  - Added optional parameter SQLServer with default value of $env:COMPUTERNAME (issue #528).
+  - Added optional parameter RestartTimeout with default value of 120 seconds.
+  - Now the resource supports restarting a sql server in a cluster (issue #527).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   - Updated example 1-EnableTcpIpOnCustomStaticPort.
   - Added unit tests (issue #294).
   - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
+  - If both parameter TcpDynamicPort and TcpPort is set at the same time it will now throw an error (issue #535).
 
 ## 7.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
@@ -75,16 +75,23 @@ Function Get-TargetResource
     Enables or disables the network protocol.
 
     .PARAMETER TcpDynamicPorts
-    Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value.
+    Set the value to '0' if dynamic ports should be used.
+    If static port should be used set this to a empty string value.
+    Value can not be set to '0' if TcpPort is also set to a value.
 
     .PARAMETER TcpPort
-    The TCP port that SQL Server should be listening on.
+    The TCP port(s) that SQL Server should be listening on.
+    If the IP address should listen on more than one port, list all ports
+    separated with a comma ('1433,1500,1501'). To use this parameter set
+    TcpDynamicPorts to the value '' (empty string).
 
     .PARAMETER RestartService
-    If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
+    If set to $true then SQL Server and dependent services will be restarted
+    if a change to the configuration is made. The default value is $false.
 
     .PARAMETER RestartTimeout
-    Timeout value for restarting the SQL Server services. The default value is 120 seconds.
+    Timeout value for restarting the SQL Server services. The default value
+    is 120 seconds.
 #>
 Function Set-TargetResource
 {
@@ -213,18 +220,25 @@ Function Set-TargetResource
     Enables or disables the network protocol.
 
     .PARAMETER TcpDynamicPorts
-    Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value.
+    Set the value to '0' if dynamic ports should be used.
+    If static port should be used set this to a empty string value.
+    Value can not be set to '0' if TcpPort is also set to a value.
 
     .PARAMETER TcpPort
-    The TCP port that SQL Server should be listening on.
+    The TCP port(s) that SQL Server should be listening on.
+    If the IP address should listen on more than one port, list all ports
+    separated with a comma ('1433,1500,1501'). To use this parameter set
+    TcpDynamicPorts to the value '' (empty string).
 
     .PARAMETER RestartService
-    If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
+    If set to $true then SQL Server and dependent services will be restarted
+    if a change to the configuration is made. The default value is $false.
 
     Not used in Test-TargetResource.
 
     .PARAMETER RestartTimeout
-    Timeout value for restarting the SQL Server services. The default value is 120 seconds.
+    Timeout value for restarting the SQL Server services. The default value
+    is 120 seconds.
 
     Not used in Test-TargetResource.
 #>

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
@@ -1,80 +1,124 @@
 ﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
+<#
+    .SYNOPSIS
+    Returns the current state of the SQL Server network properties.
 
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER ProtocolName
+    The name of network protocol to be configured. Only tcp is currently supported.
+#>
 Function Get-TargetResource
 {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
-    param(
-        [parameter(Mandatory = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InstanceName,
 
         # For now there is only support for the tcp protocol.
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Tcp')]
         [System.String]
         $ProtocolName
     )
 
-    Try
+    try
     {
-        $dom_get = Register-SqlWmiManagement -SQLInstanceName $InstanceName
+        $applicationDomainObject = Register-SqlWmiManagement -SQLInstanceName $InstanceName
 
-        $wmi = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
+        $managedComputerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
 
-        Write-Verbose "Getting [$ProtocolName] network protocol for [$InstanceName] SQL instance"
-        $tcp = $wmi.ServerInstances[$InstanceName].ServerProtocols[$ProtocolName]
+        Write-Verbose "Getting [$ProtocolName] network protocol for [$InstanceName] SQL instance."
+        $tcp = $managedComputerObject.ServerInstances[$InstanceName].ServerProtocols[$ProtocolName]
 
-        Write-Verbose "Reading state values:"
+        Write-Verbose "Reading current network properties."
         $returnValue = @{
             InstanceName = $InstanceName
             ProtocolName = $ProtocolName
             IsEnabled = $tcp.IsEnabled
-            TcpDynamicPorts = $tcp.IPAddresses["IPAll"].IPAddressProperties["TcpDynamicPorts"].Value
-            TcpPort = $tcp.IPAddresses["IPAll"].IPAddressProperties["TcpPort"].Value
+            TcpDynamicPorts = $tcp.IPAddresses['IPAll'].IPAddressProperties['TcpDynamicPorts'].Value
+            TcpPort = $tcp.IPAddresses['IPAll'].IPAddressProperties['TcpPort'].Value
         }
 
-        $returnValue.Keys | % { Write-Verbose "$_ = $($returnValue[$_])" }
-
+        $returnValue.Keys | ForEach-Object {
+            Write-Verbose "$_ = $($returnValue[$_])"
+        }
     }
-    Finally
+    finally
     {
-        Unregister-SqlAssemblies -ApplicationDomain $dom_get
+        Unregister-SqlAssemblies -ApplicationDomain $applicationDomainObject
     }
 
     return $returnValue
 }
 
+<#
+    .SYNOPSIS
+    Sets the SQL Server network properties.
+
+    .PARAMETER SQLServer
+    The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER ProtocolName
+    The name of network protocol to be configured. Only tcp is currently supported.
+
+    .PARAMETER IsEnabled
+    Enables or disables the network protocol.
+
+    .PARAMETER TcpDynamicPorts
+    Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value.
+
+    .PARAMETER TcpPort
+    The TCP port that SQL Server should be listening on.
+
+    .PARAMETER RestartService
+    If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
+
+    .PARAMETER RestartTimeout
+    Timeout value for restarting the SQL Server services. The default value is 120 seconds.
+#>
 Function Set-TargetResource
 {
     [CmdletBinding()]
-    param(
+    param
+    (
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InstanceName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Tcp')]
         [System.String]
         $ProtocolName,
 
+        [Parameter()]
         [System.Boolean]
         $IsEnabled,
 
-        [ValidateSet("0","")]
+        [Parameter()]
+        [ValidateSet('0','')]
         [System.String]
         $TcpDynamicPorts,
 
+        [Parameter()]
         [System.String]
         $TcpPort,
 
+        [Parameter()]
         [System.Boolean]
         $RestartService = $false,
 
@@ -83,11 +127,11 @@ Function Set-TargetResource
         $RestartTimeout = 120
     )
 
-    $currentState = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName
+    $getTargetResourceResult = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName
 
-    $dom_get = Register-SqlWmiManagement -SQLInstanceName $InstanceName
+    $applicationDomainObject = Register-SqlWmiManagement -SQLInstanceName $InstanceName
 
-    Try
+    try
     {
         $desiredState = @{
             InstanceName = $InstanceName
@@ -99,52 +143,86 @@ Function Set-TargetResource
 
         $isRestartNeeded = $false
 
-        $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
+        $managedComputerObject = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
 
         Write-Verbose "Getting [$ProtocolName] network protocol for [$InstanceName] SQL instance"
-        $tcp = $wmi.ServerInstances[$InstanceName].ServerProtocols[$ProtocolName]
+        $tcp = $managedComputerObject.ServerInstances[$InstanceName].ServerProtocols[$ProtocolName]
 
-        Write-Verbose "Checking [IsEnabled] property."
-        if($desiredState["IsEnabled"] -ine $currentState["IsEnabled"])
+        Write-Verbose 'Checking [IsEnabled] property.'
+        if ($desiredState['IsEnabled'] -ine $getTargetResourceResult['IsEnabled'])
         {
-            Write-Verbose "Updating [IsEnabled] from $($currentState["IsEnabled"]) to $($desiredState["IsEnabled"])"
-            $tcp.IsEnabled = $desiredState["IsEnabled"]
+            Write-Verbose "Updating [IsEnabled] from $($getTargetResourceResult['IsEnabled']) to $($desiredState['IsEnabled'])."
+            $tcp.IsEnabled = $desiredState['IsEnabled']
             $tcp.Alter()
 
             $isRestartNeeded = $true
         }
 
-        Write-Verbose "Checking [TcpDynamicPorts] property."
-        if($desiredState["TcpDynamicPorts"] -ine $currentState["TcpDynamicPorts"])
+        Write-Verbose 'Checking [TcpDynamicPorts] property.'
+        if ($desiredState['TcpDynamicPorts'] -ine $getTargetResourceResult['TcpDynamicPorts'])
         {
-            Write-Verbose "Updating [TcpDynamicPorts] from $($currentState["TcpDynamicPorts"]) to $($desiredState["TcpDynamicPorts"])"
-            $tcp.IPAddresses["IPAll"].IPAddressProperties["TcpDynamicPorts"].Value = $desiredState["TcpDynamicPorts"]
+            Write-Verbose "Updating [TcpDynamicPorts] from $($getTargetResourceResult['TcpDynamicPorts']) to $($desiredState['TcpDynamicPorts'])."
+            $tcp.IPAddresses['IPAll'].IPAddressProperties['TcpDynamicPorts'].Value = $desiredState['TcpDynamicPorts']
             $tcp.Alter()
 
             $isRestartNeeded = $true
         }
 
-        Write-Verbose "Checking [TcpPort property]."
-        if($desiredState["TcpPort"] -ine $currentState["TcpPort"])
+        Write-Verbose 'Checking [TcpPort property].'
+        if ($desiredState['TcpPort'] -ine $getTargetResourceResult['TcpPort'])
         {
-            Write-Verbose "Updating [TcpPort] from $($currentState["TcpPort"]) to $($desiredState["TcpPort"])"
-            $tcp.IPAddresses["IPAll"].IPAddressProperties["TcpPort"].Value = $desiredState["TcpPort"]
+            Write-Verbose "Updating [TcpPort] from $($getTargetResourceResult['TcpPort']) to $($desiredState['TcpPort'])."
+            $tcp.IPAddresses['IPAll'].IPAddressProperties['TcpPort'].Value = $desiredState['TcpPort']
             $tcp.Alter()
 
             $isRestartNeeded = $true
         }
 
-        if($RestartService -and $isRestartNeeded)
+        if ($RestartService -and $isRestartNeeded)
         {
             Restart-SqlService -SQLServer $SQLServer -SQLInstanceName $InstanceName -Timeout $RestartTimeout
         }
     }
-    Finally
+    finally
     {
-        Unregister-SqlAssemblies -ApplicationDomain $dom_get
+        Unregister-SqlAssemblies -ApplicationDomain $applicationDomainObject
     }
 }
 
+<#
+    .SYNOPSIS
+    Sets the SQL Server network properties.
+
+    .PARAMETER SQLServer
+    The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+
+    Not used in Test-TargetResource.
+
+    .PARAMETER InstanceName
+    The name of the SQL instance to be configured.
+
+    .PARAMETER ProtocolName
+    The name of network protocol to be configured. Only tcp is currently supported.
+
+    .PARAMETER IsEnabled
+    Enables or disables the network protocol.
+
+    .PARAMETER TcpDynamicPorts
+    Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value.
+
+    .PARAMETER TcpPort
+    The TCP port that SQL Server should be listening on.
+
+    .PARAMETER RestartService
+    If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
+
+    Not used in Test-TargetResource.
+
+    .PARAMETER RestartTimeout
+    Timeout value for restarting the SQL Server services. The default value is 120 seconds.
+
+    Not used in Test-TargetResource.
+#>
 Function Test-TargetResource
 {
     [CmdletBinding()]
@@ -155,25 +233,29 @@ Function Test-TargetResource
         [System.String]
         $SQLServer = $env:COMPUTERNAME,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InstanceName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Tcp')]
         [System.String]
         $ProtocolName,
 
+        [Parameter()]
         [System.Boolean]
         $IsEnabled,
 
-        [ValidateSet("0","")]
+        [Parameter()]
+        [ValidateSet('0','')]
         [System.String]
         $TcpDynamicPorts,
 
+        [Parameter()]
         [System.String]
         $TcpPort,
 
+        [Parameter()]
         [System.Boolean]
         $RestartService = $false,
 
@@ -190,20 +272,26 @@ Function Test-TargetResource
         TcpPort = $TcpPort
     }
 
-    $currentState = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName
+    $getTargetResourceResult = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName
 
-    Write-Verbose "Comparing desiredState with currentSate ..."
-    foreach($key in $desiredState.Keys)
+    $isInDesiredState = $true
+
+    Write-Verbose "Comparing desired state with current state."
+    foreach ($key in $desiredState.Keys)
     {
-        if($desiredState[$key] -ine $currentState[$key] )
+        if( $desiredState[$key] -ine $getTargetResourceResult[$key] )
         {
-            Write-Verbose "$key is different: desired = $($desiredState[$key]); current = $($currentState[$key])"
-            return $false
+            Write-Verbose "$key is different: desired = $($desiredState[$key]); current = $($getTargetResourceResult[$key])"
+            $isInDesiredState = $false
         }
     }
 
-    Write-Verbose "States match"
-    return $true
+    if ($isInDesiredState)
+    {
+        Write-Verbose "In desired state."
+    }
+
+    return $isInDesiredState
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
@@ -127,6 +127,11 @@ Function Set-TargetResource
         $RestartTimeout = 120
     )
 
+    if ($TcpDynamicPorts -eq '0' -and $TcpPort)
+    {
+        throw New-TerminatingError -ErrorType UnableToUseBothDynamicAndStaticPort -ErrorCategory InvalidOperation
+    }
+
     $getTargetResourceResult = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName
 
     $applicationDomainObject = Register-SqlWmiManagement -SQLInstanceName $InstanceName
@@ -264,12 +269,34 @@ Function Test-TargetResource
         $RestartTimeout = 120
     )
 
+    if ($TcpDynamicPorts -eq '0' -and $TcpPort)
+    {
+        throw New-TerminatingError -ErrorType UnableToUseBothDynamicAndStaticPort -ErrorCategory InvalidOperation
+    }
+
     $desiredState = @{
-        InstanceName = $InstanceName
         ProtocolName = $ProtocolName
-        IsEnabled = $IsEnabled
-        TcpDynamicPorts = $TcpDynamicPorts
-        TcpPort = $TcpPort
+    }
+
+    if ($PSBoundParameters.ContainsKey('IsEnabled'))
+    {
+        $desiredState += @{
+            IsEnabled = $IsEnabled
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('TcpDynamicPorts'))
+    {
+        $desiredState += @{
+            TcpDynamicPorts = $TcpDynamicPorts
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('TcpPort'))
+    {
+        $desiredState += @{
+            TcpPort = $TcpPort
+        }
     }
 
     $getTargetResourceResult = Get-TargetResource -InstanceName $InstanceName -ProtocolName $ProtocolName

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -3,8 +3,10 @@ class MSFT_xSQLServerNetwork : OMI_BaseResource
 {
     [Key, Description("SQL Server instance name of which network protocol should be configured")] String InstanceName;
     [Required, Description("Network protocol name that should be configured"), ValueMap{"tcp"}, Values{"tcp"}] String ProtocolName;
+    [Write, Description("The host name of the SQL Server to be configured.")] String SQLServer;
     [Write, Description("Is network protocol should be enabled or disabled")] Boolean IsEnabled;
     [Write, Description("If dynamic ports are used should be set to 0, otherwise leave empty"), ValueMap{"0"}, Values{"0"}] String TCPDynamicPorts;
     [Write, Description("Sets static port for TCP/IP")] String TCPPort;
     [Write, Description("Controls if affected SQL Service should be restarted automatically")] Boolean RestartService;
+    [Write, Description("Timeout value for restarting the SQL services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -2,11 +2,11 @@
 class MSFT_xSQLServerNetwork : OMI_BaseResource
 {
     [Key, Description("SQL Server instance name of which network protocol should be configured")] String InstanceName;
-    [Required, Description("Network protocol name that should be configured"), ValueMap{"tcp"}, Values{"tcp"}] String ProtocolName;
+    [Required, Description("Network protocol name that should be configured"), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
     [Write, Description("The host name of the SQL Server to be configured.")] String SQLServer;
     [Write, Description("Is network protocol should be enabled or disabled")] Boolean IsEnabled;
-    [Write, Description("If dynamic ports are used should be set to 0, otherwise leave empty"), ValueMap{"0"}, Values{"0"}] String TCPDynamicPorts;
-    [Write, Description("Sets static port for TCP/IP")] String TCPPort;
+    [Write, Description("If dynamic ports are used should be set to 0, otherwise leave empty"), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
+    [Write, Description("Sets static port for TCP/IP")] String TcpPort;
     [Write, Description("Controls if affected SQL Service should be restarted automatically")] Boolean RestartService;
     [Write, Description("Timeout value for restarting the SQL services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -5,8 +5,8 @@ class MSFT_xSQLServerNetwork : OMI_BaseResource
     [Required, Description("The name of network protocol to be configured. Only tcp is currently supported."), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
     [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;
-    [Write, Description("Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value."), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
-    [Write, Description("The TCP port that SQL Server should be listening on.")] String TcpPort;
+    [Write, Description("Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. Value can not be set to '0' if TcpPort is also set to a value."), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
+    [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to the value '' (empty string).")] String TcpPort;
     [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean RestartService;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -1,12 +1,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerNetwork")]
 class MSFT_xSQLServerNetwork : OMI_BaseResource
 {
-    [Key, Description("SQL Server instance name of which network protocol should be configured")] String InstanceName;
-    [Required, Description("Network protocol name that should be configured"), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
-    [Write, Description("The host name of the SQL Server to be configured.")] String SQLServer;
-    [Write, Description("Is network protocol should be enabled or disabled")] Boolean IsEnabled;
-    [Write, Description("If dynamic ports are used should be set to 0, otherwise leave empty"), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
-    [Write, Description("Sets static port for TCP/IP")] String TcpPort;
-    [Write, Description("Controls if affected SQL Service should be restarted automatically")] Boolean RestartService;
-    [Write, Description("Timeout value for restarting the SQL services. The default value is 120 seconds.")] UInt16 RestartTimeout;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
+    [Required, Description("The name of network protocol to be configured. Only tcp is currently supported."), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
+    [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
+    [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;
+    [Write, Description("Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value."), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
+    [Write, Description("The TCP port that SQL Server should be listening on.")] String TcpPort;
+    [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean RestartService;
+    [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpOnCustomStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpOnCustomStaticPort.ps1
@@ -20,8 +20,9 @@ Configuration Example
         xSQLServerNetwork 'RDBMS'
         {
             InstanceName = 'MSSQLSERVER'
-            ProtocolName = 'tcp'
+            ProtocolName = 'Tcp'
             IsEnabled = $true
+            TCPDynamicPorts = ''
             TCPPort = 4509
             RestartService = $true
         }

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -1,0 +1,30 @@
+﻿<#
+.EXAMPLE
+    This example will enable TCP/IP protocol and set the custom static port to 4509.
+    When RestartService is set to $true the resource will also restart the SQL service.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost
+    {
+        xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName = 'MSSQLSERVER'
+            ProtocolName = 'Tcp'
+            IsEnabled = $true
+            TCPDynamicPorts = ''
+            TCPPort = 4509
+            RestartService = $true
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -17,14 +17,13 @@ Configuration Example
 
     node localhost
     {
-        xSQLServerNetwork 'RDBMS'
+        xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
             InstanceName = 'MSSQLSERVER'
             ProtocolName = 'Tcp'
             IsEnabled = $true
-            TCPDynamicPorts = ''
-            TCPPort = 4509
-            RestartService = $true
+            TCPDynamicPorts = '0'
+            RestartService = $false
         }
     }
 }

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -23,7 +23,7 @@ Configuration Example
             ProtocolName = 'Tcp'
             IsEnabled = $true
             TCPDynamicPorts = '0'
-            RestartService = $false
+            RestartService = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -766,14 +766,14 @@ This resource is used to change the network settings for the instance.
 
 #### Parameters
 
-* **[String] InstanceName** _(Key)_: Name of SQL Server instance for which network will be configured.
-* **[String] ProtocolName** _(Required)_: Name of network protocol to be configured. Only tcp is currently supported. { tcp }.
+* **[String] InstanceName** _(Key)_: The name of the SQL instance to be configured.
+* **[String] ProtocolName** _(Required)_: The name of network protocol to be configured. Only tcp is currently supported. { tcp }.
 * **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
-* **[Boolean] IsEnabled** _(Write)_: Enables/Disables network protocol.
+* **[Boolean] IsEnabled** _(Write)_: Enables or disables the network protocol.
 * **[String] TCPDynamicPorts** _(Write)_: Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. { '0','' }.
-* **[String] TCPPort** _(Write)_: Custom TCP port.
-* **[Boolean] RestartService** _(Write)_: If true will restart SQL Service instance service after update. The default value is $false.
-* **[Uint16] RestartTimeout** _(Write)_: Timeout value for restarting the SQL services. The default value is 120 seconds.
+* **[String] TCPPort** _(Write)_: The TCP port that SQL Server should be listening on.
+* **[Boolean] RestartService** _(Write)_: If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
+* **[Uint16] RestartTimeout** _(Write)_: Timeout value for restarting the SQL Server services. The default value is 120 seconds.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -757,6 +757,8 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) - (102
 
 This resource is used to change the network settings for the instance.
 
+Read more about the network settings in the article [TCP/IP Properties (IP Addresses Tab)](https://docs.microsoft.com/en-us/sql/tools/configuration-manager/tcp-ip-properties-ip-addresses-tab).
+
 >Note: Currently only TCP is supported.
 
 #### Requirements
@@ -770,14 +772,15 @@ This resource is used to change the network settings for the instance.
 * **[String] ProtocolName** _(Required)_: The name of network protocol to be configured. Only tcp is currently supported. { tcp }.
 * **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 * **[Boolean] IsEnabled** _(Write)_: Enables or disables the network protocol.
-* **[String] TCPDynamicPorts** _(Write)_: Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. { '0','' }.
-* **[String] TCPPort** _(Write)_: The TCP port that SQL Server should be listening on.
+* **[String] TcpDynamicPorts** _(Write)_: Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. Value can not be set to '0' if TcpPort is also set to a value. { '0','' }.
+* **[String] TcpPort** _(Write)_: The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to the value '' (empty string).
 * **[Boolean] RestartService** _(Write)_: If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.
 * **[Uint16] RestartTimeout** _(Write)_: Timeout value for restarting the SQL Server services. The default value is 120 seconds.
 
 #### Examples
 
-* [Enable TCP/IP on custom static port](/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpOnCustomStaticPort.ps1)
+* [Enable TCP/IP with static port and restart SQL Server](/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1)
+* [Enable TCP/IP with dynamic port](/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1)
 
 ### xSQLServerPermission
 

--- a/README.md
+++ b/README.md
@@ -755,7 +755,9 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) - (102
 
 ### xSQLServerNetwork
 
-No description.
+This resource is used to change the network settings for the instance.
+
+>Note: Currently only TCP is supported.
 
 #### Requirements
 
@@ -764,11 +766,11 @@ No description.
 
 #### Parameters
 
-* **[String] InstanceName** _(Key)_: name of SQL Server instance for which network will be configured.
+* **[String] InstanceName** _(Key)_: Name of SQL Server instance for which network will be configured.
 * **[String] ProtocolName** _(Required)_: Name of network protocol to be configured. Only tcp is currently supported. { tcp }.
 * **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 * **[Boolean] IsEnabled** _(Write)_: Enables/Disables network protocol.
-* **[String] TCPDynamicPorts** _(Write)_: 0 if Dynamic ports should be used otherwise empty. { 0 }.
+* **[String] TCPDynamicPorts** _(Write)_: Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. { '0','' }.
 * **[String] TCPPort** _(Write)_: Custom TCP port.
 * **[Boolean] RestartService** _(Write)_: If true will restart SQL Service instance service after update. The default value is $false.
 * **[Uint16] RestartTimeout** _(Write)_: Timeout value for restarting the SQL services. The default value is 120 seconds.

--- a/README.md
+++ b/README.md
@@ -740,8 +740,8 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) - (102
 #### Parameters
 
 * **[String] SQLInstance** _(Key)_: The name of the SQL instance to be configured.
-* **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is *$env:COMPUTERNAME*.
-* **[Boolean] DynamicAlloc** _(Write)_: If set to $true then max memory will be dynamically configured. When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured. Default value is *$false*.
+* **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
+* **[Boolean] DynamicAlloc** _(Write)_: If set to $true then max memory will be dynamically configured. When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured. Default value is $false.
 * **[String] Ensure** _(Write)_: When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true. When set to 'Absent' min and max memory will be set to default values. { *Present* | Absent }.
 * **[Sint32] MinMemory** _(Write)_: Minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
 * **[Sint32] MaxMemory** _(Write)_: Maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
@@ -766,10 +766,12 @@ No description.
 
 * **[String] InstanceName** _(Key)_: name of SQL Server instance for which network will be configured.
 * **[String] ProtocolName** _(Required)_: Name of network protocol to be configured. Only tcp is currently supported. { tcp }.
+* **[String] SQLServer** _(Write)_: The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 * **[Boolean] IsEnabled** _(Write)_: Enables/Disables network protocol.
 * **[String] TCPDynamicPorts** _(Write)_: 0 if Dynamic ports should be used otherwise empty. { 0 }.
 * **[String] TCPPort** _(Write)_: Custom TCP port.
-* **[Boolean] RestartService** _(Write)_: If true will restart SQL Service instance service after update. Default false.
+* **[Boolean] RestartService** _(Write)_: If true will restart SQL Service instance service after update. The default value is $false.
+* **[Uint16] RestartTimeout** _(Write)_: Timeout value for restarting the SQL services. The default value is 120 seconds.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
@@ -178,7 +178,6 @@ try
                         $testParameters += @{
                             TcpDynamicPorts = '0'
                             IsEnabled = $false
-                            TcpPort = '4509'
                         }
                     }
 
@@ -193,7 +192,6 @@ try
                         $testParameters += @{
                             TcpPort = '1433'
                             IsEnabled = $true
-                            TcpDynamicPorts = ''
                         }
                     }
 
@@ -202,24 +200,41 @@ try
                         $result | Should Be $false
                     }
                 }
+
+                Context 'When both TcpDynamicPorts and TcpPort is being set' {
+                    BeforeEach {
+                        $testParameters += @{
+                            TcpDynamicPorts = '0'
+                            TcpPort = '1433'
+                            IsEnabled = $false
+                        }
+                    }
+
+                    It 'Should throw the correct error message' {
+                        { Test-TargetResource @testParameters } | Should -Throw 'Unable to set both tcp dynamic port and tcp static port. Only one can be set.'
+                    }
+                }
             }
 
             Context 'When the system is in the desired state' {
                 BeforeEach {
-                    $mockDynamicValue_IsEnabled = $false
+                    $mockDynamicValue_IsEnabled = $true
                     $mockDynamicValue_TcpDynamicPorts = '0'
                     $mockDynamicValue_TcpPort = '1433'
-
-                    $testParameters += @{
-                        IsEnabled = $false
-                        TcpDynamicPorts = '0'
-                        TcpPort = '1433'
-                    }
                 }
 
-                It 'Should return $true' {
-                    $result = Test-TargetResource @testParameters
-                    $result | Should Be $true
+                Context 'When TcpPort is in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            TcpPort = '1433'
+                            IsEnabled = $true
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $true
+                    }
                 }
             }
 
@@ -284,7 +299,6 @@ try
                         $testParameters += @{
                             IsEnabled = $true
                             TcpDynamicPorts = '0'
-                            TcpPort = '4509'
                         }
                     }
 
@@ -310,6 +324,20 @@ try
                         $script:WasMethodAlterCalled | Should -Be $true
 
                         Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                    }
+                }
+
+                Context 'When both TcpDynamicPorts and TcpPort is being set' {
+                    BeforeEach {
+                        $testParameters += @{
+                            TcpDynamicPorts = '0'
+                            TcpPort = '1433'
+                            IsEnabled = $false
+                        }
+                    }
+
+                    It 'Should throw the correct error message' {
+                        { Set-TargetResource @testParameters } | Should -Throw 'Unable to set both tcp dynamic port and tcp static port. Only one can be set.'
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
@@ -1,0 +1,353 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerNetwork'
+
+#region HEADER
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup {
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+}
+
+# Begin Testing
+try
+{
+    Invoke-TestSetup
+
+    InModuleScope $script:DSCResourceName {
+        $mockInstanceName = 'TEST'
+        $mockTcpProtocolName = 'Tcp'
+
+        $script:WasMethodAlterCalled = $false
+
+        $mockFunction_NewObject_ManagedComputer = {
+                return New-Object -TypeName Object |
+                    Add-Member -MemberType ScriptProperty -Name 'ServerInstances' {
+                        return @{
+                            $mockInstanceName = New-Object -TypeName Object |
+                                Add-Member -MemberType ScriptProperty -Name 'ServerProtocols' {
+                                    return @{
+                                        $mockTcpProtocolName = New-Object -TypeName Object |
+                                            Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $mockDynamicValue_IsEnabled -PassThru |
+                                            Add-Member -MemberType ScriptProperty -Name 'IPAddresses' {
+                                                return @{
+                                                    'IPAll' = New-Object -TypeName Object |
+                                                        Add-Member -MemberType ScriptProperty -Name 'IPAddressProperties' {
+                                                            return @{
+                                                                'TcpDynamicPorts' = New-Object -TypeName Object |
+                                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpDynamicPorts -PassThru -Force
+                                                                'TcpPort' = New-Object -TypeName Object |
+                                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpPort -PassThru -Force
+                                                            }
+                                                        } -PassThru -Force
+                                                }
+                                            } -PassThru |
+                                            Add-Member -MemberType ScriptMethod -Name 'Alter' {
+                                                <#
+                                                    It is not possible to verify that the correct value was set here for TcpDynamicPorts and
+                                                    TcpPort with the current implementation.
+                                                    If `$this.IPAddresses['IPAll'].IPAddressProperties['TcpDynamicPorts'].Value` would be
+                                                    called it would just return the same value over an over again, not the value that was
+                                                    set in the function Set-TargetResource.
+                                                    To be able to do this check for TcpDynamicPorts and TcpPort, then the class must be mocked
+                                                    in SMO.cs.
+                                                #>
+                                                if ($this.IsEnabled -ne $mockExpectedValue_IsEnabled)
+                                                {
+                                                    throw ('Mock method Alter() was called with an unexpected value for IsEnabled. Expected ''{0}'', but was ''{1}''' -f $mockExpectedValue_IsEnabled, $this.IsEnabled)
+                                                }
+
+                                                # This can be used to verify so that alter method was actually called.
+                                                $script:WasMethodAlterCalled = $true
+                                            } -PassThru -Force
+                                    }
+                                } -PassThru -Force
+                        }
+                    } -PassThru -Force
+        }
+
+        $mockFunction_NewObject_ManagedComputer_ParameterFilter = {
+            $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer'
+        }
+
+        $mockFunction_RegisterSqlWmiManagement = {
+            return [System.AppDomain]::CreateDomain('DummyTestApplicationDomain')
+        }
+
+        $mockDefaultParameters = @{
+            InstanceName = $mockInstanceName
+            ProtocolName = $mockTcpProtocolName
+        }
+
+        Describe "MSFT_xSQLServerNetwork\Get-TargetResource" -Tag 'Get'{
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+
+                Mock -CommandName Register-SqlWmiManagement `
+                    -MockWith $mockFunction_RegisterSqlWmiManagement `
+                    -Verifiable
+
+                Mock -CommandName New-Object `
+                    -MockWith $mockFunction_NewObject_ManagedComputer `
+                    -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable
+            }
+
+            Context 'When Get-TargetResource is called' {
+                BeforeEach {
+                    $mockDynamicValue_IsEnabled = $true
+                    $mockDynamicValue_TcpDynamicPorts = '0'
+                    $mockDynamicValue_TcpPort = '4509'
+                }
+
+                It 'Should return the correct values' {
+                    $result = Get-TargetResource @testParameters
+                    $result.IsEnabled | Should Be $mockDynamicValue_IsEnabled
+                    $result.TcpDynamicPorts | Should Be $mockDynamicValue_TcpDynamicPorts
+                    $result.TcpPort | Should Be $mockDynamicValue_TcpPort
+
+                    Assert-MockCalled -CommandName Register-SqlWmiManagement -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.InstanceName | Should Be $testParameters.InstanceName
+                    $result.ProtocolName | Should Be $testParameters.ProtocolName
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe "MSFT_xSQLServerNetwork\Test-TargetResource" -Tag 'Test'{
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+
+                Mock -CommandName Register-SqlWmiManagement `
+                    -MockWith $mockFunction_RegisterSqlWmiManagement `
+                    -Verifiable
+
+                Mock -CommandName New-Object `
+                    -MockWith $mockFunction_NewObject_ManagedComputer `
+                    -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable
+            }
+
+            Context 'When the system is not in the desired state' {
+                BeforeEach {
+                    $mockDynamicValue_IsEnabled = $true
+                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpPort = '4509'
+                }
+
+                Context 'When IsEnabled is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            IsEnabled = $false
+                            TcpDynamicPorts = ''
+                            TcpPort = '4509'
+                        }
+                    }
+
+                    It 'Should return $false' {
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+                }
+
+                Context 'When TcpDynamicPorts is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            TcpDynamicPorts = '0'
+                            IsEnabled = $false
+                            TcpPort = '4509'
+                        }
+                    }
+
+                    It 'Should return $false' {
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+                }
+
+                Context 'When TcpPort is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            TcpPort = '1433'
+                            IsEnabled = $true
+                            TcpDynamicPorts = ''
+                        }
+                    }
+
+                    It 'Should return $false' {
+                        $result = Test-TargetResource @testParameters
+                        $result | Should Be $false
+                    }
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeEach {
+                    $mockDynamicValue_IsEnabled = $false
+                    $mockDynamicValue_TcpDynamicPorts = '0'
+                    $mockDynamicValue_TcpPort = '1433'
+
+                    $testParameters += @{
+                        IsEnabled = $false
+                        TcpDynamicPorts = '0'
+                        TcpPort = '1433'
+                    }
+                }
+
+                It 'Should return $true' {
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+
+        Describe "MSFT_xSQLServerNetwork\Set-TargetResource" -Tag 'Set'{
+            BeforeEach {
+                $testParameters = $mockDefaultParameters.Clone()
+
+                Mock -CommandName Restart-SqlService -Verifiable
+                Mock -CommandName Register-SqlWmiManagement `
+                    -MockWith $mockFunction_RegisterSqlWmiManagement `
+                    -Verifiable
+
+                Mock -CommandName New-Object `
+                    -MockWith $mockFunction_NewObject_ManagedComputer `
+                    -ParameterFilter $mockFunction_NewObject_ManagedComputer_ParameterFilter -Verifiable
+
+                # This is used to evaluate if mocked Alter() method was called.
+                $script:WasMethodAlterCalled = $false
+            }
+
+            Context 'When the system is not in the desired state' {
+                BeforeEach {
+                    # This is the values the mock will return
+                    $mockDynamicValue_IsEnabled = $true
+                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpPort = '4509'
+
+                    <#
+                        This is the values we expect to be set when Alter() method is called.
+                        These values will set here to same as the values the mock will return,
+                        but before each test the these will be set to the correct value that is
+                        expected to be returned for that particular test.
+                    #>
+                    $mockExpectedValue_IsEnabled = $mockDynamicValue_IsEnabled
+                }
+
+                Context 'When IsEnabled is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            IsEnabled = $false
+                            TcpDynamicPorts = ''
+                            TcpPort = '4509'
+                            RestartService = $true
+                        }
+
+                        $mockExpectedValue_IsEnabled = $false
+                    }
+
+                    It 'Should call Set-TargetResource without throwing and should call Alter()' {
+                        { Set-TargetResource @testParameters } | Should -Not -Throw
+                        $script:WasMethodAlterCalled | Should -Be $true
+
+                        Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When TcpDynamicPorts is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            IsEnabled = $true
+                            TcpDynamicPorts = '0'
+                            TcpPort = '4509'
+                        }
+                    }
+
+                    It 'Should call Set-TargetResource without throwing and should call Alter()' {
+                        { Set-TargetResource @testParameters } | Should -Not -Throw
+                        $script:WasMethodAlterCalled | Should -Be $true
+
+                        Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                    }
+                }
+
+                Context 'When TcpPort is not in desired state' {
+                    BeforeEach {
+                        $testParameters += @{
+                            IsEnabled = $true
+                            TcpDynamicPorts = ''
+                            TcpPort = '4508'
+                        }
+                    }
+
+                    It 'Should call Set-TargetResource without throwing and should call Alter()' {
+                        { Set-TargetResource @testParameters } | Should -Not -Throw
+                        $script:WasMethodAlterCalled | Should -Be $true
+
+                        Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                    }
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeEach {
+                    # This is the values the mock will return
+                    $mockDynamicValue_IsEnabled = $true
+                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpPort = '4509'
+
+                    <#
+                        We do not expect Alter() method to be called. So we set this to $null so
+                        if it is, then it will throw an error.
+                    #>
+                    $mockExpectedValue_IsEnabled = $null
+
+                    $testParameters += @{
+                        IsEnabled = $true
+                        TcpDynamicPorts = ''
+                        TcpPort = '4509'
+                    }
+                }
+
+                It 'Should call Set-TargetResource without throwing and should not call Alter()' {
+                    { Set-TargetResource @testParameters } | Should -Not -Throw
+                    $script:WasMethodAlterCalled | Should -Be $false
+
+                    Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Assert-VerifiableMocks
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}
+

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -909,7 +909,7 @@ InModuleScope $script:moduleName {
         $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockInstance_InstanceId\Setup"
     }
 
-    Describe 'Testing Get-SqlMajorVersion' -Tag GetSqlMajorVersion {
+    Describe 'Testing Get-SqlInstanceMajorVersion' -Tag GetSqlInstanceMajorVersion {
         BeforeEach {
             Mock -CommandName Get-ItemProperty `
                 -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL `
@@ -924,9 +924,9 @@ InModuleScope $script:moduleName {
 
         $mockInstance_InstanceId = "MSSQL$($mockSqlMajorVersion).$($mockInstanceName)"
 
-        Context 'When calling Get-SqlMajorVersion' {
+        Context 'When calling Get-SqlInstanceMajorVersion' {
             It 'Should return the correct major SQL version number' {
-                $result = Get-SqlMajorVersion -SQLInstanceName $mockInstanceName
+                $result = Get-SqlInstanceMajorVersion -SQLInstanceName $mockInstanceName
                 $result | Should -Be $mockSqlMajorVersion
 
                 Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
@@ -937,7 +937,7 @@ InModuleScope $script:moduleName {
             }
         }
 
-        Context 'When calling Get-SqlMajorVersion and nothing is returned' {
+        Context 'When calling Get-SqlInstanceMajorVersion and nothing is returned' {
             It 'Should throw the correct error' {
                 Mock -CommandName Get-ItemProperty `
                     -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup `
@@ -945,7 +945,7 @@ InModuleScope $script:moduleName {
                         return New-Object Object
                     } -Verifiable
 
-                 { Get-SqlMajorVersion -SQLInstanceName $mockInstanceName } | Should -Throw 'Could not get the SQL version for the instance ''TEST''.'
+                 { Get-SqlInstanceMajorVersion -SQLInstanceName $mockInstanceName } | Should -Throw 'Could not get the SQL version for the instance ''TEST''.'
 
                 Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
                     -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL
@@ -968,7 +968,7 @@ InModuleScope $script:moduleName {
     #>
     Describe 'Testing Register-SqlSmo' -Tag RegisterSqlSmo {
         BeforeEach {
-            Mock -CommandName Get-SqlMajorVersion -MockWith {
+            Mock -CommandName Get-SqlInstanceMajorVersion -MockWith {
                 return '0' # Mocking zero because that could never match a correct assembly
             } -Verifiable
         }
@@ -979,7 +979,7 @@ InModuleScope $script:moduleName {
                     Register-SqlSmo -SQLInstanceName $mockInstanceName
                 } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.Smo, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
 
-                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Get-SqlInstanceMajorVersion
             }
         }
 
@@ -989,7 +989,7 @@ InModuleScope $script:moduleName {
                     Register-SqlSmo -SQLInstanceName $mockInstanceName -ApplicationDomain $mockApplicationDomainObject
                 } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.Smo, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
 
-                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Get-SqlInstanceMajorVersion
             }
         }
 
@@ -1003,7 +1003,7 @@ InModuleScope $script:moduleName {
     #>
     Describe 'Testing Register-SqlWmiManagement' -Tag RegisterSqlWmiManagement {
         BeforeEach {
-            Mock -CommandName Get-SqlMajorVersion -MockWith {
+            Mock -CommandName Get-SqlInstanceMajorVersion -MockWith {
                 return '0' # Mocking zero because that could never match a correct assembly
             } -Verifiable
 
@@ -1020,7 +1020,7 @@ InModuleScope $script:moduleName {
                     Register-SqlWmiManagement -SQLInstanceName $mockInstanceName
                 } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.SqlWmiManagement, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
 
-                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Get-SqlInstanceMajorVersion
                 Assert-MockCalled -CommandName Register-SqlSmo -Exactly -Times 1 -Scope It -ParameterFilter {
                     $SQLInstanceName -eq $mockInstanceName -and $ApplicationDomain -eq $null
                 }
@@ -1033,7 +1033,7 @@ InModuleScope $script:moduleName {
                     Register-SqlWmiManagement -SQLInstanceName $mockInstanceName -ApplicationDomain $mockApplicationDomainObject
                 } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.SqlWmiManagement, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
 
-                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Get-SqlInstanceMajorVersion
                 Assert-MockCalled -CommandName Register-SqlSmo -Exactly -Times 0 -Scope It -ParameterFilter {
                     $SQLInstanceName -eq $mockInstanceName -and $ApplicationDomain -eq $null
                 }

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -47,6 +47,7 @@ InModuleScope $script:moduleName {
         $TypeName -eq 'Microsoft.AnalysisServices.Server'
     }
 
+    $mockSqlMajorVersion = 13
     $mockInstanceName = 'TEST'
 
     $mockSetupCredentialUserName = 'TestUserName12345'
@@ -878,6 +879,185 @@ InModuleScope $script:moduleName {
                 Assert-MockCalled -CommandName Import-Module -Exactly -Times 1 -Scope It
             }
         }
+
         Assert-VerifiableMocks
+    }
+
+    $mockGetItemProperty_MicrosoftSQLServer_InstanceNames_SQL = {
+        return @(
+            (
+                New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name $mockInstanceName -Value $mockInstance_InstanceId -PassThru -Force
+            )
+        )
+    }
+
+    $mockGetItemProperty_MicrosoftSQLServer_FullInstanceId_Setup = {
+        return @(
+            (
+                New-Object Object |
+                    Add-Member -MemberType NoteProperty -Name 'Version' -Value "$($mockSqlMajorVersion).0.4001.0" -PassThru -Force
+            )
+        )
+    }
+
+    $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL = {
+        $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL'
+    }
+
+    $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup = {
+        $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockInstance_InstanceId\Setup"
+    }
+
+    Describe 'Testing Get-SqlMajorVersion' -Tag GetSqlMajorVersion {
+        BeforeEach {
+            Mock -CommandName Get-ItemProperty `
+                -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL `
+                -MockWith $mockGetItemProperty_MicrosoftSQLServer_InstanceNames_SQL `
+                -Verifiable
+
+            Mock -CommandName Get-ItemProperty `
+                -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup `
+                -MockWith $mockGetItemProperty_MicrosoftSQLServer_FullInstanceId_Setup `
+                -Verifiable
+        }
+
+        $mockInstance_InstanceId = "MSSQL$($mockSqlMajorVersion).$($mockInstanceName)"
+
+        Context 'When calling Get-SqlMajorVersion' {
+            It 'Should return the correct major SQL version number' {
+                $result = Get-SqlMajorVersion -SQLInstanceName $mockInstanceName
+                $result | Should -Be $mockSqlMajorVersion
+
+                Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL
+
+                Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup
+            }
+        }
+
+        Context 'When calling Get-SqlMajorVersion and nothing is returned' {
+            It 'Should throw the correct error' {
+                Mock -CommandName Get-ItemProperty `
+                    -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup `
+                    -MockWith {
+                        return New-Object Object
+                    } -Verifiable
+
+                 { Get-SqlMajorVersion -SQLInstanceName $mockInstanceName } | Should -Throw 'Could not get the SQL version for the instance ''TEST''.'
+
+                Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_InstanceNames_SQL
+
+                Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockGetItemProperty_ParameterFilter_MicrosoftSQLServer_FullInstanceId_Setup
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    $mockApplicationDomainName = 'xSQLServerHelperTests'
+    $mockApplicationDomainObject = [System.AppDomain]::CreateDomain($mockApplicationDomainName)
+
+    <#
+        It is not possible to fully test this helper function since we can't mock having the correct assembly
+        in the GAC. So these test will try to load the wrong assembly and will catch the error. But that means
+        it will never test the rows after if fails to load the assembly.
+    #>
+    Describe 'Testing Register-SqlSmo' -Tag RegisterSqlSmo {
+        BeforeEach {
+            Mock -CommandName Get-SqlMajorVersion -MockWith {
+                return '0' # Mocking zero because that could never match a correct assembly
+            } -Verifiable
+        }
+
+        Context 'When calling Register-SqlSmo to load the wrong assembly' {
+            It 'Should throw with the correct error' {
+                {
+                    Register-SqlSmo -SQLInstanceName $mockInstanceName
+                } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.Smo, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
+
+                Assert-MockCalled -CommandName Get-SqlMajorVersion
+            }
+        }
+
+        Context 'When calling Register-SqlSmo with a application domain to load the wrong assembly' {
+            It 'Should throw with the correct error' {
+                {
+                    Register-SqlSmo -SQLInstanceName $mockInstanceName -ApplicationDomain $mockApplicationDomainObject
+                } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.Smo, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
+
+                Assert-MockCalled -CommandName Get-SqlMajorVersion
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    <#
+        It is not possible to fully test this helper function since we can't mock having the correct assembly
+        in the GAC. So these test will try to load the wrong assembly and will catch the error. But that means
+        it will never test the rows after if fails to load the assembly.
+    #>
+    Describe 'Testing Register-SqlWmiManagement' -Tag RegisterSqlWmiManagement {
+        BeforeEach {
+            Mock -CommandName Get-SqlMajorVersion -MockWith {
+                return '0' # Mocking zero because that could never match a correct assembly
+            } -Verifiable
+
+            Mock -CommandName Register-SqlSmo -MockWith {
+                [System.AppDomain]::CreateDomain('xSQLServerHelper')
+            } -ParameterFilter {
+                $SQLInstanceName -eq $mockInstanceName
+            } -Verifiable
+        }
+
+        Context 'When calling Register-SqlWmiManagement to load the wrong assembly' {
+            It 'Should throw with the correct error' {
+                {
+                    Register-SqlWmiManagement -SQLInstanceName $mockInstanceName
+                } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.SqlWmiManagement, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
+
+                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Register-SqlSmo -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $SQLInstanceName -eq $mockInstanceName -and $ApplicationDomain -eq $null
+                }
+            }
+        }
+
+        Context 'When calling Register-SqlWmiManagement with a application domain to load the wrong assembly' {
+            It 'Should throw with the correct error' {
+                {
+                    Register-SqlWmiManagement -SQLInstanceName $mockInstanceName -ApplicationDomain $mockApplicationDomainObject
+                } | Should -Throw 'Exception calling "Load" with "1" argument(s): "Could not load file or assembly ''Microsoft.SqlServer.SqlWmiManagement, Version=0.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'' or one of its dependencies. The system cannot find the file specified."'
+
+                Assert-MockCalled -CommandName Get-SqlMajorVersion
+                Assert-MockCalled -CommandName Register-SqlSmo -Exactly -Times 0 -Scope It -ParameterFilter {
+                    $SQLInstanceName -eq $mockInstanceName -and $ApplicationDomain -eq $null
+                }
+
+                Assert-MockCalled -CommandName Register-SqlSmo -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $SQLInstanceName -eq $mockInstanceName -and $ApplicationDomain.FriendlyName -eq $mockApplicationDomainName
+                }
+            }
+        }
+
+        Assert-VerifiableMocks
+    }
+
+    <#
+        NOTE! This test must be after the tests for Register-SqlSmo and Register-SqlWmiManagement.
+        This test unloads the application domain that is used during those tests.
+    #>
+    Describe 'Testing Unregister-SqlAssemblies' -Tag UnregisterSqlAssemblies {
+        Context 'When calling Unregister-SqlAssemblies to unload the assemblies' {
+            It 'Should not throw an error' {
+                {
+                    Unregister-SqlAssemblies -ApplicationDomain $mockApplicationDomainObject
+                } | Should -Not -Throw
+            }
+        }
     }
 }

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -114,5 +114,5 @@ AddMemberServerRoleSetError = Failed to add member {3} to the server role named 
 DropMemberServerRoleSetError = Failed to drop member {3} to the server role named {2} on {0}\\{1}.
 
 # SQLServerNetwork
-UnableToUseBothDynamicAndStaticPort = Unable to set both tcp dynamic port and tcp static port. Only one can be set.
+UnableToUseBothDynamicAndStaticPort = Unable to set both TCP dynamic port and TCP static port. Only one can be set.
 '@

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -13,6 +13,7 @@ NotConnectedToInstance = Was unable to connect to the instance '{0}\\{1}'
 AlterAvailabilityGroupFailed = Failed to alter the availability group '{0}'.
 HadrNotEnabled = HADR is not enabled.
 AvailabilityGroupNotFound = Unable to locate the availability group '{0}' on the instance '{1}'.
+SqlServerVersionIsInvalid = 'Could not get the SQL version for the instance '{0}'.
 
 # SQLServer
 NoDatabase = Database '{0}' does not exist on SQL server '{1}\\{2}'.

--- a/en-US/xSQLServer.strings.psd1
+++ b/en-US/xSQLServer.strings.psd1
@@ -112,4 +112,7 @@ CreateServerRoleSetError = Failed to create the server role named {2} on {0}\\{1
 DropServerRoleSetError = Failed to drop the server role named {2} on {0}\\{1}.
 AddMemberServerRoleSetError = Failed to add member {3} to the server role named {2} on {0}\\{1}.
 DropMemberServerRoleSetError = Failed to drop member {3} to the server role named {2} on {0}\\{1}.
+
+# SQLServerNetwork
+UnableToUseBothDynamicAndStaticPort = Unable to set both tcp dynamic port and tcp static port. Only one can be set.
 '@

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -188,7 +188,7 @@ function Register-SqlSmo
         $ApplicationDomain
     )
 
-    $sqlMajorVersion = Get-SqlMajorVersion -SQLInstanceName $SQLInstanceName
+    $sqlMajorVersion = Get-SqlInstanceMajorVersion -SQLInstanceName $SQLInstanceName
     New-VerboseMessage -Message ('SQL major version is {0}.' -f $sqlMajorVersion)
 
     if( -not $ApplicationDomain )
@@ -248,7 +248,7 @@ function Register-SqlWmiManagement
         $ApplicationDomain
     )
 
-    $sqlMajorVersion = Get-SqlMajorVersion -SQLInstanceName $SQLInstanceName
+    $sqlMajorVersion = Get-SqlInstanceMajorVersion -SQLInstanceName $SQLInstanceName
     New-VerboseMessage -Message ('SQL major version is {0}.' -f $sqlMajorVersion)
 
     <#
@@ -304,7 +304,7 @@ function Unregister-SqlAssemblies
     .OUTPUTS
         System.UInt16. Returns the SQL Server major version number.
 #>
-function Get-SqlMajorVersion
+function Get-SqlInstanceMajorVersion
 {
     [CmdletBinding()]
     [OutputType([System.UInt16])]

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -290,7 +290,7 @@ function Unregister-SqlAssemblies
         $ApplicationDomain
     )
 
-    New-VerboseMessage -Message ('Unloads application domain ''{0}''.' -f $ApplicationDomain.FriendlyName)
+    New-VerboseMessage -Message ('Unloading application domain ''{0}''.' -f $ApplicationDomain.FriendlyName)
     [System.AppDomain]::Unload($ApplicationDomain)
 }
 

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -243,7 +243,7 @@ function Register-SqlWmiManagement
         $SQLInstanceName,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNull()]
         [System.AppDomain]
         $ApplicationDomain
     )
@@ -269,7 +269,7 @@ function Register-SqlWmiManagement
     New-VerboseMessage -Message ('Loading assembly ''{0}''.' -f $sqlSqlWmiManagementAssemblyName)
     $applicationDomainObject.Load($sqlSqlWmiManagementAssemblyName) | Out-Null
 
-    return $applicationDomainName
+    return $applicationDomainObject
 }
 
 <#
@@ -285,7 +285,7 @@ function Unregister-SqlAssemblies
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNull()]
         [System.AppDomain]
         $ApplicationDomain
     )


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerNetwork
  - Added optional parameter SQLServer with default value of $env:COMPUTERNAME (issue #528).
  - Added optional parameter RestartTimeout with default value of 120 seconds.
  - Now the resource supports restarting a sql server in a cluster (issue #527 and issue #455).
  - Now the resource allows to set the parameter TcpDynamicPorts to a blank value (partly fixes issue #534). Setting a blank value for parameter TcpDynamicPorts together with a value for parameter TcpPort means that static port will be used.
  - Now the resource will not call Alter() in the Set-TargetResource when there is no change necessary (issue #537).
  - Updated example 1-EnableTcpIpOnCustomStaticPort.
  - Added unit tests (issue #294).
  - Refactored some of the code, cleaned up the rest and fixed PSSA rules warnings (issue #261).
  - If both parameter TcpDynamicPort and TcpPort is set at the same time it will now throw an error (issue #535).
  - Added examples (issue #536).
  - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).

**This Pull Request (PR) fixes the following issues:**
Fixes #261
Fixes #294
Fixes #455
Fixes #527
Fixes #528
Fixes #535
Fixes #536
Fixes #537
Fixes #564

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/538)
<!-- Reviewable:end -->
