### PR TITLE
xSQLServerSetup: Now uses same identifier for InstallSharedDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
   - Fixed virtual directory creation for SQL Server 2016 (issue #569).
   - Added unit tests (issue #295).
-
 - Changes to xSQLServerDatabase
   - Changed the readme, SQLInstance should have been SQLInstanceName.
 - Changes to xSQLServerSetup
@@ -41,6 +40,8 @@
   - Updated all examples to match the removal of SetupCredential.
   - Updated (removed) severe known issues in README.md for resource xSQLServerSetup.
   - Now all major version uses the same identifier to evaluate InstallSharedDir and InstallSharedWOWDir (issue #420).
+  - Now setup arguments that contain no value will be ignored, for example when InstallSharedDir and
+    InstallSharedWOWDir path is already present on the target node, because of a previous installation (issue #639).
 
 ## 7.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   - Added a new parameter SetupProcessTimeout which defaults to 7200 seconds (2 hours). If the setup process has not finished before the timeout value in SetupProcessTimeout an error will be thrown (issue #566).
   - Updated all examples to match the removal of SetupCredential.
   - Updated (removed) severe known issues in README.md for resource xSQLServerSetup.
+  - Now all major version uses the same identifier to evaluate InstallSharedDir and InstallSharedWOWDir (issue #420).
 
 ## 7.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -369,25 +369,7 @@ function Get-TargetResource
 
         switch ($sqlVersion)
         {
-            '10'
-            {
-                $registryKeySharedDir = '0D1F366D0FE0E404F8C15EE4F1C15094'
-                $registryKeySharedWOWDir = 'C90BFAC020D87EA46811C836AD3C507F'
-            }
-
-            '11'
-            {
-                $registryKeySharedDir = 'FEE2E540D20152D4597229B6CFBC0A69'
-                $registryKeySharedWOWDir = 'A79497A344129F64CA7D69C56F5DD8B4'
-            }
-
-            '12'
-            {
-                $registryKeySharedDir = 'FEE2E540D20152D4597229B6CFBC0A69'
-                $registryKeySharedWOWDir = 'C90BFAC020D87EA46811C836AD3C507F'
-            }
-
-            { $_ -in ('13','14') }
+            { $_ -in ('10','11','12','13','14') }
             {
                 $registryKeySharedDir = 'FEE2E540D20152D4597229B6CFBC0A69'
                 $registryKeySharedWOWDir = 'A79497A344129F64CA7D69C56F5DD8B4'
@@ -878,46 +860,7 @@ function Set-TargetResource
     # If SQL shared components already installed, clear InstallShared*Dir variables
     switch ($sqlVersion)
     {
-        '10'
-        {
-            if((Get-Variable -Name 'InstallSharedDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedDir' -Value ''
-            }
-
-            if((Get-Variable -Name 'InstallSharedWOWDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedWOWDir' -Value ''
-            }
-        }
-
-        '11'
-        {
-            if((Get-Variable -Name 'InstallSharedDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedDir' -Value ''
-            }
-
-            if((Get-Variable -Name 'InstallSharedWOWDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedWOWDir' -Value ''
-            }
-        }
-
-        '12'
-        {
-            if((Get-Variable -Name 'InstallSharedDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedDir' -Value ''
-            }
-
-            if((Get-Variable -Name 'InstallSharedWOWDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -ErrorAction SilentlyContinue))
-            {
-                Set-Variable -Name 'InstallSharedWOWDir' -Value ''
-            }
-        }
-
-        { $_ -in ('13','14') }
+        { $_ -in ('10','11','12','13','14') }
         {
             if((Get-Variable -Name 'InstallSharedDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69' -ErrorAction SilentlyContinue))
             {
@@ -1267,7 +1210,11 @@ function Set-TargetResource
         }
         else
         {
-            $setupArguments += @{ $argument = (Get-Variable -Name $argument -ValueOnly) }
+            # If the argument contains a value, then add the argument to the setup argument list
+            if (Get-Variable -Name $argument -ValueOnly)
+            {
+                $setupArguments += @{ $argument = (Get-Variable -Name $argument -ValueOnly) }
+            }
         }
     }
 

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -966,31 +966,25 @@ try
 
                 # Mocking SharedDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                 } -MockWith $mockGetItem_SharedDirectory -Verifiable
 
                 # Mocking SharedWowDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
 
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
                     $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
                 } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
-
             }
 
             BeforeEach {
@@ -2264,24 +2258,19 @@ try
 
                 # Mocking SharedDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                 } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
                 } -MockWith $mockGetItem_SharedDirectory -Verifiable
 
                 # Mocking SharedWowDirectory
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
 
                 Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                     $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                 } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
             }
@@ -3213,14 +3202,11 @@ try
 
                         # Mocking SharedDirectory (when previously installed and should not be installed again).
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\0D1F366D0FE0E404F8C15EE4F1C15094' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\30AE1F084B1CF8B4797ECB3CCAA3B3B6'
                         } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
 
                         # Mocking SharedWowDirectory (when previously installed and should not be installed again).
                         Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\C90BFAC020D87EA46811C836AD3C507F' -or
                             $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
                         } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
 


### PR DESCRIPTION
**Pull Request (PR) description**
* Changes to xSQLServerSetup
  * Now all major version uses the same identifier to evaluate InstallSharedDir and InstallSharedWOWDir (issue #420).

**This Pull Request (PR) fixes the following issues:**
Fixes #420 
Fixes #639 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/599)
<!-- Reviewable:end -->
