### PR TITLE
xSQLServerAlwaysOnAvailabilityGroupReplica: Fix to add named SQLInstance as secondary replica to AAG.

### DIFF
--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
@@ -444,7 +444,7 @@ function Set-TargetResource
                     $endpointUrl = "TCP://$($EndpointHostName):$($endpointPort)"
 
                     $newAvailabilityGroupReplicaParams = @{
-                        Name = $Name
+                        Name = $serverObject.Name
                         InputObject = $primaryReplicaAvailabilityGroup
                         AvailabilityMode = $AvailabilityMode
                         EndpointUrl = $endpointUrl

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
@@ -79,7 +79,7 @@ function Get-TargetResource
         $alwaysOnAvailabilityGroupReplicaResource.AvailabilityGroupName = $availabilityGroup.Name
         
         # Try to find the replica
-        $availabilityGroupReplica = $availabilityGroup.AvailabilityReplicas[$Name]
+        $availabilityGroupReplica = $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
 
         if ( $availabilityGroupReplica )
         {
@@ -658,7 +658,6 @@ function Test-TargetResource
         'Present'
         {
             $parametersToCheck = @(
-                'Name',
                 'AvailabilityGroupName',
                 'SQLServer',
                 'SQLInstanceName',


### PR DESCRIPTION
**Pull Request (PR) description**

- Fix to add named SQLInstance as secondary replica to AAG.


**This Pull Request (PR) fixes the following issues:**

-  Fixes #548

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/549)
<!-- Reviewable:end -->
