### PR TITLE
xSQLServerMaxDop & xSQLServerMemory: Fixed issue with SQLServer parameter not assuming the default value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Changes to xSQLServerMemory
   - Changed the way SQLServer parameter is passed from Test-TargetResource to Get-TargetResource so that the default value isn't lost (issue #576).
+  - Added condition to unit tests for when no SQLServer parameter is set.
 - Changes to xSQLServerMaxDop
   - Changed the way SQLServer parameter is passed from Test-TargetResource to Get-TargetResource so that the default value isn't lost (issue #576).
+  - Added condition to unit tests for when no SQLServer parameter is set.
 - Changes to xWaitForAvailabilityGroup
   - Updated README.md with a description for the resources and revised the parameter descriptions.
   - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Changes to xSQLServerMemory
+  - Changed the way SQLServer parameter is passed from Test-TargetResource to Get-TargetResource so that the default value isn't lost (issue #576).
+- Changes to xSQLServerMaxDop
+  - Changed the way SQLServer parameter is passed from Test-TargetResource to Get-TargetResource so that the default value isn't lost (issue #576).
 - Changes to xWaitForAvailabilityGroup
   - Updated README.md with a description for the resources and revised the parameter descriptions.
   - The default value for RetryIntervalSec is now 20 seconds and the default value for RetryCount is now 30 times (issue #505).

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -201,7 +201,7 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing the max degree of parallelism server configuration option'
      
     $parameters = @{
-        SQLInstanceName = $PSBoundParameters.SQLInstanceName
+        SQLInstanceName = $SQLInstanceName
         SQLServer       = $SQLServer
     }
     

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -202,7 +202,7 @@ function Test-TargetResource
      
     $parameters = @{
         SQLInstanceName = $PSBoundParameters.SQLInstanceName
-        SQLServer       = $PSBoundParameters.SQLServer
+        SQLServer       = $SQLServer
     }
     
     $currentValues = Get-TargetResource @parameters    

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -229,7 +229,7 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing the values of the minimum and maximum memory server configuration option set to be used by the instance.'  
 
     $getTargetResourceParameters = @{
-        SQLInstanceName = $PSBoundParameters.SQLInstanceName
+        SQLInstanceName = $SQLInstanceName
         SQLServer       = $SQLServer
     }
 

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -230,7 +230,7 @@ function Test-TargetResource
 
     $getTargetResourceParameters = @{
         SQLInstanceName = $PSBoundParameters.SQLInstanceName
-        SQLServer       = $PSBoundParameters.SQLServer
+        SQLServer       = $SQLServer
     }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters

--- a/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
@@ -324,6 +324,19 @@ try
                 }
             }
 
+            # This is regression test for issue #576
+            Context 'When the system is in the desired state and SQLServer is not set' {
+                $testParameters = $mockDefaultParameters
+                $testParameters.Remove('SQLServer')
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                It 'Should return the state as true when desired MaxDop is the correct value' {
+                    { Test-TargetResource @testParameters } | Should Not Throw
+                }
+            }
+
             Assert-VerifiableMocks
         }
         

--- a/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
@@ -332,7 +332,7 @@ try
                     Ensure = 'Absent'
                 }
 
-                It 'Should return the state as true when desired MaxDop is the correct value' {
+                It 'Should not throw an error' {
                     { Test-TargetResource @testParameters } | Should Not Throw
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
@@ -403,7 +403,7 @@ try
                     Ensure = 'Absent'
                 }
 
-                It 'Should return the state as true when desired MaxDop is the correct value' {
+                It 'Should not throw an error' {
                     { Test-TargetResource @testParameters } | Should Not Throw
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
@@ -395,6 +395,19 @@ try
                 }
             }
 
+            # This is regression test for issue #576
+            Context 'When the system is in the desired state and SQLServer is not set' {
+                $testParameters = $mockDefaultParameters
+                $testParameters.Remove('SQLServer')
+                $testParameters += @{
+                    Ensure = 'Absent'
+                }
+
+                It 'Should return the state as true when desired MaxDop is the correct value' {
+                    { Test-TargetResource @testParameters } | Should Not Throw
+                }
+            }
+
             Assert-VerifiableMocks
         }
         
@@ -647,7 +660,7 @@ try
                 }
 
                 It 'Should throw the correct error' {                
-                    { Set-TargetResource @testParameters } | Should Throw ("Failed to alter the server configuration memory for $mockSQLServerName" + "\" +`
+                    { Set-TargetResource @testParameters } | Should Throw ("Failed to alter the server configuration memory for $($env:COMPUTERNAME)" + "\" +`
                                                                         "$mockSQLServerInstanceName. InnerException: Exception calling ""Alter"" with ""0"" argument(s): " + `
                                                                         """Mock Alter Method was called with invalid operation.""")
                 }


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please make sure you have read the contributing section at https://github.com/PowerShell/xSQLServer#contributing.

Please prefix the PR title with the resource name, i.e. 'xSQLServerSetup: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xSQLServerSetup: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
This issue affects two resources - xSQLServerMaxDop and xSQLServerMemory.
This fixes an issue with the SQLServer property not assuming the default value when no value is passed.

**This Pull Request (PR) fixes the following issues:**
Fixes #576 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/577)
<!-- Reviewable:end -->
