### PR TITLE
xSQLServerAlwaysOnService: Added missing read property, fixed types, and added examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   - Added read-only property IsHadrEnabled to schema.mof and the README.md
     (issue #687).
   - Minor cleanup of code.
+  - Added examples (issue #633)
+    - 1-EnableAlwaysOn.ps1
+    - 2-DisableAlwaysOn.ps1
 
 ## 8.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
   - Added back .markdownlint.json so that lint rule MD013 is enforced.
   - Change the module to use the image 'Visual Studio 2017' as the build worker
     image for AppVeyor (issue #685).
+- Changes to xSQLServerAlwaysOnService
+  - Added resource description in README.md.
+  - Updated parameters descriptions in comment-based help, schema.mof and README.md.
+  - Changed the datatype of the parameter to Uint32 so the same datatype is used
+    in both the Get-/Test-/Set-TargetResource functions as in the schema.mof
+    (issue #688).
+  - Added read-only property IsHadrEnabled to schema.mof and the README.md
+    (issue #687).
+  - Minor cleanup of code.
 
 ## 8.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerAlwaysOnService/MSFT_xSQLServerAlwaysOnService.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnService/MSFT_xSQLServerAlwaysOnService.psm1
@@ -4,22 +4,26 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
 <#
     .SYNOPSIS
-    Gets the current value of the SQL Server HADR property.
+    Gets the current value of the SQL Server Always On high availability and
+    disaster recovery (HADR) property.
 
     .PARAMETER Ensure
+    An enumerated value that describes if the SQL Server should have Always On high
+    availability and disaster recovery (HADR) property enabled ('Present') or
+    disabled ('Absent').
+
     *** Not used in this function ***
-    HADR is Present (enabled) or Absent (disabled).
 
     .PARAMETER SQLServer
-    Hostname of the SQL Server to be configured.
+    The hostname of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued.
+    The name of the SQL instance to be configured.
 #>
 function Get-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([Hashtable])]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -68,7 +72,6 @@ function Get-TargetResource
         }
     }
 
-
     New-VerboseMessage -Message ( 'SQL Always On is {0} on "{1}\{2}".' -f $statusString, $SQLServer, $SQLInstanceName )
 
     return @{
@@ -78,16 +81,18 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Sets the current value of the SQL Server HADR property.
+    Sets the current value of the SQL Server Always On high availability and disaster recovery (HADR) property.
 
     .PARAMETER Ensure
-    HADR is Present (enabled) or Absent (disabled).
+    An enumerated value that describes if the SQL Server should have Always On high
+    availability and disaster recovery (HADR) property enabled ('Present') or
+    disabled ('Absent').
 
     .PARAMETER SQLServer
-    Hostname of the SQL Server to be configured.
+    The hostname of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued.
+    The name of the SQL instance to be configured.
 
     .PARAMETER RestartTimeout
     The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.
@@ -111,11 +116,11 @@ function Set-TargetResource
         $SQLInstanceName,
 
         [Parameter()]
-        [Int32]
+        [System.Uint32]
         $RestartTimeout = 120
     )
 
-    # Build the instance name to allow the Enable/Disable-AlwaysOn to connect to the instance
+    # Build the instance name to allow the Enable/Disable-Always On to connect to the instance
     if($SQLInstanceName -eq "MSSQLSERVER")
     {
         $serverInstance = $SQLServer
@@ -157,25 +162,29 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Determines whether the current value of the SQL Server HADR property is properly set.
+    Determines whether the current value of the SQL Server Always On high
+    availability and disaster recovery (HADR) property is properly set.
 
     .PARAMETER Ensure
-    HADR is Present (enabled) or Absent (disabled).
+    An enumerated value that describes if the SQL Server should have Always On high
+    availability and disaster recovery (HADR) property enabled ('Present') or
+    disabled ('Absent').
 
     .PARAMETER SQLServer
-    Hostname of the SQL Server to be configured.
+    The hostname of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configued.
+    The name of the SQL instance to be configured.
 
     .PARAMETER RestartTimeout
-    *** Not used in this function ***
     The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.
+
+    *** Not used in this function ***
 #>
 function Test-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([Boolean])]
+    [OutputType([System.Boolean])]
     param
     (
         [parameter(Mandatory = $true)]
@@ -192,18 +201,18 @@ function Test-TargetResource
         $SQLInstanceName,
 
         [Parameter()]
-        [Int32]
+        [System.Uint32]
         $RestartTimeout = 120
     )
 
     # Determine the current state of Always On
-    $params = @{
+    $getTargetResourceParameters = @{
         Ensure = $Ensure
         SQLServer = $SQLServer
         SQLInstanceName = $SQLInstanceName
     }
 
-    $state = Get-TargetResource @params
+    $state = Get-TargetResource @getTargetResourceParameters
 
     # Determine what the desired state of Always On is
     $hadrDesiredState = @{ 'Present' = $true; 'Absent' = $false }[$Ensure]

--- a/DSCResources/MSFT_xSQLServerAlwaysOnService/MSFT_xSQLServerAlwaysOnService.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnService/MSFT_xSQLServerAlwaysOnService.schema.mof
@@ -1,8 +1,9 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerAlwaysOnService")]
 class MSFT_xSQLServerAlwaysOnService : OMI_BaseResource
 {
-    [Required, Description("An enumerated value that describes if SQL server should have AlwaysOn property present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Key, Description("The hostname of the SQL Server to be configured")] String SQLServer;
-    [Key, Description("Name of the SQL instance to be configured.")] String SQLInstanceName;
-    [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] Sint32 RestartTimeout;
+    [Required, Description("An enumerated value that describes if the SQL Server should have Always On high availability and disaster recovery (HADR) property enabled ('Present') or disabled ('Absent')."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Key, Description("The hostname of the SQL Server to be configured.")] String SQLServer;
+    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The length of time, in seconds, to wait for the service to restart. Default is 120 seconds.")] Uint32 RestartTimeout;
+    [Read, Description("Returns the status of AlwaysOn high availability and disaster recovery (HADR).")] Boolean IsHadrEnabled;
 };

--- a/Examples/Resources/xSQLServerAlwaysOnService/1-EnableAlwaysOn.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnService/1-EnableAlwaysOn.ps1
@@ -1,0 +1,30 @@
+<#
+.EXAMPLE
+    This example shows how to enable SQL Server Always On high availability and
+    disaster recovery (HADR).
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost
+    {
+        xSQLServerAlwaysOnService 'EnableAlwaysOn'
+        {
+            Ensure = 'Present'
+            SQLServer = 'SP23-VM-SQL1'
+            SQLInstanceName = 'MSSQLSERVER'
+            RestartTimeout = 120
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+    }
+}

--- a/Examples/Resources/xSQLServerAlwaysOnService/2-DisableAlwaysOn.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnService/2-DisableAlwaysOn.ps1
@@ -1,0 +1,30 @@
+<#
+.EXAMPLE
+    This example shows how to disable SQL Server Always On high availability and
+    disaster recovery (HADR).
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $SysAdminAccount
+    )
+
+    Import-DscResource -ModuleName xSqlServer
+
+    node localhost
+    {
+        xSQLServerAlwaysOnService 'DisableAlwaysOn'
+        {
+            Ensure = 'Absent'
+            SQLServer = 'SP23-VM-SQL1'
+            SQLInstanceName = 'MSSQLSERVER'
+            RestartTimeout = 120
+
+            PsDscRunAsCredential = $SysAdminAccount
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ Always On Availability Group Replica.
 
 ### xSQLServerAlwaysOnService
 
-Enables or disabled SQL Server Always On high availability and disaster recovery (Always On HADR).
+Enables or disabled SQL Server Always On high availability and disaster recovery
+(Always On HADR).
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Always On Availability Group Replica.
 
 ### xSQLServerAlwaysOnService
 
-No description.
+Enables or disabled SQL Server Always On high availability and disaster recovery (Always On HADR).
 
 #### Requirements
 
@@ -361,11 +361,17 @@ No description.
 #### Parameters
 
 * **`[String]` SQLServer** _(Key)_: The hostname of the SQL Server to be configured.
-* **`[String]` SQLInstance** _(Key)_: Name of the SQL instance to be configured.
-* **`[String]` Ensure** _(Required)_: An enumerated value that describes if SQL server
-  should have AlwaysOn property present or absent. { Present | Absent }.
+* **`[String]` SQLInstance** _(Key)_: The name of the SQL instance to be configured.
+* **`[String]` Ensure** _(Required)_: An enumerated value that describes if the SQL
+  Server should have Always On high availability and disaster recovery (HADR)
+  property enabled ('Present') or disabled ('Absent'). { Present | Absent }.
 * **`[Sint32]` RestartTimeout** _(Write)_: The length of time, in seconds, to wait
   for the service to restart. Default is 120 seconds.
+
+#### Read-Only Properties from Get-TargetResource
+
+* **`[Boolean]` IsHadrEnabled** _(Read)_: Returns the status of AlwaysOn high
+  availability and disaster recovery (HADR).
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,8 @@ Enables or disabled SQL Server Always On high availability and disaster recovery
 
 #### Examples
 
-None.
+* [Enable SQL Server Always On](/Examples/Resources/xSQLServerAlwaysOnService/1-EnableAlwaysOn.ps1)
+* [Disable SQL Server Always On](/Examples/Resources/xSQLServerAlwaysOnService/1-DisableAlwaysOn.ps1)
 
 ### xSQLServerAvailabilityGroupListener
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerAlwaysOnService
  - Added resource description in README.md.
  - Updated parameters descriptions in comment-based help, schema.mof and README.md.
  - Changed the datatype of the parameter to Uint32 so the same datatype is used
    in both the Get-/Test-/Set-TargetResource functions as in the schema.mof
    (issue #688).
  - Added read-only property IsHadrEnabled to schema.mof and the README.md
    (issue #687).
  - Minor cleanup of code.
  - Added examples (issue #633)
    - 1-EnableAlwaysOn.ps1
    - 2-DisableAlwaysOn.ps1

**This Pull Request (PR) fixes the following issues:**
Fixes #633 
Fixes #687 
Fixes #688 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/689)
<!-- Reviewable:end -->
