### PR TITLE
xSQLServerDatabaseRole: Updated variable passed to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
   - Added an optional boolean parameter Disabled. It can be used to enable/disable existing logins or create disabled logins (new logins are created as enabled by default).
 - Changes to xSQLServerDatabaseRole
   - Updated variable passed to Microsoft.SqlSErver.Management.Smo.User constructor to fix issue #530
-  
+
 ## 7.0.0.0
 
 - Examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@
   - Updated to return the exception raised when an error is thrown.
 - Changes to xSQLServerLogin
   - Added an optional boolean parameter Disabled. It can be used to enable/disable existing logins or create disabled logins (new logins are created as enabled by default).
-
+- Changes to xSQLServerDatabaseRole
+  - Updated variable passed to Microsoft.SqlSErver.Management.Smo.User constructor to fix issue #530
+  
 ## 7.0.0.0
 
 - Examples

--- a/DSCResources/MSFT_xSQLServerDatabaseRole/MSFT_xSQLServerDatabaseRole.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabaseRole/MSFT_xSQLServerDatabaseRole.psm1
@@ -217,7 +217,7 @@ function Set-TargetResource
                                                      "'$Database', on the instance $SQLServer\$SQLInstanceName")
 
                         $sqlDatabaseUser = New-Object -TypeName Microsoft.SqlServer.Management.Smo.User `
-                                                      -ArgumentList $SQLDatabase, $Name
+                                                      -ArgumentList $sqlDatabaseObject, $Name
                         $sqlDatabaseUser.Login = $Name
                         $sqlDatabaseUser.Create()
                     }


### PR DESCRIPTION
Updated creation of smo.user object, fixes #530 

<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please make sure you have read the contributing section at https://github.com/PowerShell/xSQLServer#contributing.

Please prefix the PR title with the resource name, i.e. 'xSQLServerSetup: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xSQLServerSetup: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
Wrong variable used in smo.user object creation, updated variable.

**This Pull Request (PR) fixes the following issues:**
Fixes #530 

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/544)
<!-- Reviewable:end -->
