### PR TITLE
xSQLServerRSConfig: Replaced sqlcmd.exe with Invoke-Sqlcmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   - If parameter TcpDynamicPort is set to '0' at the same time as TcpPort is set the resource will now throw an error (issue #535).
   - Added examples (issue #536).
   - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).
+- Changes to xSQLServerRSConfig
+  - Replaced sqlcmd.exe usages with Invoke-Sqlcmd calls (issue #567).
 
 ## 7.0.0.0
 


### PR DESCRIPTION
**Pull Request (PR) description**
Replaced two sqlcmd.exe executions with Invoke-Sqlcmd calls.

A small code cleanup as the result of the above change.

Removed the conditional use of $RSConfig.MachineAccountIdentity as
$RSSvcAccountUsername, since it was always empty (tested on SQL2014
only). Need to double-check this.

**This Pull Request (PR) fixes the following issues:**
Fixes #567

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/571)
<!-- Reviewable:end -->
