### PR TITLE
xSQLServerDatabase: Changed SQLInstance to SQLInstanceName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changes to xSQLServerDatabase
+  - Changed the readme, SQLInstance should have been SQLInstancename.
+
 ## 7.1.0.0
 
 - Changes to xSQLServerMemory
@@ -63,7 +66,6 @@
   - If parameter TcpDynamicPort is set to '0' at the same time as TcpPort is set the resource will now throw an error (issue #535).
   - Added examples (issue #536).
   - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).
-<<<<<<< HEAD
 - Changes to xSQLServerRSConfig
   - Replaced sqlcmd.exe usages with Invoke-Sqlcmd calls (issue #567).
 - Changes to xSQLServerDatabasePermission
@@ -73,10 +75,6 @@
   - Updated tests to cover Revoke().
 - Changes to xSQLServerHelper
   - The missing helper function ('Test-SPDSCObjectHasProperty'), that was referenced in the helper function Test-SQLDscParameterState, is now incorporated into Test-SQLDscParameterState (issue #589).
-=======
-- Changes to xSQLServerDatabase
-  - Changed the readme, SQLInstance should have been SQLInstancename.
->>>>>>> added information to the changelog
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
   - If parameter TcpDynamicPort is set to '0' at the same time as TcpPort is set the resource will now throw an error (issue #535).
   - Added examples (issue #536).
   - When TcpDynamicPorts is set to '0' the Test-TargetResource function will no longer fail each time (issue #564).
+<<<<<<< HEAD
 - Changes to xSQLServerRSConfig
   - Replaced sqlcmd.exe usages with Invoke-Sqlcmd calls (issue #567).
 - Changes to xSQLServerDatabasePermission
@@ -72,6 +73,10 @@
   - Updated tests to cover Revoke().
 - Changes to xSQLServerHelper
   - The missing helper function ('Test-SPDSCObjectHasProperty'), that was referenced in the helper function Test-SQLDscParameterState, is now incorporated into Test-SQLDscParameterState (issue #589).
+=======
+- Changes to xSQLServerDatabase
+  - Changed the readme, SQLInstance should have been SQLInstancename.
+>>>>>>> added information to the changelog
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Changes to xSQLServerDatabase
-  - Changed the readme, SQLInstance should have been SQLInstancename.
+  - Changed the readme, SQLInstance should have been SQLInstanceName.
 
 ## 7.1.0.0
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ This resource is used to create or delete a database. For more information about
 #### Parameters
 
 * **[String] SQLServer** _(Key)_: The host name of the SQL Server to be configured.
-* **[String] SQLInstance** _(Key)_: The name of the SQL instance to be configured.
+* **[String] SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **[String] Name** _(Key)_: The name of database to be created or dropped.
 * **[String] Ensure** _(Write)_: When set to 'Present', the database will be created. When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 


### PR DESCRIPTION
Changed the documenation for the xSQLServerDatabase, there was an error in there because the sqlinstance should be sqlinstancename.

checked the code for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/579)
<!-- Reviewable:end -->
