### PR TITLE
xSQLServerSetup: Fixed bug with ASSysAdminAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
     - 2-DisableAlwaysOn.ps1
 - Changes to xSQLServerSetup
   - Added Swedish localization ([issue #695](https://github.com/PowerShell/xSQLServer/issues/695)).
+  - Now Get-TargetResource correctly returns an array for property ASSysAdminAccounts,
+    and no longer throws an error when there is just one Analysis Services
+    administrator (issue #691).
 
 ## 8.0.0.0
 

--- a/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
+++ b/DSCResources/MSFT_xSQLServerSetup/MSFT_xSQLServerSetup.psm1
@@ -255,7 +255,7 @@ function Get-TargetResource
         Write-Verbose -Message $script:localizedData.FullTextFeatureFound
 
         $features += 'FULLTEXT,'
-        $fulltextServiceAccountUsername = (Get-CimInstance -ClassName Win32_Service -Filter "Name = '$fullTextServiceName'").StartName
+        $fullTextServiceAccountUsername = (Get-CimInstance -ClassName Win32_Service -Filter "Name = '$fullTextServiceName'").StartName
     }
     else
     {
@@ -293,7 +293,7 @@ function Get-TargetResource
         $analysisLogDirectory = $analysisServer.ServerProperties['LogDir'].Value
         $analysisBackupDirectory = $analysisServer.ServerProperties['BackupDir'].Value
 
-        $analysisSystemAdminAccounts = $analysisServer.Roles['Administrators'].Members.Name
+        $analysisSystemAdminAccounts = [System.String[]] $analysisServer.Roles['Administrators'].Members.Name
 
         $analysisConfigDirectory = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$analysisServiceName" -Name 'ImagePath').ImagePath.Replace(' -s ',',').Split(',')[1].Trim('"')
     }
@@ -477,7 +477,7 @@ function Get-TargetResource
         SQLTempDBDir = $null
         SQLTempDBLogDir = $null
         SQLBackupDir = $sqlBackupDirectory
-        FTSvcAccountUsername = $fulltextServiceAccountUsername
+        FTSvcAccountUsername = $fullTextServiceAccountUsername
         RSSvcAccountUsername = $reportingServiceAccountUsername
         ASSvcAccountUsername = $analysisServiceAccountUsername
         ASCollation = $analysisCollation


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerSetup
  - Now Get-TargetResource correctly returns an array for property ASSysAdminAccounts,
    and no longer throws an error when there is just one Analysis Services
    administrator (issue #691).
   - Fixed typo in variable $fullTextServiceAccountUsername.

**This Pull Request (PR) fixes the following issues:**
Fixes #691 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/715)
<!-- Reviewable:end -->
