### PR TITLE
xSQLServer: Opt-in for module files common tests

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,3 +1,4 @@
 [
-     "Common Tests - Validate Markdown Files"
+     "Common Tests - Validate Markdown Files",
+     "Common Tests - Validate Module Files"
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   - Minor style changes to the unit tests for CommonResourceHelper.
   - Changes to xSQLServerHelper
     - Added Swedish localization ([issue #695](https://github.com/PowerShell/xSQLServer/issues/695)).
+  - Opt-in for module files common tests ([issue #702](https://github.com/PowerShell/xFailOverCluster/issues/702)).
+    - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.psm1,
+      MSFT\_xSQLServerAvailabilityGroupListener.psm1, MSFT\_xSQLServerConfiguration.psm1,
+      MSFT\_xSQLServerEndpointPermission.psm1, MSFT\_xSQLServerEndpointState.psm1,
+      MSFT\_xSQLServerNetwork.psm1, MSFT\_xSQLServerPermission.psm1,
+      MSFT\_xSQLServerReplication.psm1, MSFT\_xSQLServerScript.psm1,
+      SQLPSStub.psm1, SQLServerStub.psm1.
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,4 +1,4 @@
-﻿<#
+<#
     .SYNOPSIS
         Creates and throws an invalid argument exception.
 

--- a/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
+++ b/DSCResources/MSFT_xSQLServerAvailabilityGroupListener/MSFT_xSQLServerAvailabilityGroupListener.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 <#

--- a/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
+++ b/DSCResources/MSFT_xSQLServerConfiguration/MSFT_xSQLServerConfiguration.psm1
@@ -1,4 +1,4 @@
-﻿# Load Common Code
+# Load Common Code
 Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
@@ -8,13 +8,13 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
     .PARAMETER SQLServer
     Hostname of the SQL Server to be configured
-    
+
     .PARAMETER SQLInstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be checked
-    
+
     .PARAMETER OptionValue
     The desired value of the SQL configuration option
 
@@ -58,7 +58,7 @@ function Get-TargetResource
 
     ## get the configuration option
     $option = $sql.Configuration.Properties | Where-Object { $_.DisplayName -eq $OptionName }
-    
+
     if(!$option)
     {
         throw New-TerminatingError -ErrorType "ConfigurationOptionNotFound" -FormatArgs $OptionName -ErrorCategory InvalidArgument
@@ -80,13 +80,13 @@ function Get-TargetResource
 
     .PARAMETER SQLServer
     Hostname of the SQL Server to be configured
-    
+
     .PARAMETER SQLInstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be set
-    
+
     .PARAMETER OptionValue
     The desired value of the SQL configuration option
 
@@ -135,9 +135,9 @@ function Set-TargetResource
 
     $option.ConfigValue = $OptionValue
     $sql.Configuration.Alter()
-    
+
     if ($option.IsDynamic -eq $true)
-    {  
+    {
         New-VerboseMessage -Message 'Configuration option has been updated.'
     }
     elseif (($option.IsDynamic -eq $false) -and ($RestartService -eq $true))
@@ -157,13 +157,13 @@ function Set-TargetResource
 
     .PARAMETER SQLServer
     Hostname of the SQL Server to be configured
-    
+
     .PARAMETER SQLInstanceName
     Name of the SQL instance to be configued. Default is 'MSSQLSERVER'
 
     .PARAMETER OptionName
     The name of the SQL configuration option to be tested
-    
+
     .PARAMETER OptionValue
     The desired value of the SQL configuration option
 

--- a/DSCResources/MSFT_xSQLServerEndpointPermission/MSFT_xSQLServerEndpointPermission.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpointPermission/MSFT_xSQLServerEndpointPermission.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 <#

--- a/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.psm1
+++ b/DSCResources/MSFT_xSQLServerEndpointState/MSFT_xSQLServerEndpointState.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 <#

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 <#

--- a/DSCResources/MSFT_xSQLServerPermission/MSFT_xSQLServerPermission.psm1
+++ b/DSCResources/MSFT_xSQLServerPermission/MSFT_xSQLServerPermission.psm1
@@ -1,4 +1,4 @@
-﻿Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
+Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) `
                                -ChildPath 'xSQLServerHelper.psm1') `
                                -Force
 <#

--- a/DSCResources/MSFT_xSQLServerReplication/MSFT_xSQLServerReplication.psm1
+++ b/DSCResources/MSFT_xSQLServerReplication/MSFT_xSQLServerReplication.psm1
@@ -1,4 +1,4 @@
-﻿$dom = [AppDomain]::CreateDomain('xSQLServerReplication')
+$dom = [AppDomain]::CreateDomain('xSQLServerReplication')
 
 function Get-TargetResource
 {
@@ -64,7 +64,7 @@ function Get-TargetResource
         $RemoteDistributor = $localReplicationServer.DistributionServer
         $WorkingDirectory = $localReplicationServer.WorkingDirectory
     }
-               
+
     $returnValue = @{
         InstanceName = $InstanceName
         Ensure = $Ensure
@@ -73,7 +73,7 @@ function Get-TargetResource
         RemoteDistributor = $RemoteDistributor
         WorkingDirectory = $WorkingDirectory
     }
-    
+
     return $returnValue
 }
 
@@ -150,7 +150,7 @@ function Set-TargetResource
                 -WorkingDirectory $WorkingDirectory `
                 -UseTrustedConnection $UseTrustedConnection
         }
-            
+
         if($DistributorMode -eq 'Remote' -and $localReplicationServer.IsPublisher -eq $false)
         {
             Write-Verbose "Remote distribution will be configured ..."
@@ -235,7 +235,7 @@ function Test-TargetResource
     {
         $result = $true
     }
-          
+
     return $result
 }
 
@@ -322,7 +322,7 @@ function New-DistributionPublisher
         [System.Object]
         $ServerConnection
     )
-    
+
     $rmo = Get-RmoAssembly -SqlMajorVersion $SqlMajorVersion
     $distributorPublisher = New-object $rmo.GetType('Microsoft.SqlServer.Replication.DistributionPublisher') $PublisherName, $ServerConnection
 
@@ -422,7 +422,7 @@ function Register-DistributorPublisher
         -SqlMajorVersion $SqlMajorVersion `
         -PublisherName $PublisherName `
         -ServerConnection $ServerConnection
-    
+
     $distributorPublisher.DistributionDatabase = $DistributionDBName
     $distributorPublisher.WorkingDirectory = $WorkingDirectory
     $distributorPublisher.PublisherSecurity.WindowsAuthentication = $UseTrustedConnection

--- a/DSCResources/MSFT_xSQLServerScript/MSFT_xSQLServerScript.psm1
+++ b/DSCResources/MSFT_xSQLServerScript/MSFT_xSQLServerScript.psm1
@@ -1,4 +1,4 @@
-﻿$script:currentPath = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+$script:currentPath = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 Import-Module -Name (Join-Path -Path (Split-Path -Path (Split-Path -Path $script:currentPath -Parent) -Parent) -ChildPath 'xSQLServerHelper.psm1')
 
 <#
@@ -67,7 +67,7 @@ function Get-TargetResource
         [Parameter(Mandatory = $false)]
         [System.UInt32]
         $QueryTimeout,
-  
+
         [System.String[]]
         $Variable
     )
@@ -153,7 +153,7 @@ function Set-TargetResource
         [Parameter(Mandatory = $false)]
         [System.UInt32]
         $QueryTimeout,
-  
+
         [System.String[]]
         $Variable
     )
@@ -293,8 +293,8 @@ function Invoke-SqlScript
 
         [Parameter(Mandatory = $false)]
         [System.UInt32]
-        $QueryTimeout, 
-  
+        $QueryTimeout,
+
         [System.String[]]
         $Variable
     )

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe 'CommonResourceHelper Unit Tests' {
+Describe 'CommonResourceHelper Unit Tests' {
     BeforeAll {
         # Import the CommonResourceHelper module to test
         $dscResourcesFolderFilePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) `

--- a/Tests/Unit/Stubs/SQLPSStub.psm1
+++ b/Tests/Unit/Stubs/SQLPSStub.psm1
@@ -1,6 +1,6 @@
-﻿# Generated from SQL Server 2014 (build 12.0.4213.0)
+# Generated from SQL Server 2014 (build 12.0.4213.0)
 
-# Suppressing this rule because these functions are from an external module 
+# Suppressing this rule because these functions are from an external module
 # and are only being used as stubs
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
 param()

--- a/Tests/Unit/Stubs/SQLServerStub.psm1
+++ b/Tests/Unit/Stubs/SQLServerStub.psm1
@@ -1,6 +1,6 @@
-﻿# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
+# Generated from SQLServer module, module version 20.0 (SQL Server Management Studio 13.0.15600.2 - August 2016)
 
-# Suppressing this rule because these functions are from an external module 
+# Suppressing this rule because these functions are from an external module
 # and are only being used as stubs
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
 param()


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Opt-in for module files common tests (issue #702).
    - Removed Byte Order Mark (BOM) from the files; CommonResourceHelper.psm1,
      MSFT_xSQLServerAvailabilityGroupListener.psm1, MSFT_xSQLServerConfiguration.psm1, 
      MSFT_xSQLServerEndpointPermission.psm1, MSFT_xSQLServerEndpointState.psm1, 
      MSFT_xSQLServerNetwork.psm1, MSFT_xSQLServerPermission.psm1, 
      MSFT_xSQLServerReplication.psm1, MSFT_xSQLServerScript.psm1, SQLPSStub.psm1, 
      SQLServerStub.psm1.

**This Pull Request (PR) fixes the following issues:**
Fixers #702 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/704)
<!-- Reviewable:end -->
