### PR TITLE
xSQLServer: Update VS Code formatting settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
-// Place your settings in this file to overwrite default and user settings.
 {
     "powershell.codeFormatting.openBraceOnSameLine": false,
     "powershell.codeFormatting.newLineAfterOpenBrace": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@
     SHIFT+ALT+F, or press F1 and choose 'Format document' in the list. The
     PowerShell code will then be formatted according to the Style Guideline
     (although maybe not complete, but would help a long way).
-      - Removed alignPropertyValuePairs setting since it does not align with the
-        style guideline.
+      - Removed powershell.codeFormatting.alignPropertyValuePairs setting since
+        it does not align with the style guideline.
+      - Added powershell.codeFormatting.preset with a value of 'Custom' so that
+        workspace formatting settings are honored (issue #665).
   - Fixed lint error MD013 and MD036 in README.md.
   - Updated .markdownlint.json to enable rule MD013 and MD036 to enforce those
     lint markdown rules in the common tests.


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Added powershell.codeFormatting.preset with a value of 'Custom' so that workspace formatting settings are honored (issue #665).

**This Pull Request (PR) fixes the following issues:**
Fixes #665 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/666)
<!-- Reviewable:end -->
