### PR TITLE
xSQLServerSetup: Move checking for Tools features to not depend on SQLEngine - Fixes #591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Changes to xSQLServerDatabase
   - Changed the readme, SQLInstance should have been SQLInstanceName.
+- Changes to xSQLServerSetup
+  - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
 
 ## 7.1.0.0
 
@@ -45,7 +47,6 @@
 - Changes to xSQLServerSetUp
   - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490).
   - Added change to detect DQ, DQC, BOL, SDK features. Now the function Test-TargetResource returns true after calling set for DQ, DQC, BOL, SDK features (issue #516 and #490).
-  - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Updated to return the exception raised when an error is thrown.
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-<<<<<<< HEAD
 - Changes to xSQLServerDatabase
   - Changed the readme, SQLInstance should have been SQLInstanceName.
 - Changes to xSQLServerSetup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,6 @@
 - Changes to xSQLServerSetup
   - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
 
-=======
-- Changes to xSQLServerSetup
-  - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
-<<<<<<< HEAD
-  
->>>>>>> Fixed missing blank lines
-=======
-
->>>>>>> Remove random space
 ## 7.1.0.0
 
 - Changes to xSQLServerMemory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Changes to xSQLServerSetUp
   - Updated xSQLServerSetup Module Get-Resource method to fix (issue #516 and #490).
   - Added change to detect DQ, DQC, BOL, SDK features. Now the function Test-TargetResource returns true after calling set for DQ, DQC, BOL, SDK features (issue #516 and #490).
+  - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Updated to return the exception raised when an error is thrown.
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@
 =======
 - Changes to xSQLServerSetup
   - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
+<<<<<<< HEAD
   
 >>>>>>> Fixed missing blank lines
+=======
+
+>>>>>>> Remove random space
 ## 7.1.0.0
 
 - Changes to xSQLServerMemory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## Unreleased
 
+<<<<<<< HEAD
 - Changes to xSQLServerDatabase
   - Changed the readme, SQLInstance should have been SQLInstanceName.
 - Changes to xSQLServerSetup
   - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
 
+=======
+- Changes to xSQLServerSetup
+  - Updated Get-TargetResource to correctly detect BOL, Conn, BC and other tools when they are installed withouth SQLENGINE (issue #591).
+  
+>>>>>>> Fixed missing blank lines
 ## 7.1.0.0
 
 - Changes to xSQLServerMemory

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -371,7 +371,7 @@ function Get-TargetResource
     }
 
     $features = $features.Trim(',')
-    if ($Features)
+    if ($features)
     {
         $registryInstallerComponentsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components'
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -371,7 +371,7 @@ function Get-TargetResource
     }
 
     $features = $features.Trim(',')
-    if ($features -ne '')
+    if ([string]::IsNullOrWhiteSpace($Features))
     {
         $registryInstallerComponentsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components'
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -89,7 +89,7 @@ function Get-TargetResource
 
     $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
+    Write-Verbose -Message "Using path: $pathToSetupExecutable"
 
     $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
@@ -133,42 +133,42 @@ function Get-TargetResource
         $fullInstanceId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -Name $InstanceName).$InstanceName
 
         # Check if Replication sub component is configured for this instance
-        New-VerboseMessage -Message "Detecting replication feature (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState)"
+        Write-Verbose -Message "Detecting replication feature (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState)"
         $isReplicationInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState").SQL_Replication_Core_Inst
         if ($isReplicationInstalled -eq 1)
         {
-            New-VerboseMessage -Message 'Replication feature detected'
+            Write-Verbose -Message 'Replication feature detected'
             $features += 'REPLICATION,'
         }
         else
         {
-            New-VerboseMessage -Message 'Replication feature not detected'
+            Write-Verbose -Message 'Replication feature not detected'
         }
 
         # Check if Data Quality Client sub component is configured
-        New-VerboseMessage -Message "Detecting Data Quality Client (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        Write-Verbose -Message "Detecting Data Quality Client (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
         $isDQCInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_DQ_CLIENT_Full
         if ($isDQCInstalled -eq 1)
         {
-            New-VerboseMessage -Message 'Data Quality Client feature detected'
+            Write-Verbose -Message 'Data Quality Client feature detected'
             $features += 'DQC,'
         }
         else
         {
-            New-VerboseMessage -Message 'Data Quality Client feature not detected'
+            Write-Verbose -Message 'Data Quality Client feature not detected'
         }
 
         # Check if Data Quality Services sub component is configured
-        New-VerboseMessage -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*)"
+        Write-Verbose -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*)"
         $isDQInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*" -ErrorAction SilentlyContinue)
         if ($isDQInstalled)
         {
-            New-VerboseMessage -Message 'Data Quality Services feature detected'
+            Write-Verbose -Message 'Data Quality Services feature detected'
             $features += 'DQ,'
         }
         else
         {
-            New-VerboseMessage -Message 'Data Quality Services feature not detected'
+            Write-Verbose -Message 'Data Quality Services feature not detected'
         }
 
         $instanceId = $fullInstanceId.Split('.')[1]
@@ -206,7 +206,7 @@ function Get-TargetResource
 
         if ($databaseServer.IsClustered)
         {
-            New-VerboseMessage -Message 'Clustered instance detected'
+            Write-Verbose -Message 'Clustered instance detected'
 
             $clusteredSqlInstance = Get-CimInstance -Namespace root/MSCluster -ClassName MSCluster_Resource -Filter "Type = 'SQL Server'" |
                 Where-Object { $_.PrivateProperties.InstanceName -eq $InstanceName }
@@ -216,7 +216,7 @@ function Get-TargetResource
                 throw New-TerminatingError -ErrorType FailoverClusterResourceNotFound -FormatArgs $InstanceName -ErrorCategory 'ObjectNotFound'
             }
 
-            New-VerboseMessage -Message 'Clustered SQL Server resource located'
+            Write-Verbose -Message 'Clustered SQL Server resource located'
 
             $clusteredSqlGroup = $clusteredSqlInstance | Get-CimAssociatedInstance -ResultClassName MSCluster_ResourceGroup
             $clusteredSqlNetworkName = $clusteredSqlGroup | Get-CimAssociatedInstance -ResultClassName MSCluster_Resource |
@@ -231,7 +231,7 @@ function Get-TargetResource
         }
         else
         {
-            New-VerboseMessage -Message 'Clustered instance not detected'
+            Write-Verbose -Message 'Clustered instance not detected'
         }
     }
 
@@ -272,16 +272,16 @@ function Get-TargetResource
     }
 
     # Check if Documentation Components "BOL" is configured
-    New-VerboseMessage -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+    Write-Verbose -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
     $isBOLInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_BOL_Components
     if ($isBOLInstalled -eq 1)
     {
-        New-VerboseMessage -Message 'Documentation Components feature detected'
+        Write-Verbose -Message 'Documentation Components feature detected'
         $features += 'BOL,'
     }
     else
     {
-        New-VerboseMessage -Message 'Documentation Components feature not detected'
+        Write-Verbose -Message 'Documentation Components feature not detected'
     }
 
     $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
@@ -290,34 +290,34 @@ function Get-TargetResource
     Write-Debug -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
     if ($registryClientComponentsFullFeatureList -like '*Connectivity_FNS=3*')
     {
-        New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
+        Write-Verbose -Message 'Client Connectivity Tools feature detected'
         $features += 'CONN,'
     }
     else
     {
-        New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
+        Write-Verbose -Message 'Client Connectivity Tools feature not detected'
     }
 
     Write-Debug -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
     if ($registryClientComponentsFullFeatureList -like '*Tools_Legacy_FNS=3*')
     {
-        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
+        Write-Verbose -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
         $features += 'BC,'
     }
     else
     {
-        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
+        Write-Verbose -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
     }
 
     Write-Debug -Message "Detecting Client Tools SDK feature ($clientComponentsFullRegistryPath)"
     if (($registryClientComponentsFullFeatureList -like '*SDK_Full=3*') -and ($registryClientComponentsFullFeatureList -like '*SDK_FNS=3*'))
     {
-        New-VerboseMessage -Message 'Client Tools SDK feature detected'
+        Write-Verbose -Message 'Client Tools SDK feature detected'
         $features += 'SDK,'
     }
     else
     {
-        New-VerboseMessage -Message 'Client Tools SDK feature not detected'
+        Write-Verbose -Message 'Client Tools SDK feature not detected'
     }
 
     $registryUninstallPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
@@ -850,7 +850,7 @@ function Set-TargetResource
 
         $mediaDestinationPath = Join-Path -Path (Get-TemporaryFolder) -ChildPath $mediaDestinationFolder
 
-        New-VerboseMessage -Message "Robocopy is copying media from source '$SourcePath' to destination '$mediaDestinationPath'"
+        Write-Verbose -Message "Robocopy is copying media from source '$SourcePath' to destination '$mediaDestinationPath'"
         Copy-ItemWithRoboCopy -Path $SourcePath -DestinationPath $mediaDestinationPath
 
         Remove-SmbMapping -RemotePath $SourcePath -Force
@@ -860,7 +860,7 @@ function Set-TargetResource
 
     $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
+    Write-Verbose -Message "Using path: $pathToSetupExecutable"
 
     $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
@@ -990,7 +990,7 @@ function Set-TargetResource
                 $parameterValue = Get-Variable -Name $parameterName -ValueOnly
                 if ($parameterValue)
                 {
-                    New-VerboseMessage -Message ("Found assigned parameter '{0}'. Adding path '{1}' to list of paths that required cluster drive." -f $parameterName, $parameterValue)
+                    Write-Verbose -Message ("Found assigned parameter '{0}'. Adding path '{1}' to list of paths that required cluster drive." -f $parameterName, $parameterValue)
                     $requiredDrive += $parameterValue
                 }
             }
@@ -1319,7 +1319,7 @@ function Set-TargetResource
         }
     }
 
-    New-VerboseMessage -Message "Starting setup using arguments: $log"
+    Write-Verbose -Message "Starting setup using arguments: $log"
 
     $arguments = $arguments.Trim()
     $processArguments = @{
@@ -1334,7 +1334,7 @@ function Set-TargetResource
 
     $process = StartWin32Process @processArguments
 
-    New-VerboseMessage -Message $process
+    Write-Verbose -Message $process
 
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments
 
@@ -1346,7 +1346,7 @@ function Set-TargetResource
         }
         else
         {
-            New-VerboseMessage -Message 'Suppressing reboot'
+            Write-Verbose -Message 'Suppressing reboot'
         }
     }
 
@@ -1696,7 +1696,7 @@ function Test-TargetResource
     $boundParameters = $PSBoundParameters
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    New-VerboseMessage -Message "Features found: '$($getTargetResourceResult.Features)'"
+    Write-Verbose -Message "Features found: '$($getTargetResourceResult.Features)'"
 
     $result = $true
 
@@ -1709,7 +1709,7 @@ function Test-TargetResource
 
             if(!($getTargetResourceResult.Features.Contains($feature)))
             {
-                New-VerboseMessage -Message "Unable to find feature '$feature' among the installed features: '$($getTargetResourceResult.Features)'"
+                Write-Verbose -Message "Unable to find feature '$feature' among the installed features: '$($getTargetResourceResult.Features)'"
                 $result = $false
             }
         }
@@ -1721,13 +1721,13 @@ function Test-TargetResource
 
     if ($PSCmdlet.ParameterSetName -eq 'ClusterInstall')
     {
-        New-VerboseMessage -Message "Clustered install, checking parameters."
+        Write-Verbose -Message "Clustered install, checking parameters."
 
         $boundParameters.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
             $variableName = $_
 
             if ($getTargetResourceResult.$variableName -ne $boundParameters[$variableName]) {
-                New-VerboseMessage -Message "$variableName '$($boundParameters[$variableName])' is not in the desired state for this cluster."
+                Write-Verbose -Message "$variableName '$($boundParameters[$variableName])' is not in the desired state for this cluster."
                 $result = $false
             }
         }

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -371,7 +371,7 @@ function Get-TargetResource
     }
 
     $features = $features.Trim(',')
-    if ($Features -ne '')
+    if (-not ([string]::IsNullOrWhiteSpace($Features)))
     {
         $registryInstallerComponentsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components'
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -371,7 +371,7 @@ function Get-TargetResource
     }
 
     $features = $features.Trim(',')
-    if ([string]::IsNullOrWhiteSpace($Features))
+    if ($Features -ne '')
     {
         $registryInstallerComponentsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components'
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -371,7 +371,7 @@ function Get-TargetResource
     }
 
     $features = $features.Trim(',')
-    if (-not ([string]::IsNullOrWhiteSpace($Features)))
+    if ($Features)
     {
         $registryInstallerComponentsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components'
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -171,55 +171,6 @@ function Get-TargetResource
             New-VerboseMessage -Message 'Data Quality Services feature not detected'
         }
 
-        # Check if Documentation Components "BOL" is configured
-        New-VerboseMessage -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
-        $isBOLInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_BOL_Components
-        if ($isBOLInstalled -eq 1)
-        {
-            New-VerboseMessage -Message 'Documentation Components feature detected'
-            $features += 'BOL,'
-        }
-        else
-        {
-            New-VerboseMessage -Message 'Documentation Components feature not detected'
-        }
-
-        $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
-        $registryClientComponentsFullFeatureList = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
-
-        Write-Debug -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
-        if ($registryClientComponentsFullFeatureList -like '*Connectivity_FNS=3*')
-        {
-            New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
-            $features += 'CONN,'
-        }
-        else
-        {
-            New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
-        }
-
-        Write-Debug -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
-        if ($registryClientComponentsFullFeatureList -like '*Tools_Legacy_FNS=3*')
-        {
-            New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
-            $features += 'BC,'
-        }
-        else
-        {
-            New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
-        }
-
-        Write-Debug -Message "Detecting Client Tools SDK feature ($clientComponentsFullRegistryPath)"
-        if (($registryClientComponentsFullFeatureList -like '*SDK_Full=3*') -and ($registryClientComponentsFullFeatureList -like '*SDK_FNS=3*'))
-        {
-            New-VerboseMessage -Message 'Client Tools SDK feature detected'
-            $features += 'SDK,'
-        }
-        else
-        {
-            New-VerboseMessage -Message 'Client Tools SDK feature not detected'
-        }
-
         $instanceId = $fullInstanceId.Split('.')[1]
         $instanceDirectory = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\Setup" -Name 'SqlProgramDir').SqlProgramDir.Trim("\")
 
@@ -318,6 +269,55 @@ function Get-TargetResource
     {
         $features += 'IS,'
         $integrationServiceAccountUsername = (Get-CimInstance -ClassName Win32_Service -Filter "Name = '$integrationServiceName'").StartName
+    }
+
+    # Check if Documentation Components "BOL" is configured
+    New-VerboseMessage -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+    $isBOLInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_BOL_Components
+    if ($isBOLInstalled -eq 1)
+    {
+        New-VerboseMessage -Message 'Documentation Components feature detected'
+        $features += 'BOL,'
+    }
+    else
+    {
+        New-VerboseMessage -Message 'Documentation Components feature not detected'
+    }
+
+    $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
+    $registryClientComponentsFullFeatureList = (Get-ItemProperty -Path $clientComponentsFullRegistryPath -ErrorAction SilentlyContinue).FeatureList
+
+    Write-Debug -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
+    if ($registryClientComponentsFullFeatureList -like '*Connectivity_FNS=3*')
+    {
+        New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
+        $features += 'CONN,'
+    }
+    else
+    {
+        New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
+    }
+
+    Write-Debug -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
+    if ($registryClientComponentsFullFeatureList -like '*Tools_Legacy_FNS=3*')
+    {
+        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
+        $features += 'BC,'
+    }
+    else
+    {
+        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
+    }
+
+    Write-Debug -Message "Detecting Client Tools SDK feature ($clientComponentsFullRegistryPath)"
+    if (($registryClientComponentsFullFeatureList -like '*SDK_Full=3*') -and ($registryClientComponentsFullFeatureList -like '*SDK_FNS=3*'))
+    {
+        New-VerboseMessage -Message 'Client Tools SDK feature detected'
+        $features += 'SDK,'
+    }
+    else
+    {
+        New-VerboseMessage -Message 'Client Tools SDK feature not detected'
     }
 
     $registryUninstallPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -89,7 +89,7 @@ function Get-TargetResource
 
     $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    Write-Verbose -Message "Using path: $pathToSetupExecutable"
+    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
 
     $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
@@ -133,42 +133,42 @@ function Get-TargetResource
         $fullInstanceId = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -Name $InstanceName).$InstanceName
 
         # Check if Replication sub component is configured for this instance
-        Write-Verbose -Message "Detecting replication feature (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState)"
+        New-VerboseMessage -Message "Detecting replication feature (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState)"
         $isReplicationInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$fullInstanceId\ConfigurationState").SQL_Replication_Core_Inst
         if ($isReplicationInstalled -eq 1)
         {
-            Write-Verbose -Message 'Replication feature detected'
+            New-VerboseMessage -Message 'Replication feature detected'
             $features += 'REPLICATION,'
         }
         else
         {
-            Write-Verbose -Message 'Replication feature not detected'
+            New-VerboseMessage -Message 'Replication feature not detected'
         }
 
         # Check if Data Quality Client sub component is configured
-        Write-Verbose -Message "Detecting Data Quality Client (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+        New-VerboseMessage -Message "Detecting Data Quality Client (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
         $isDQCInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_DQ_CLIENT_Full
         if ($isDQCInstalled -eq 1)
         {
-            Write-Verbose -Message 'Data Quality Client feature detected'
+            New-VerboseMessage -Message 'Data Quality Client feature detected'
             $features += 'DQC,'
         }
         else
         {
-            Write-Verbose -Message 'Data Quality Client feature not detected'
+            New-VerboseMessage -Message 'Data Quality Client feature not detected'
         }
 
         # Check if Data Quality Services sub component is configured
-        Write-Verbose -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*)"
+        New-VerboseMessage -Message "Detecting Data Quality Services (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*)"
         $isDQInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\DQ\*" -ErrorAction SilentlyContinue)
         if ($isDQInstalled)
         {
-            Write-Verbose -Message 'Data Quality Services feature detected'
+            New-VerboseMessage -Message 'Data Quality Services feature detected'
             $features += 'DQ,'
         }
         else
         {
-            Write-Verbose -Message 'Data Quality Services feature not detected'
+            New-VerboseMessage -Message 'Data Quality Services feature not detected'
         }
 
         $instanceId = $fullInstanceId.Split('.')[1]
@@ -206,7 +206,7 @@ function Get-TargetResource
 
         if ($databaseServer.IsClustered)
         {
-            Write-Verbose -Message 'Clustered instance detected'
+            New-VerboseMessage -Message 'Clustered instance detected'
 
             $clusteredSqlInstance = Get-CimInstance -Namespace root/MSCluster -ClassName MSCluster_Resource -Filter "Type = 'SQL Server'" |
                 Where-Object { $_.PrivateProperties.InstanceName -eq $InstanceName }
@@ -216,7 +216,7 @@ function Get-TargetResource
                 throw New-TerminatingError -ErrorType FailoverClusterResourceNotFound -FormatArgs $InstanceName -ErrorCategory 'ObjectNotFound'
             }
 
-            Write-Verbose -Message 'Clustered SQL Server resource located'
+            New-VerboseMessage -Message 'Clustered SQL Server resource located'
 
             $clusteredSqlGroup = $clusteredSqlInstance | Get-CimAssociatedInstance -ResultClassName MSCluster_ResourceGroup
             $clusteredSqlNetworkName = $clusteredSqlGroup | Get-CimAssociatedInstance -ResultClassName MSCluster_Resource |
@@ -231,7 +231,7 @@ function Get-TargetResource
         }
         else
         {
-            Write-Verbose -Message 'Clustered instance not detected'
+            New-VerboseMessage -Message 'Clustered instance not detected'
         }
     }
 
@@ -272,16 +272,16 @@ function Get-TargetResource
     }
 
     # Check if Documentation Components "BOL" is configured
-    Write-Verbose -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
+    New-VerboseMessage -Message "Detecting Documentation Components (HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState)"
     $isBOLInstalled = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\ConfigurationState").SQL_BOL_Components
     if ($isBOLInstalled -eq 1)
     {
-        Write-Verbose -Message 'Documentation Components feature detected'
+        New-VerboseMessage -Message 'Documentation Components feature detected'
         $features += 'BOL,'
     }
     else
     {
-        Write-Verbose -Message 'Documentation Components feature not detected'
+        New-VerboseMessage -Message 'Documentation Components feature not detected'
     }
 
     $clientComponentsFullRegistryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($sqlVersion)0\Tools\Setup\Client_Components_Full"
@@ -290,34 +290,34 @@ function Get-TargetResource
     Write-Debug -Message "Detecting Client Connectivity Tools feature ($clientComponentsFullRegistryPath)"
     if ($registryClientComponentsFullFeatureList -like '*Connectivity_FNS=3*')
     {
-        Write-Verbose -Message 'Client Connectivity Tools feature detected'
+        New-VerboseMessage -Message 'Client Connectivity Tools feature detected'
         $features += 'CONN,'
     }
     else
     {
-        Write-Verbose -Message 'Client Connectivity Tools feature not detected'
+        New-VerboseMessage -Message 'Client Connectivity Tools feature not detected'
     }
 
     Write-Debug -Message "Detecting Client Connectivity Backwards Compatibility Tools feature ($clientComponentsFullRegistryPath)"
     if ($registryClientComponentsFullFeatureList -like '*Tools_Legacy_FNS=3*')
     {
-        Write-Verbose -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
+        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature detected'
         $features += 'BC,'
     }
     else
     {
-        Write-Verbose -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
+        New-VerboseMessage -Message 'Client Connectivity Tools Backwards Compatibility feature not detected'
     }
 
     Write-Debug -Message "Detecting Client Tools SDK feature ($clientComponentsFullRegistryPath)"
     if (($registryClientComponentsFullFeatureList -like '*SDK_Full=3*') -and ($registryClientComponentsFullFeatureList -like '*SDK_FNS=3*'))
     {
-        Write-Verbose -Message 'Client Tools SDK feature detected'
+        New-VerboseMessage -Message 'Client Tools SDK feature detected'
         $features += 'SDK,'
     }
     else
     {
-        Write-Verbose -Message 'Client Tools SDK feature not detected'
+        New-VerboseMessage -Message 'Client Tools SDK feature not detected'
     }
 
     $registryUninstallPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
@@ -850,7 +850,7 @@ function Set-TargetResource
 
         $mediaDestinationPath = Join-Path -Path (Get-TemporaryFolder) -ChildPath $mediaDestinationFolder
 
-        Write-Verbose -Message "Robocopy is copying media from source '$SourcePath' to destination '$mediaDestinationPath'"
+        New-VerboseMessage -Message "Robocopy is copying media from source '$SourcePath' to destination '$mediaDestinationPath'"
         Copy-ItemWithRoboCopy -Path $SourcePath -DestinationPath $mediaDestinationPath
 
         Remove-SmbMapping -RemotePath $SourcePath -Force
@@ -860,7 +860,7 @@ function Set-TargetResource
 
     $pathToSetupExecutable = Join-Path -Path $SourcePath -ChildPath 'setup.exe'
 
-    Write-Verbose -Message "Using path: $pathToSetupExecutable"
+    New-VerboseMessage -Message "Using path: $pathToSetupExecutable"
 
     $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
 
@@ -990,7 +990,7 @@ function Set-TargetResource
                 $parameterValue = Get-Variable -Name $parameterName -ValueOnly
                 if ($parameterValue)
                 {
-                    Write-Verbose -Message ("Found assigned parameter '{0}'. Adding path '{1}' to list of paths that required cluster drive." -f $parameterName, $parameterValue)
+                    New-VerboseMessage -Message ("Found assigned parameter '{0}'. Adding path '{1}' to list of paths that required cluster drive." -f $parameterName, $parameterValue)
                     $requiredDrive += $parameterValue
                 }
             }
@@ -1319,7 +1319,7 @@ function Set-TargetResource
         }
     }
 
-    Write-Verbose -Message "Starting setup using arguments: $log"
+    New-VerboseMessage -Message "Starting setup using arguments: $log"
 
     $arguments = $arguments.Trim()
     $processArguments = @{
@@ -1334,7 +1334,7 @@ function Set-TargetResource
 
     $process = StartWin32Process @processArguments
 
-    Write-Verbose -Message $process
+    New-VerboseMessage -Message $process
 
     WaitForWin32ProcessEnd -Path $pathToSetupExecutable -Arguments $arguments
 
@@ -1346,7 +1346,7 @@ function Set-TargetResource
         }
         else
         {
-            Write-Verbose -Message 'Suppressing reboot'
+            New-VerboseMessage -Message 'Suppressing reboot'
         }
     }
 
@@ -1696,7 +1696,7 @@ function Test-TargetResource
     $boundParameters = $PSBoundParameters
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    Write-Verbose -Message "Features found: '$($getTargetResourceResult.Features)'"
+    New-VerboseMessage -Message "Features found: '$($getTargetResourceResult.Features)'"
 
     $result = $true
 
@@ -1709,7 +1709,7 @@ function Test-TargetResource
 
             if(!($getTargetResourceResult.Features.Contains($feature)))
             {
-                Write-Verbose -Message "Unable to find feature '$feature' among the installed features: '$($getTargetResourceResult.Features)'"
+                New-VerboseMessage -Message "Unable to find feature '$feature' among the installed features: '$($getTargetResourceResult.Features)'"
                 $result = $false
             }
         }
@@ -1721,13 +1721,13 @@ function Test-TargetResource
 
     if ($PSCmdlet.ParameterSetName -eq 'ClusterInstall')
     {
-        Write-Verbose -Message "Clustered install, checking parameters."
+        New-VerboseMessage -Message "Clustered install, checking parameters."
 
         $boundParameters.Keys | Where-Object {$_ -imatch "^FailoverCluster"} | ForEach-Object {
             $variableName = $_
 
             if ($getTargetResourceResult.$variableName -ne $boundParameters[$variableName]) {
-                Write-Verbose -Message "$variableName '$($boundParameters[$variableName])' is not in the desired state for this cluster."
+                New-VerboseMessage -Message "$variableName '$($boundParameters[$variableName])' is not in the desired state for this cluster."
                 $result = $false
             }
         }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2941,7 +2941,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (Mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -3181,7 +3181,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (Mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
 
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
@@ -3359,7 +3359,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3539,7 +3539,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -2182,9 +2182,9 @@ try
                         $currentState = Get-TargetResource @testParams
 
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It-ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It-ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It-ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
 
                         $currentState.InstanceName | Should Be $testParams.InstanceName
                     }
@@ -2754,7 +2754,7 @@ try
                     $result | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It-ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
                     Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
                 }
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1040,11 +1040,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It 
+                        } -Exactly -Times 0 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It 
+                        } -Exactly -Times 1 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1167,11 +1167,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It 
+                        } -Exactly -Times 0 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It 
+                        } -Exactly -Times 1 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1841,11 +1841,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It 
+                        } -Exactly -Times 0 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It 
+                        } -Exactly -Times 1 -Scope It
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -2182,9 +2182,9 @@ try
                         $currentState = Get-TargetResource @testParams
 
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It-ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It-ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
+                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It-ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
 
                         $currentState.InstanceName | Should Be $testParams.InstanceName
                     }
@@ -2754,7 +2754,7 @@ try
                     $result | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
+                    Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It-ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
                     Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 3 -Scope It
                 }
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1036,7 +1036,7 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
@@ -1059,6 +1059,14 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
+
                         $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }
@@ -1182,6 +1190,15 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
+
                         $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }
@@ -1843,6 +1860,14 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
+
                         $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -887,7 +887,7 @@ try
                 These are written with both lower-case and upper-case to make sure we support that.
                 The feature list must be written in the order it is returned by the function Get-TargerResource.
             #>
-            Features = 'SQLEngine,Replication,Dqc,Dq,Bol,Conn,Bc,Sdk,FullText,Rs,As,Is,Ssms,Adv_Ssms'
+            Features = 'SQLEngine,Replication,Dqc,Dq,FullText,Rs,As,Is,Bol,Conn,Bc,Sdk,Ssms,Adv_Ssms'
         }
 
         $featuresForSqlServer2016 = ''
@@ -1316,11 +1316,11 @@ try
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,BOL,FULLTEXT,RS,AS,IS'
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,BOL'
                         }
                         else
                         {
-                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,BOL,FULLTEXT,RS,AS,IS,SSMS,ADV_SSMS'
+                            $result.Features | Should Be 'SQLENGINE,REPLICATION,DQC,DQ,FULLTEXT,RS,AS,IS,BOL,SSMS,ADV_SSMS'
                         }
                     }
                 }

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1036,11 +1036,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1059,7 +1059,7 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
+                        $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }
 
@@ -1159,11 +1159,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1182,7 +1182,7 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
+                        $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }
 
@@ -1507,7 +1507,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' {
+                    It 'Should return the correct values in the hash table' { ###FixThis
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
                         $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
@@ -1719,7 +1719,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' {
+                    It 'Should return the correct values in the hash table' { ###FixThis
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePathUNC
                         $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
@@ -1820,11 +1820,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 0 -Scope It
+                        } -Exactly -Times 1 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1843,7 +1843,7 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
-                        $result = Get-TargetResource @testParameters
+                        $result = Get-TargetResource @testParameters ###FixThis
                         $result.Features | Should Be ''
                     }
 
@@ -2055,7 +2055,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' {
+                    It 'Should return the correct values in the hash table' { ###FixThis
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
                         $result.InstanceName | Should Be $mockNamedInstance_InstanceName
@@ -2904,7 +2904,7 @@ try
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -3136,7 +3136,7 @@ try
                         } -MockWith $mockEmptyHashtable -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
 
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
@@ -3306,7 +3306,7 @@ try
                         } -MockWith $mockEmptyHashtable -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3478,7 +3478,7 @@ try
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' {
+                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1010,19 +1010,23 @@ try
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1059,15 +1063,7 @@ try
                     }
 
                     It 'Should not return any names of installed features' {
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -MockWith {} -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith {} -Verifiable
-
-                        $result = Get-TargetResource @testParameters ###FixThis
+                        $result = Get-TargetResource @testParameters
                         $result.Features | Should Be ''
                     }
 
@@ -1141,19 +1137,23 @@ try
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1167,7 +1167,7 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
@@ -1813,19 +1813,23 @@ try
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_ConfigurationState -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1837,7 +1841,7 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It ###FixThis
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
@@ -2927,6 +2931,14 @@ try
                         } -MockWith $mockEmptyHashtable -Verifiable
 
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
@@ -3159,6 +3171,14 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
@@ -3329,6 +3349,14 @@ try
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
                             $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
                         } -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
@@ -3501,6 +3529,14 @@ try
 
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                         Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
@@ -3676,7 +3712,16 @@ try
                         } -Verifiable
 
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
+                    }
 
+                    BeforeEach {
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+                        
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3775,7 +3820,7 @@ try
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
+                        } -MockWith {} -Verifiable
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -3783,6 +3828,12 @@ try
 
                         Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
 
+                    }
+
+                    BeforeEach {
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -4074,8 +4125,8 @@ try
 
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_BOLandDQCFeature -Verifiable
-
+                        } -MockWith {} -Verifiable
+                        
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
                         } -MockWith $mockGetItemProperty_Setup -Verifiable
@@ -4101,6 +4152,12 @@ try
                         Mock -CommandName Get-CimInstance -MockWith {} -ParameterFilter {
                             ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
                         } -Verifiable
+                    }
+
+                    BeforeEach {
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
                     }
 
                     It 'Should pass correct arguments to the setup process' {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -4231,6 +4231,14 @@ try
                             SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
+                        } -MockWith {} -Verifiable
+
+                        Mock -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
+                        } -MockWith {} -Verifiable
                     }
 
                     BeforeAll {

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -1040,11 +1040,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 1 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1167,11 +1167,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 1 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1199,7 +1199,7 @@ try
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith {} -Verifiable
 
-                        $result = Get-TargetResource @testParameters ###FixThis
+                        $result = Get-TargetResource @testParameters 
                         $result.Features | Should Be ''
                     }
 
@@ -1524,7 +1524,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' { ###FixThis
+                    It 'Should return the correct values in the hash table' { 
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
                         $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
@@ -1736,7 +1736,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' { ###FixThis
+                    It 'Should return the correct values in the hash table' { 
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePathUNC
                         $result.InstanceName | Should Be $mockDefaultInstance_InstanceName
@@ -1841,11 +1841,11 @@ try
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It ###FixThis
+                        } -Exactly -Times 0 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It ###FixThis
+                        } -Exactly -Times 1 -Scope It 
 
                         Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
@@ -1872,7 +1872,7 @@ try
                             $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
                         } -MockWith {} -Verifiable
 
-                        $result = Get-TargetResource @testParameters ###FixThis
+                        $result = Get-TargetResource @testParameters 
                         $result.Features | Should Be ''
                     }
 
@@ -2084,7 +2084,7 @@ try
                         }
                     }
 
-                    It 'Should return the correct values in the hash table' { ###FixThis
+                    It 'Should return the correct values in the hash table' { 
                         $result = Get-TargetResource @testParameters
                         $result.SourcePath | Should Be $mockSourcePath
                         $result.InstanceName | Should Be $mockNamedInstance_InstanceName
@@ -2941,7 +2941,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (Mocks maybe?)
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -3181,7 +3181,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (Mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (Mocks maybe?)
 
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
@@ -3359,7 +3359,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (mocks maybe?)
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'
@@ -3539,7 +3539,7 @@ try
                         } -MockWith {} -Verifiable
                     }
 
-                    It 'Should set the system in the desired state when feature is SQLENGINE' { ###FixThis (mocks maybe?)
+                    It 'Should set the system in the desired state when feature is SQLENGINE' {  (mocks maybe?)
                         $mockStartWin32ProcessExpectedArgument = @{
                             Quiet = 'True'
                             IAcceptSQLServerLicenseTerms = 'True'


### PR DESCRIPTION
**Pull Request (PR) description**
Get-TargetResource was only checking for Conn, BC and other features if the SQL service was found, There are use cases for installing these tools without installing SQL Engine. This moves them outside that scope and updates the tests to reflect this change. 

**This Pull Request (PR) fixes the following issues:**
Fixes #591 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/595)
<!-- Reviewable:end -->
