### PR TITLE
xSQLServer: Minor style change in CommonResourceHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Added back .markdownlint.json so that lint rule MD013 is enforced.
   - Change the module to use the image 'Visual Studio 2017' as the build worker
     image for AppVeyor (issue #685).
+  - Minor style change in CommonResourceHelper. Added missing [Parameter()] on
+    three parameters.
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     image for AppVeyor (issue #685).
   - Minor style change in CommonResourceHelper. Added missing [Parameter()] on
     three parameters.
+  - Minor style changes to the unit tests for CommonResourceHelper.
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -57,6 +57,7 @@ function New-InvalidOperationException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord
@@ -108,6 +109,7 @@ function New-ObjectNotFoundException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord
@@ -159,6 +161,7 @@ function New-InvalidResultException
         [System.String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -120,7 +120,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-InvalidResultException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -144,7 +144,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.Exception: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-ObjectNotFoundException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.Exception: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -168,7 +168,7 @@
                     $mockException = New-Object System.Exception $mockExceptionErrorMessage
                     $mockErrorRecord = New-Object System.Management.Automation.ErrorRecord $mockException, $null, 'InvalidResult', $null
 
-                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw 'System.InvalidOperationException: Mocked error ---> System.Exception: Mocked exception error message'
+                    { New-InvalidOperationException -Message $mockErrorMessage -ErrorRecord $mockErrorRecord } | Should Throw ('System.InvalidOperationException: {0} ---> System.Exception: {1}' -f $mockErrorMessage, $mockExceptionErrorMessage)
                 }
             }
 
@@ -181,7 +181,7 @@
                     $mockErrorMessage = 'Mocked error'
                     $mockArgumentName = 'MockArgument'
 
-                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw 'Parameter name: MockArgument'
+                    { New-InvalidArgumentException -Message $mockErrorMessage -ArgumentName $mockArgumentName } | Should Throw ('Parameter name: {0}' -f $mockArgumentName)
                 }
             }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Minor style change in CommonResourceHelper. Added missing [Parameter()] on three parameters.

**This Pull Request (PR) fixes the following issues:**
n/a

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/693)
<!-- Reviewable:end -->
