### PR TITLE
xSQLServerAlwaysOnAvailabilityGroup: Fix incorrect utilization of 'FailoverMode'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
   - Added a test to test some error handling for cluster installations.
 - Changes to xSQLServerAlwaysOnService
   - Fixed typos in localization strings and in tests.
+- Changes to xSQLServerAlwaysOnAvailabilityGroup
+  - Fix: Utilize the value of 'FailoverMode' to set the 'FailoverMode' property of the AG instead of the 'AvailabilityMode' of the AG
 
 ## 7.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -1,4 +1,4 @@
-Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 
@@ -482,7 +482,7 @@ function Set-TargetResource
 
                 if ( $FailoverMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].FailoverMode )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].AvailabilityMode = $FailoverMode
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].FailoverMode = $FailoverMode
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
                 }
                 

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 


### PR DESCRIPTION
Instead of applying the value of the 'FailoverMode' DSC parameter to the
AvailabilityMode property of the SQL AG, which results in an error message that
e.g. 'Automatic' cannot be converted to the SMO AvailabilityMode enumeration,
the value of the 'FailoverMode' DSC parameter must instead be applied to the
FailoverMode property of the SQL AG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/650)
<!-- Reviewable:end -->
