### PR TITLE
xSQLServer: Fixed typos and the use of wrong parameters in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
       1-WaitForASingleClusterGroup.ps1, 2-WaitForMultipleClusterGroups.ps1.
   - Updated year to 2017 in license file ([issue #711](https://github.com/PowerShell/xFailOverCluster/issues/711)).
   - Code style clean-up throughout the module to align against the Style Guideline.
+  - Fixed typos and the use of wrong parameters in unit tests which was found
+    after release of new version of Pester ([issue #773](https://github.com/PowerShell/xFailOverCluster/issues/773)).
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.

--- a/Tests/Unit/MSFT_xSQLServerAlias.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlias.Tests.ps1
@@ -1,5 +1,5 @@
-$script:DSCModuleName      = 'xSQLServer' 
-$script:DSCResourceName    = 'MSFT_xSQLServerAlias' 
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'MSFT_xSQLServerAlias'
 
 #region HEADER
 
@@ -15,7 +15,7 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 
 $TestEnvironment = Initialize-TestEnvironment -DSCModuleName $script:DSCModuleName `
                                               -DSCResourceName $script:DSCResourceName `
-                                              -TestType Unit 
+                                              -TestType Unit
 
 #endregion HEADER
 
@@ -98,7 +98,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -122,7 +122,7 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It "Should return $tcpPort as the port number used" {
                 $result.TcpPort | Should Be $tcpPort
             }
@@ -137,7 +137,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -163,7 +163,7 @@ try
             It 'Should not return any protocol' {
                 $result.Protocol | Should Be ''
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -178,7 +178,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -204,7 +204,7 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It "Should return $differentTcpPort as the port number used" {
                 $result.TcpPort | Should Be $differentTcpPort
             }
@@ -219,7 +219,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -248,7 +248,7 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It "Should return $tcpPort as the port number used" {
                 $result.TcpPort | Should Be $tcpPort
             }
@@ -263,7 +263,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -274,7 +274,7 @@ try
                 Name = $name
                 ServerName = $serverNameTcp
             }
-            
+
             # Testing protocol TCP "With Dynamically determine port"
             Mock -CommandName Get-ItemProperty -ParameterFilter { $Path -eq $registryPath -and $Name -eq $name } -MockWith {
                 return @{
@@ -290,7 +290,7 @@ try
 
             # Mocking 64-bit OS
             Mock -CommandName Get-CimInstance -MockWith {
-                return New-Object Object | 
+                return New-Object Object |
                     Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
             } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -308,11 +308,11 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It 'Should return the UseDynamicTcpPort parameter as false' {
                 $result.UseDynamicTcpPort | Should Be $false
             }
-            
+
             It "Should not return any pipe name" {
                 $result.PipeName | Should Be ''
             }
@@ -327,7 +327,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -335,7 +335,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -409,11 +409,11 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It 'Should return the UseDynamicTcpPort parameter as false' {
                 $result.UseDynamicTcpPort | Should Be $false
             }
-            
+
             It "Should not return any pipe name" {
                 $result.PipeName | Should Be ''
             }
@@ -429,7 +429,7 @@ try
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
-                        
+
             It 'Should not call the Get-ItemProperty for the Wow6432Node-path' {
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope Context
@@ -456,7 +456,7 @@ try
             It 'Should not return any protocol' {
                 $result.Protocol | Should Be ''
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -518,7 +518,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -542,7 +542,7 @@ try
             It 'Should return NP as the protocol used' {
                 $result.Protocol | Should Be 'NP'
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -557,7 +557,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -583,7 +583,7 @@ try
             It 'Should return NP as the protocol used' {
                 $result.Protocol | Should Be 'NP'
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -598,7 +598,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -624,7 +624,7 @@ try
             It 'Should not return any protocol' {
                 $result.Protocol | Should Be ''
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -639,7 +639,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -647,7 +647,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -671,7 +671,7 @@ try
             It 'Should return NP as the protocol used' {
                 $result.Protocol | Should Be 'NP'
             }
-            
+
             It 'Should not return a port number' {
                 $result.TcpPort | Should Be 0
             }
@@ -696,7 +696,7 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -705,7 +705,7 @@ try
                 Name = $name
                 ServerName = $serverNameTcp
             }
-            
+
             # Testing protocol TCP "With Dynamically determine port"
             Mock -CommandName Get-ItemProperty -ParameterFilter { $Path -eq $registryPath -and $Name -eq $name } -MockWith {
                 return @{
@@ -733,11 +733,11 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It 'Should return the UseDynamicTcpPort parameter as true' {
                 $result.UseDynamicTcpPort | Should Be $true
             }
-            
+
             It "Should not return any pipe name" {
                 $result.PipeName | Should Be ''
             }
@@ -752,15 +752,15 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
         }
-                
+
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -797,11 +797,11 @@ try
             It 'Should return TCP as the protocol used' {
                 $result.Protocol | Should Be 'TCP'
             }
-            
+
             It 'Should return the UseDynamicTcpPort parameter as true' {
                 $result.UseDynamicTcpPort | Should Be $true
             }
-            
+
             It "Should not return any pipe name" {
                 $result.PipeName | Should Be ''
             }
@@ -817,7 +817,7 @@ try
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
-                        
+
             It 'Should not call the Get-ItemProperty for the Wow6432Node-path' {
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 0 -ModuleName $script:DSCResourceName -Scope Context
@@ -839,10 +839,10 @@ try
 
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
-        
+
         Context 'When the system is not in the desired state for 64-bit OS using TCP' {
             It 'Should call mocked functions Test-Path, New-Item and Set-ItemProperty twice each when desired state should be present for protocol TCP' {
                 $testParameters = @{
@@ -941,7 +941,7 @@ try
 
         # Mocking 32-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '32-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -1059,11 +1059,11 @@ try
 
         Mock -CommandName Get-ItemProperty -ParameterFilter { $Path -eq $registryPath -and $Name -eq $unknownName } -MockWith {
             return $null
-        } -ModuleName $script:DSCResourceName -Verifiable      
-        
+        } -ModuleName $script:DSCResourceName -Verifiable
+
         # Mocking 64-bit OS
         Mock -CommandName Get-CimInstance -MockWith {
-            return New-Object Object | 
+            return New-Object Object |
                 Add-Member -MemberType NoteProperty -Name OSArchitecture -Value '64-bit' -PassThru -Force
         } -ParameterFilter { $ClassName -eq 'win32_OperatingSystem' } -ModuleName $script:DSCResourceName -Verifiable
 
@@ -1072,7 +1072,7 @@ try
                 Name = $name
                 ServerName = $serverNameTcp
             }
-    
+
             It "Should return true from the test method" {
                 Test-TargetResource @testParameters | Should Be $true
             }
@@ -1083,18 +1083,18 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
         }
-        
+
         Context 'When the system is in the desired state (when using UseDynamicTcpPort)' {
             $testParameters = @{
                 Name = $name
                 ServerName = $serverNameTcp
             }
-    
+
             It "Should return true from the test method" {
                 Test-TargetResource @testParameters | Should Be $true
             }
@@ -1105,7 +1105,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -1116,7 +1116,7 @@ try
                 Name = $unknownName
                 ServerName = $serverNameTcp
             }
-    
+
             It "Should return false from the test method" {
                 Test-TargetResource @testParameters | Should Be $false
             }
@@ -1127,18 +1127,18 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
         }
-                
+
         Context 'When the system is not in the desired state (when using UseDynamicTcpPort)' {
             $testParameters = @{
                 Name = $unknownName
                 ServerName = $serverNameTcp
             }
-    
+
             It "Should return false from the test method" {
                 Test-TargetResource @testParameters | Should Be $false
             }
@@ -1149,7 +1149,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -1176,7 +1176,7 @@ try
                 Name = $name
                 ServerName = $serverNameNamedPipes
             }
-    
+
             It "Should return true from the test method" {
                 $testParameters.Add('Protocol','NP')
                 Test-TargetResource @testParameters | Should Be $true
@@ -1188,18 +1188,18 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
         }
-        
+
         Context 'When the system is not in the desired state (when using Named Pipes)' {
             $testParameters = @{
                 Name = $unknownName
                 ServerName = $unknownServerName
             }
-    
+
             It "Should return false from the test method" {
                 Test-TargetResource @testParameters | Should Be $false
             }
@@ -1210,7 +1210,7 @@ try
 
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPath } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
-                
+
                 Assert-MockCalled Get-ItemProperty -ParameterFilter { $Path -eq $registryPathWow6432Node } `
                     -Exactly -Times 1 -ModuleName $script:DSCResourceName -Scope Context
             }
@@ -1222,7 +1222,7 @@ finally
 {
     #region FOOTER
 
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
 
     #endregion
 }

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -13,7 +13,7 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 # Loading stub cmdlets
 Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
@@ -62,7 +62,7 @@ try
         #region Login mocks
 
             $mockLogins = @{} # Will be dynamically set during tests
-            
+
             $mockNtServiceClusSvcName = 'NT SERVICE\ClusSvc'
             $mockNtAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
 
@@ -321,7 +321,7 @@ try
                 {
                     New-VerboseMessage -Message "$($property): $($AvailabilityGroup.$property) ($($defaultPresentParameters.$property))"
                 }
-                
+
                 throw "Update-AvailabilityGroup should be setting the property '$($mockAvailabilityGroupProperty)' to '$($mockAvailabilityGroupPropertyValue)'"
             }
         }
@@ -348,29 +348,29 @@ try
                 {
                     New-VerboseMessage -Message "$($property): $($AvailabilityGroupReplica.$property) ($($defaultPresentParameters.$property))"
                 }
-                
+
                 throw "Update-AvailabilityGroupReplica should be setting the property '$($mockAvailabilityGroupReplicaProperty)' to '$($mockAvailabilityGroupReplicaPropertyValue)'"
             }
         }
-        
+
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Get-TargetResource" {
-            
+
             BeforeEach {
                 $mockLogins = $mockAllLoginsPresent
             }
-            
+
             Context 'When the Availability Group is Absent'{
 
                 It 'Should not return an Availability Group when Ensure is set to Present and the version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     $getParams = @{
                         Name = $defaultAbsentParameters.Name
                         SQLServer = $defaultAbsentParameters.SQLServer
                         SQLInstanceName = $defaultAbsentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -381,14 +381,14 @@ try
 
                 It 'Should not return an Availability Group when Ensure is set to Present and the version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+
                     $getParams = @{
                         Name = $defaultAbsentParameters.Name
                         SQLServer = $defaultAbsentParameters.SQLServer
                         SQLInstanceName = $defaultAbsentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -402,14 +402,14 @@ try
 
                 It 'Should return the correct Availability Group properties when Ensure is set to Present and the SQL version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
 
                     $getParams = @{
                         Name = $defaultPresentParameters.Name
                         SQLServer = $defaultPresentParameters.SQLServer
                         SQLInstanceName = $defaultPresentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -432,14 +432,14 @@ try
 
                 It 'Should return the correct Availability Group properties when Ensure is set to Absent and the SQL version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     $getParams = @{
                         Name = $defaultPresentParameters.Name
                         SQLServer = $defaultPresentParameters.SQLServer
                         SQLInstanceName = $defaultPresentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -462,14 +462,14 @@ try
 
                 It 'Should return the correct Availability Group properties when Ensure is set to Present and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
 
                     $getParams = @{
                         Name = $defaultPresentParameters.Name
                         SQLServer = $defaultPresentParameters.SQLServer
                         SQLInstanceName = $defaultPresentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -492,14 +492,14 @@ try
 
                 It 'Should return the correct Availability Group properties when Ensure is set to Absent and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+
                     $getParams = @{
                         Name = $defaultPresentParameters.Name
                         SQLServer = $defaultPresentParameters.SQLServer
                         SQLInstanceName = $defaultPresentParameters.SQLInstanceName
                     }
-                    
+
                     # Get the current state
                     $result = Get-TargetResource @getParams
 
@@ -523,31 +523,31 @@ try
         }
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Set-TargetResource" {
-            
+
             BeforeEach {
                 $mockLogins = $mockAllLoginsPresent # Need this for legacy purposes
                 $mockConnectSqlVersion12ServerObject.Logins = $mockAllLoginsPresent
                 $mockConnectSqlVersion13ServerObject.Logins = $mockAllLoginsPresent
             }
-            
+
             Mock -CommandName Invoke-Query -MockWith {} -Verifiable
             Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
             Mock -CommandName New-TerminatingError { $ErrorType } -Verifiable
 
             Context 'When the Availability Group is Absent' {
 
-                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -Scope Context
-                Mock -CommandName Update-AvailabilityGroup -MockWith {} -Verifiable -Scope Context
-                Mock -CommandName Update-AvailabilityGroupReplica -MockWith {} -Verifiable -Scope Context
-                
+                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
+                Mock -CommandName Update-AvailabilityGroup -MockWith {} -Verifiable
+                Mock -CommandName Update-AvailabilityGroupReplica -MockWith {} -Verifiable
+
                 It 'Should create the Availability Group when Ensure is set to Present and the SQL version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
 
                     { Set-TargetResource @defaultAbsentParameters } | Should Not Throw
@@ -566,12 +566,12 @@ try
 
                 It 'Should create the Availability Group when Ensure is set to Present and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
                     $defaultAbsentParameters.BasicAvailabilityGroup = $true
 
@@ -591,18 +591,18 @@ try
 
                 It 'Should throw the correct error, HadrNotEnabled, when Ensure is set to Present, but Always On is not enabled' {
                     Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{ 
+                        return New-Object PSObject -Property @{
                             IsHadrEnabled = $false
                         }
-                    } -Verifiable -Scope It
+                    } -Verifiable
                     Mock -CommandName Invoke-Query -MockWith {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-                    
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'HadrNotEnabled'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -618,16 +618,16 @@ try
                 }
 
                 It 'Should throw the correct error (ClusterPermissionsMissing) when the logins "NT SERVICE\ClusSvc" or "NT AUTHORITY\SYSTEM" are absent' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
 
                     $defaultAbsentParameters.Ensure = 'Present'
                     $mockConnectSqlVersion12ServerObject.Logins = $mockAllLoginsAbsent.Clone()
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'ClusterPermissionsMissing'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -639,15 +639,15 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
-                
+
                 It 'Should create the Availability Group when Ensure is set to Present and NT AUTHORITY\SYSTEM has the correct permissions' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
 
                     { Set-TargetResource @defaultAbsentParameters } | Should Not Throw
@@ -663,16 +663,16 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
-                
+
                 It 'Should throw the correct error, ClusterPermissionsMissing, when Ensure is set to Present, but the cluster does not have the correct permissions' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'ClusterPermissionsMissing'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -689,19 +689,19 @@ try
 
                 It 'Should throw the correct error, DatabaseMirroringEndpointNotFound, when Ensure is set to Present, but no DatabaseMirroring endpoints are present' {
                     Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{ 
+                        return New-Object PSObject -Property @{
                             AvailabilityGroups = @()
                             Endpoints = @()
                             IsHadrEnabled = $true
                             Logins = $mockNtServiceClusSvcPresent
                         }
-                    } -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    } -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -714,18 +714,18 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
-                
+
                 It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 12' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -738,16 +738,16 @@ try
                 }
 
                 It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 13' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -760,17 +760,17 @@ try
                 }
 
                 It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 12' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup { throw 'CreateAvailabilityGroupFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-TargetResource -MockWith {$false} -Verifiable -Scope It
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup -MockWith { throw 'CreateAvailabilityGroupFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-TargetResource -MockWith { $false } -Verifiable
+
                     $defaultAbsentParameters.Ensure = 'Present'
-                    
+
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -783,17 +783,17 @@ try
                 }
 
                 It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 13' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -Scope It
-                    Mock -CommandName New-SqlAvailabilityGroup { throw 'CreateAvailabilityGroupFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-TargetResource -MockWith {$false} -Scope It
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup -MockWith { throw 'CreateAvailabilityGroupFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+                    Mock -CommandName Test-TargetResource -MockWith {$false}
+
                     $defaultAbsentParameters.Ensure = 'Present'
 
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -813,15 +813,15 @@ try
                     Mock -CommandName Update-AvailabilityGroup -MockWith $mockUpdateAvailabilityGroup -Verifiable
                     Mock -CommandName Update-AvailabilityGroupReplica -MockWith $mockUpdateAvailabilityGroupReplica -Verifiable
                 }
-                
+
                 It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable
+
                     $defaultPresentParameters.Ensure = 'Absent'
-                    
+
                     { Set-TargetResource @defaultPresentParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -837,12 +837,12 @@ try
 
                 It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable
+
                     $defaultPresentParameters.Ensure = 'Absent'
-                    
+
                     { Set-TargetResource @defaultPresentParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -860,7 +860,7 @@ try
                 It 'Should throw the correct error message, InstanceNotPrimaryReplica, when Ensure is set to Absent and the primary replica is not on the current instance' {
 
                     Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{ 
+                        return New-Object PSObject -Property @{
                             AvailabilityGroups = @{
                                 PresentAG = @{
                                     AutomatedBackupPreference = 'Secondary'
@@ -883,13 +883,13 @@ try
                             IsHadrEnabled = $true
                             NetName = 'Server2'
                         }
-                    } -Verifiable -Scope It
-                    
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable -Scope It
-                    
+                    } -Verifiable
+
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable
+
                     $defaultPresentParameters.Ensure = 'Absent'
-                    
+
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'InstanceNotPrimaryReplica'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -904,13 +904,13 @@ try
                 }
 
                 It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 12' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable -Scope It
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable
+
                     $defaultPresentParameters.Ensure = 'Absent'
-                    
+
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -925,13 +925,13 @@ try
                 }
 
                 It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 13' {
-                    
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable -Scope It
-                    
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith {} -Verifiable
+
                     $defaultPresentParameters.Ensure = 'Absent'
-                    
+
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1011,8 +1011,8 @@ try
                         $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
 
                         return $mock
-                    } -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    
+                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+
                     Mock -CommandName Connect-SQL -MockWith {
                         $mock = New-Object PSObject -Property @{
                             AvailabilityGroups = @{
@@ -1077,15 +1077,15 @@ try
                         $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
 
                         return $mock
-                    } -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server2' }
-                    
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server2' }
+
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $mockAvailabilityGroupReplicaProperty = ''
                     $mockAvailabilityGroupReplicaPropertyValue = ''
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq 'Server2' }
@@ -1099,18 +1099,18 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
-                
+
                 It 'Should set the AutomatedBackupPreference to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.AutomatedBackupPreference = 'Primary'
                     $mockAvailabilityGroupProperty = 'AutomatedBackupPreference'
                     $mockAvailabilityGroupPropertyValue = 'Primary'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1128,15 +1128,15 @@ try
 
                 It 'Should set the AvailabilityMode to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.AvailabilityMode = 'SynchronousCommit'
                     $mockAvailabilityGroupReplicaProperty = 'AvailabilityMode'
                     $mockAvailabilityGroupReplicaPropertyValue = 'SynchronousCommit'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1154,15 +1154,15 @@ try
 
                 It 'Should set the BackupPriority to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.BackupPriority = 42
                     $mockAvailabilityGroupReplicaProperty = 'BackupPriority'
                     $mockAvailabilityGroupReplicaPropertyValue = 42
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1180,15 +1180,15 @@ try
 
                 It 'Should set the BasicAvailabilityGroup to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.BasicAvailabilityGroup = $true
                     $mockAvailabilityGroupProperty = 'BasicAvailabilityGroup'
                     $mockAvailabilityGroupPropertyValue = $true
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1206,15 +1206,15 @@ try
 
                 It 'Should set the ConnectionModeInPrimaryRole to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.ConnectionModeInPrimaryRole = 'AllowReadWriteConnections'
                     $mockAvailabilityGroupReplicaProperty = 'ConnectionModeInPrimaryRole'
                     $mockAvailabilityGroupReplicaPropertyValue = 'AllowReadWriteConnections'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1233,15 +1233,15 @@ try
 
                 It 'Should set the ConnectionModeInSecondaryRole to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.ConnectionModeInSecondaryRole = 'AllowReadIntentConnectionsOnly'
                     $mockAvailabilityGroupReplicaProperty = 'ConnectionModeInSecondaryRole'
                     $mockAvailabilityGroupReplicaPropertyValue = 'AllowReadIntentConnectionsOnly'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1323,14 +1323,14 @@ try
                         $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
 
                         return $mock
-                    } -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
                     $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1348,15 +1348,15 @@ try
 
                 It 'Should set the EndpointUrl to the desired state when the EndpointHostName is specified' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.EndpointHostName = 'TestServer.Contoso.com'
                     $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
                     $mockAvailabilityGroupReplicaPropertyValue = 'TCP://TestServer.Contoso.com:5022'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1438,15 +1438,15 @@ try
                         $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
 
                         return $mock
-                    } -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.Remove('EndpointHostName')
                     $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
                     $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1528,14 +1528,14 @@ try
                         $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
 
                         return $mock
-                    } -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
                     $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1553,15 +1553,15 @@ try
 
                 It 'Should set the FailureConditionLevel to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.FailureConditionLevel = 'OnAnyQualifiedFailureCondition'
                     $mockAvailabilityGroupProperty = 'FailureConditionLevel'
                     $mockAvailabilityGroupPropertyValue = 'OnAnyQualifiedFailureCondition'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1579,15 +1579,15 @@ try
 
                 It 'Should set the FailoverMode to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It -ParameterFilter { $SQLServer -eq 'Server1' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.FailoverMode = 'Automatic'
                     $mockAvailabilityGroupReplicaProperty = 'FailoverMode'
                     $mockAvailabilityGroupReplicaPropertyValue = 'Automatic'
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1605,15 +1605,15 @@ try
 
                 It 'Should set the HealthCheckTimeout to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -Scope It -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
+
                     $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
                     $defaultPresentParametersIncorrectProperties.HealthCheckTimeout = 42
                     $mockAvailabilityGroupProperty = 'HealthCheckTimeout'
                     $mockAvailabilityGroupPropertyValue = 42
-                    
+
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1632,18 +1632,18 @@ try
         }
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Test-TargetResource" {
-            
+
             BeforeEach {
                 $mockLogins = $mockAllLoginsPresent
             }
-            
+
             Context 'When the Availability Group is Absent' {
 
                 It 'Should be $false when the desired state is Present and the SQL version is 12' {
 
                     $defaultAbsentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     Test-TargetResource @defaultAbsentParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1652,7 +1652,7 @@ try
                 It 'Should be $true when the desired state is Absent and the SQL version is 12' {
 
                     $defaultAbsentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
 
                     Test-TargetResource @defaultAbsentParameters | Should Be $true
 
@@ -1662,8 +1662,8 @@ try
                 It 'Should be $false when the desired state is Present and the SQL version is 13' {
 
                     $defaultAbsentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+
                     Test-TargetResource @defaultAbsentParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1672,7 +1672,7 @@ try
                 It 'Should be $true when the desired state is Absent and the SQL version is 13' {
 
                     $defaultAbsentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
 
                     Test-TargetResource @defaultAbsentParameters | Should Be $true
 
@@ -1685,18 +1685,18 @@ try
                 It 'Should be $false when the desired state is Absent and the SQL version is 12' {
 
                     $defaultPresentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     Test-TargetResource @defaultPresentParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should be $true when the desired state is Present and the SQL version is 12' {
-                    
+
                     $defaultPresentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     Test-TargetResource @defaultPresentParameters | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1704,12 +1704,12 @@ try
 
                 It 'Should be $false when the desired state is Present, there is a parameter not correctly set, and the SQL version is 12' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
 
                     $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
                     $defaultPresentParametersIncorrectParameter.AvailabilityMode = 'SynchronousCommit'
-                    
+
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1718,18 +1718,18 @@ try
                 It 'Should be $false when the desired state is Absent and the SQL version is 13' {
 
                     $defaultPresentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+
                     Test-TargetResource @defaultPresentParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should be $true when the desired state is Present and the SQL version is 13' {
-                    
+
                     $defaultPresentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
+
                     Test-TargetResource @defaultPresentParameters | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1737,13 +1737,13 @@ try
 
                 It 'Should be $false when the desired state is Present, there is a parameter not correctly set, and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
 
                     $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
                     $defaultPresentParametersIncorrectParameter.AvailabilityMode = 'SynchronousCommit'
                     $defaultPresentParametersIncorrectParameter.BasicAvailabilityGroup = $true
-                    
+
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1753,42 +1753,42 @@ try
                     $defaultPresentParametersEndpointHostNameNotSpecified = $defaultPresentParameters.Clone()
                     $defaultPresentParametersEndpointHostNameNotSpecified.Ensure = 'Present'
                     $defaultPresentParametersEndpointHostNameNotSpecified.Remove('EndpointHostName')
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
-                    
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+
                     Test-TargetResource @defaultPresentParametersEndpointHostNameNotSpecified | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
-                
+
                 It 'Should be $false when the desired state is Present and the Endpoint Hostname is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
 
                     $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
                     $defaultPresentParametersIncorrectParameter.EndpointHostName = 'server1.contoso.com'
-                    
+
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should be $false when the desired state is Present and the Endpoint Protocol is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointProtocol -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointProtocol -Verifiable
 
                     $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
-                    
+
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should be $false when the desired state is Present and the Endpoint Port is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointPort -Verifiable -Scope It
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointPort -Verifiable
 
                     $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
                     $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
-                    
+
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1798,11 +1798,11 @@ try
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Update-AvailabilityGroup" {
             Mock -CommandName New-TerminatingError -MockWith { $ErrorType }
-            
+
             Context 'When the Availability Group is altered' {
                 It 'Should silently alter the Availability Group' {
                     $ag = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroup
-                    
+
                     { Update-AvailabilityGroup -AvailabilityGroup $ag } | Should Not Throw
 
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
@@ -1811,7 +1811,7 @@ try
                 It 'Should throw the correct error, AlterAvailabilityGroupFailed, when altering the Availaiblity Group fails' {
                     $ag = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroup
                     $ag.Name = 'AlterFailed'
-                    
+
                     { Update-AvailabilityGroup -AvailabilityGroup $ag } | Should Throw 'AlterAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
@@ -31,7 +31,7 @@ try
     Invoke-TestSetup
 
     InModuleScope 'MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica' {
-        
+
         #region parameter mocks
 
             $mockSqlServer = 'Server1'
@@ -50,8 +50,8 @@ try
             $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockSqlServer).domain.com:1433"
             $mockReadOnlyRoutingList = @($mockSqlServer)
 
-        #endregion        
-        
+        #endregion
+
         #region server mock variables
 
             $mockServer1Name = 'Server1'
@@ -66,12 +66,12 @@ try
             $mockServer3NetName = $mockServer3Name
             $mockServer3IsHadrEnabled = $true
 
-        #endregion        
+        #endregion
 
         #region Login mocks
 
             $mockLogins = @{} # Will be dynamically set during tests
-            
+
             $mockNtServiceClusSvcName = 'NT SERVICE\ClusSvc'
             $mockNtAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
 
@@ -141,7 +141,7 @@ try
 
             $mockAlternateEndpointPort = $false
             $mockAlternateEndpointProtocol = $false
-            
+
             $mockAvailabilityGroupReplica1Name = $mockServer1Name
             $mockAvailabilityGroupReplica1AvailabilityMode = 'AsynchronousCommit'
             $mockAvailabilityGroupReplica1BackupPriority = 50
@@ -177,9 +177,9 @@ try
             $mockAvailabilityGroupReplica3FailoverMode = 'Manual'
             $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer3Name).domain.com:1433"
             $mockAvailabilityGroupReplica3ReadOnlyRoutingList = @($mockServer3Name)
-            
+
         #endregion
-        
+
         #region Function mocks
 
         $mockConnectSqlServer1 = {
@@ -193,7 +193,7 @@ try
                 [string]
                 $SQLInstanceName
             )
-            
+
             $mock = @(
                 (
                     New-Object Object |
@@ -205,7 +205,7 @@ try
                         } -PassThru -Force |
                         Add-Member ScriptProperty AvailabilityGroups {
                             return @{
-                                $mockAvailabilityGroup1Name = ( 
+                                $mockAvailabilityGroup1Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
@@ -250,7 +250,7 @@ try
                                             $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
                                             $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
                                         }
-                                        
+
                                         if ( $mockAlternateEndpointProtocol )
                                         {
                                             $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
@@ -266,7 +266,7 @@ try
                                     } -PassThru -Force
                                 )
                             }
-                        } -PassThru -Force | 
+                        } -PassThru -Force |
                         Add-Member ScriptProperty Endpoints {
                             return $mockEndpoint
                         } -PassThru -Force
@@ -290,7 +290,7 @@ try
                 [string]
                 $SQLInstanceName
             )
-            
+
             $mock = @(
                 (
                     New-Object Object |
@@ -302,7 +302,7 @@ try
                         } -PassThru -Force |
                         Add-Member ScriptProperty AvailabilityGroups {
                             return @{
-                                $mockAvailabilityGroup1Name = ( 
+                                $mockAvailabilityGroup1Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
@@ -340,21 +340,21 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         if ( $mockAlternateEndpointPort )
                                         {
                                             $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
                                             $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
                                             $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
                                         }
-                                        
+
                                         if ( $mockAlternateEndpointProtocol )
                                         {
                                             $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
                                             $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
                                             $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
                                         }
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica1Name = $mockAvailabilityGroupReplica1Object
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
@@ -362,7 +362,7 @@ try
                                         }
                                     } -PassThru -Force
                                 )
-                                $mockAvailabilityGroup2Name = ( 
+                                $mockAvailabilityGroup2Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup2Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup2PrimaryReplicaServer -PassThru |
@@ -389,14 +389,14 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
                                             $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
                                         }
                                     } -PassThru -Force
                                 )
-                                $mockAvailabilityGroup3Name = ( 
+                                $mockAvailabilityGroup3Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup3Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup3PrimaryReplicaServer -PassThru |
@@ -423,7 +423,7 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
                                             $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
@@ -431,7 +431,7 @@ try
                                     } -PassThru -Force
                                 )
                             }
-                        } -PassThru -Force | 
+                        } -PassThru -Force |
                         Add-Member ScriptProperty Endpoints {
                             return $mockEndpoint
                         } -PassThru -Force
@@ -455,7 +455,7 @@ try
                 [string]
                 $SQLInstanceName
             )
-            
+
             $mock = @(
                 (
                     New-Object Object |
@@ -467,7 +467,7 @@ try
                         } -PassThru -Force |
                         Add-Member ScriptProperty AvailabilityGroups {
                             return @{
-                                $mockAvailabilityGroup1Name = ( 
+                                $mockAvailabilityGroup1Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
@@ -505,7 +505,7 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica1Name = $mockAvailabilityGroupReplica1Object
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
@@ -513,7 +513,7 @@ try
                                         }
                                     } -PassThru -Force
                                 )
-                                $mockAvailabilityGroup2Name = ( 
+                                $mockAvailabilityGroup2Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup2Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup2PrimaryReplicaServer -PassThru |
@@ -540,14 +540,14 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
                                             $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
                                         }
                                     } -PassThru -Force
                                 )
-                                $mockAvailabilityGroup3Name = ( 
+                                $mockAvailabilityGroup3Name = (
                                     New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup3Name -PassThru |
                                     Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup3PrimaryReplicaServer -PassThru |
@@ -574,7 +574,7 @@ try
                                         $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
                                         $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-                                        
+
                                         return @{
                                             $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
                                             $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
@@ -582,7 +582,7 @@ try
                                     } -PassThru -Force
                                 )
                             }
-                        } -PassThru -Force | 
+                        } -PassThru -Force |
                         Add-Member ScriptProperty Endpoints {
                             return $mockEndpoint
                         } -PassThru -Force
@@ -620,7 +620,7 @@ try
         #endregion
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroupReplica\Get-TargetResource' {
-            BeforeEach {               
+            BeforeEach {
                 $getTargetResourceParameters = @{
                     Name = $mockAvailabilityGroupReplicaName
                     AvailabilityGroupName = $mockAvailabilityGroupName
@@ -639,7 +639,7 @@ try
 
                     $getTargetResourceParameters.Name = 'AbsentReplica'
                     $getTargetResourceParameters.AvailabilityGroupName = 'AbsentAG'
-                    
+
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                     $getTargetResourceResult.AvailabilityGroupName | Should BeNullOrEmpty
@@ -667,7 +667,7 @@ try
                 $mockEnsure = 'Present'
 
                 It 'Should return an Availability Group Replica' {
-                    
+
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                     $getTargetResourceResult.AvailabilityGroupName | Should Be $mockAvailabilityGroupName
@@ -692,7 +692,7 @@ try
         }
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroupReplica\Set-TargetResource' {
-            
+
             BeforeAll {
                 Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
                 Mock -CommandName New-TerminatingError { $ErrorType } -Verifiable
@@ -710,14 +710,14 @@ try
                 Mock -CommandName New-SqlAvailabilityReplica {} -Verifiable
                 Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable
             }
-            
+
             Context 'When the desired state is absent' {
-                
+
                 BeforeAll {
                     Mock -CommandName Update-AvailabilityGroupReplica {} -Verifiable
                 }
 
-                BeforeEach {                    
+                BeforeEach {
                     $setTargetResourceParameters = @{
                         Name = $mockSqlServer
                         AvailabilityGroupName = $mockAvailabilityGroupName
@@ -726,11 +726,11 @@ try
                         Ensure = 'Absent'
                     }
                 }
-                
+
                 It 'Should silently remove the availability group replica' {
-                    
+
                     Mock -CommandName Remove-SqlAvailabilityReplica -MockWith {} -Verifiable
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
@@ -746,9 +746,9 @@ try
                 }
 
                 It 'Should throw the correct error (RemoveAvailabilityGroupReplicaFailed) when removing the availability group replica fails' {
-                    
+
                     Mock -CommandName Remove-SqlAvailabilityReplica -MockWith { Throw 'RemoveAvailabilityGroupReplicaFailed' } -Verifiable
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'RemoveAvailabilityGroupReplicaFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
@@ -771,7 +771,7 @@ try
                     Mock -CommandName Update-AvailabilityGroupReplica {} -Verifiable
                 }
 
-                BeforeEach {               
+                BeforeEach {
                     $setTargetResourceParameters = @{
                         Name = $mockSqlServer
                         AvailabilityGroupName = $mockAvailabilityGroup2Name
@@ -794,9 +794,9 @@ try
                 It 'Should throw the correct error (HadrNotEnabled) when HADR is not enabled' {
 
                     $mockServer1IsHadrEnabled = $false
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'HadrNotEnabled'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -810,11 +810,11 @@ try
                 }
 
                 It 'Should throw the correct error (ClusterPermissionsMissing) when the logins "NT SERVICE\ClusSvc" or "NT AUTHORITY\SYSTEM" are absent' {
-                    
+
                     $mockLogins = $mockAllLoginsAbsent.Clone()
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ClusterPermissionsMissing'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -830,11 +830,11 @@ try
                 It 'Should throw the correct error (ClusterPermissionsMissing) when the logins "NT SERVICE\ClusSvc" and "NT AUTHORITY\SYSTEM" do not have permissions to manage availability groups' {
 
                     $mockLogins = $mockAllLoginsPresent.Clone()
-                    
+
                     Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ClusterPermissionsMissing'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -850,7 +850,7 @@ try
                 It 'Should create the availability group replica when "NT SERVICE\ClusSvc" is present and has the permissions to manage availability groups' {
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -866,9 +866,9 @@ try
                 It 'Should create the availability group replica when "NT AUTHORITY\SYSTEM" is present and has the permissions to manage availability groups' {
 
                     $mockLogins = $mockNtAuthoritySystemPresent
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -882,11 +882,11 @@ try
                 }
 
                 It 'Should throw the correct error (DatabaseMirroringEndpointNotFound) when the database mirroring endpoint is not absent' {
-                    
+
                     $mockEndpoint = $mockDatabaseMirroringEndpointAbsent
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -902,9 +902,9 @@ try
                 It 'Should create the availability group replica when the endpoint hostname is not defined' {
 
                     $setTargetResourceParameters.EndpointHostName = ''
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -918,11 +918,11 @@ try
                 }
 
                 It 'Should create the availability group replica when primary replica server is incorrectly supplied and the availability group exists' {
-                    
+
                     $setTargetResourceParameters.PrimaryReplicaSQLServer = $mockServer3Name
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 1 -Exactly
@@ -936,11 +936,11 @@ try
                 }
 
                 It 'Should throw the correct error (CreateAvailabilityGroupReplicaFailed) when the availability group replica fails to create' {
-                    
+
                     Mock -CommandName New-SqlAvailabilityReplica { throw } -Verifiable
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -954,11 +954,11 @@ try
                 }
 
                 It 'Should throw the correct error (JoinAvailabilityGroupFailed) when the availability group replica fails to join the availability group' {
-                    
+
                     Mock -CommandName Join-SqlAvailabilityGroup -MockWith { throw } -Verifiable
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'JoinAvailabilityGroupFailed'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -974,9 +974,9 @@ try
                 It 'Should throw the correct error (AvailabilityGroupNotFound) when the availability group does not exist on the primary replica' {
 
                     $setTargetResourceParameters.AvailabilityGroupName = 'DoesNotExist'
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'AvailabilityGroupNotFound'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -991,7 +991,7 @@ try
             }
 
             Context 'When the desired state is present and the availability group is present' {
-                
+
                 BeforeAll {
                     Mock -CommandName Remove-SqlAvailabilityReplica -MockWith {} -Verifiable
                     Mock -CommandName Update-AvailabilityGroupReplica -MockWith $mockUpdateAvailabilityGroupReplica -Verifiable
@@ -1011,7 +1011,7 @@ try
                 BeforeEach {
                     $mockAlternateEndpointPort = $false
                     $mockAlternateEndpointProtocol = $false
-                    
+
                     $setTargetResourceParameters = @{
                         Name = $mockSqlServer
                         AvailabilityGroupName = $mockAvailabilityGroupName
@@ -1034,9 +1034,9 @@ try
                 It 'Should throw the correct error (ReplicaNotFound) when the availability group replica does not exist' {
 
                     $setTargetResourceParameters.Name = 'ReplicaNotFound'
-                    
+
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ReplicaNotFound'
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -1052,13 +1052,13 @@ try
                 foreach ( $mockTestProperty in $mockTestProperties.GetEnumerator() )
                 {
                     It "Should set the property '$($mockTestProperty.Key)' to the desired state" {
-                        
+
                         $mockAvailabilityGroupReplicaPropertyName = $mockTestProperty.Key
                         $mockAvailabilityGroupReplicaPropertyValue = $mockTestProperty.Value
                         $setTargetResourceParameters.$mockAvailabilityGroupReplicaPropertyName = $mockAvailabilityGroupReplicaPropertyValue
-                        
+
                         { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        
+
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -1073,11 +1073,11 @@ try
                 }
 
                 It "Should set the Endpoint Hostname to the desired state" {
-                    
+
                     $setTargetResourceParameters.EndpointHostName = 'AnotherEndpointHostName'
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -1089,7 +1089,7 @@ try
                     Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
-                
+
                 It "Should set the Endpoint Port to the desired state" {
 
                     $mockAvailabilityGroupReplicaPropertyName = 'EndpointUrl'
@@ -1097,7 +1097,7 @@ try
                     $mockAlternateEndpointPort = $true
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -1111,13 +1111,13 @@ try
                 }
 
                 It "Should set the Endpoint Protocol to the desired state" {
-                    
+
                     $mockAvailabilityGroupReplicaPropertyName = 'EndpointUrl'
                     $mockAvailabilityGroupReplicaPropertyValue = $mockAvailabilityGroupReplica1EndpointUrl
                     $mockAlternateEndpointProtocol = $true
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
@@ -1133,8 +1133,8 @@ try
         }
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroupReplica\Test-TargetResource' {
-            
-            BeforeEach {            
+
+            BeforeEach {
                 $mockAlternateEndpointPort = $false
                 $mockAlternateEndpointProtocol = $false
                 $mockEndpoint = $mockDatabaseMirroringEndpointPresent
@@ -1161,13 +1161,13 @@ try
             }
 
             Context 'When the desired state is absent' {
-                
+
                 It 'Should return $true when the Availability Replica is absent' {
 
                     $testTargetResourceParameters.Name = $mockAvailabilityGroupReplica2Name
                     $testTargetResourceParameters.AvailabilityGroupName = $mockAvailabilityGroup2Name
                     $testTargetResourceParameters.Ensure = 'Absent'
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1176,7 +1176,7 @@ try
                 It 'Should return $false when the Availability Replica is present' {
 
                     $testTargetResourceParameters.Ensure = 'Absent'
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1201,7 +1201,7 @@ try
 
                     $testTargetResourceParameters.Name = $mockAvailabilityGroupReplica2Name
                     $testTargetResourceParameters.AvailabilityGroupName = $mockAvailabilityGroup2Name
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1228,7 +1228,7 @@ try
                 It 'Should return $false when the Availability Replica is present and the Availabiltiy Mode is not in the desired state' {
 
                     $testTargetResourceParameters.AvailabilityMode = 'SynchronousCommit'
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1237,7 +1237,7 @@ try
                 It 'Should return $true when the Availability Replica is present and the Endpoint Hostname is not specified' {
 
                     $testTargetResourceParameters.EndpointHostName = ''
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1246,25 +1246,25 @@ try
                 It 'Should return $false when the Availability Replica is present and the Endpoint Hostname is not in the desired state' {
 
                     $testTargetResourceParameters.EndpointHostName = 'OtherHostName'
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is present and the Endpoint Protocol is not in the desired state' {
-                    
+
                     $mockAlternateEndpointProtocol = $true
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is present and the Endpoint Port is not in the desired state' {
-                    
+
                     $mockAlternateEndpointPort = $true
-                    
+
                     Test-TargetResource @testTargetResourceParameters | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -543,7 +543,7 @@ try
             BeforeEach {
                 $testParameters = $defaultParameters
 
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable -Scope It
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
                 Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -Verifiable
                 Mock -CommandName Set-SqlAvailabilityGroupListener -MockWith {} -Verifiable
                 Mock -CommandName Add-SqlAvailabilityGroupListenerStaticIp -MockWith {} -Verifiable

--- a/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerConfiguration.Tests.ps1
@@ -13,7 +13,7 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 
 $defaultState = @{
     SQLServer = 'CLU01'
@@ -74,7 +74,7 @@ try
         Context 'The system is not in the desired state' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{ 
+                $mock = New-Object PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -93,7 +93,7 @@ try
 
             ## Get the current state
             $result = Get-TargetResource @desiredState
-            
+
             It 'Should return the same values as passed' {
                 $result.SQLServer | Should Be $desiredState.SQLServer
                 $result.SQLInstanceName | Should Be $desiredState.SQLInstanceName
@@ -111,7 +111,7 @@ try
         Context 'The system is in the desired state' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{ 
+                $mock = New-Object PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -148,7 +148,7 @@ try
         Context 'Invalid data is supplied' {
 
             Mock -CommandName Connect-SQL -MockWith {
-                $mock = New-Object PSObject -Property @{ 
+                $mock = New-Object PSObject -Property @{
                     Configuration = @{
                         Properties = @(
                             @{
@@ -174,11 +174,11 @@ try
     }
 
     Describe "$($script:DSCResourceName)\Test-TargetResource" {
-        
+
         Mock -CommandName New-VerboseMessage -MockWith {} -ModuleName $script:DSCResourceName
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{ 
+            $mock = New-Object PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{
@@ -210,7 +210,7 @@ try
         Mock -CommandName New-TerminatingError -MockWith {} -ModuleName $script:DSCResourceName
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{ 
+            $mock = New-Object PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{
@@ -229,7 +229,7 @@ try
         } -ModuleName $script:DSCResourceName -Verifiable -ParameterFilter { $SQLServer -eq 'CLU01' }
 
         Mock -CommandName Connect-SQL -MockWith {
-            $mock = New-Object PSObject -Property @{ 
+            $mock = New-Object PSObject -Property @{
                 Configuration = @{
                     Properties = @(
                         @{
@@ -261,7 +261,7 @@ try
                 Set-TargetResource @desiredStateRestart
                 Assert-MockCalled -ModuleName $script:DSCResourceName -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
             }
-            
+
             It 'Should warn about restart when required, but not requested' {
                 Set-TargetResource @desiredState
 

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -47,9 +47,9 @@ try
             SQLInstanceName = $mockSqlServerInstanceName
             SQLServer       = $mockSqlServerName
         }
-        
+
         #region Function mocks
-        
+
         $mockConnectSQL = {
             return @(
                 (
@@ -58,14 +58,14 @@ try
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                             return @{
-                                $mockSqlDatabaseName = ( New-Object Object | 
+                                $mockSqlDatabaseName = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Drop -Value {
                                         if ($mockInvalidOperationForDropMethod)
                                         {
                                             throw 'Mock Drop Method was called with invalid operation.'
                                         }
-                                        
+
                                         if ( $this.Name -ne $mockExpectedDatabaseNameToDrop )
                                         {
                                             throw "Called mocked Drop() method without dropping the right database. Expected '{0}'. But was '{1}'." `
@@ -74,7 +74,7 @@ try
                                     } -PassThru
                                     )
                                 }
-                            } -PassThru -Force                                        
+                            } -PassThru -Force
                 )
             )
         }
@@ -89,7 +89,7 @@ try
                             {
                                 throw 'Mock Create Method was called with invalid operation.'
                             }
-                            
+
                             if ( $this.Name -ne $mockExpectedDatabaseNameToCreate )
                             {
                                 throw "Called mocked Create() method without adding the right database. Expected '{0}'. But was '{1}'." `
@@ -127,7 +127,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
             }
-        
+
             Context 'When the system is in the desired state for a database' {
                 It 'Should return the state as present' {
                     $testParameters = $mockDefaultParameters
@@ -152,7 +152,7 @@ try
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerDatabase\Test-TargetResource" -Tag 'Test'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
@@ -169,7 +169,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -228,7 +228,7 @@ try
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerDatabase\Set-TargetResource" -Tag 'Set'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
@@ -250,13 +250,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Not Throw
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Database' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Database'
                     } -Scope Context
                 }
@@ -275,7 +275,7 @@ try
 
                     { Set-TargetResource @testParameters } | Should Not Throw
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -290,11 +290,11 @@ try
                         Name    = 'NewDatabase'
                         Ensure  = 'Present'
                     }
-                    
+
                     $throwInvalidOperation = ('InnerException: Exception calling "Create" ' + `
                                               'with "0" argument(s): "Mock Create Method was called with invalid operation."')
-                    
-                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation 
+
+                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -302,7 +302,7 @@ try
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Database' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Database'
                     } -Scope Context
                 }
@@ -317,12 +317,12 @@ try
                     Name    = 'AdventureWorks'
                     Ensure  = 'Absent'
                 }
-                
+
                 It 'Should throw the correct error when Drop() method was called with invalid operation' {
                     $throwInvalidOperation = ('InnerException: Exception calling "Drop" ' + `
                                               'with "0" argument(s): "Mock Drop Method was called with invalid operation."')
-                    
-                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation 
+
+                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
 
                 It 'Should call the mock function Connect-SQL' {

--- a/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseOwner.Tests.ps1
@@ -47,8 +47,8 @@ try
             SQLInstanceName = $mockSqlServerInstanceName
             SQLServer       = $mockSqlServerName
         }
-        
-        #region Function mocks        
+
+        #region Function mocks
         $mockConnectSQL = {
             return @(
                 (
@@ -57,8 +57,8 @@ try
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                             return @{
-                                $mockSqlDatabaseName = @(( 
-                                    New-Object Object | 
+                                $mockSqlDatabaseName = @((
+                                    New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType NoteProperty -Name Owner -Value $mockDatabaseOwner -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name SetOwner -Value {
@@ -66,7 +66,7 @@ try
                                             {
                                                 throw 'Mock of method SetOwner() was called with invalid operation.'
                                             }
-                                        
+
                                             if ( $this.Owner -ne $mockExpectedDatabaseOwner )
                                             {
                                                 throw "Called mocked SetOwner() method without setting the right login. Expected '{0}'. But was '{1}'." `
@@ -79,11 +79,11 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @{
                                 $mockSqlServerLogin = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             }
-                        } -PassThru -Force                                       
+                        } -PassThru -Force
                 )
             )
         }
@@ -158,7 +158,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -255,8 +255,12 @@ try
                         Database    = $mockSqlDatabaseName
                         Name        = $mockSqlServerLogin
                     }
-                    
-                    $throwInvalidOperation = ('Failed to set owner named Zebes\SamusAran of the database ' + `                                              'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `                                              'Exception calling "SetOwner" with "1" argument(s): "Called mocked ' + `                                              'SetOwner() method without setting the right login. ' + `                                              "Expected 'Zebes\SamusAran'. But was 'Elysia\Chozo'.")
+
+                    $throwInvalidOperation = ('Failed to set owner named Zebes\SamusAran of the database ' + `
+                                              'named AdventureWorks on localhost\MSSQLSERVER. InnerException: ' + `
+                                              'Exception calling "SetOwner" with "1" argument(s): "Called mocked ' + `
+                                              'SetOwner() method without setting the right login. ' + `
+                                              "Expected 'Zebes\SamusAran'. But was 'Elysia\Chozo'.")
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
@@ -265,7 +269,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
             }
-            
+
             Context 'When the system is not in the desired state' {
                 It 'Should throw the correct error when the method SetOwner() was called' {
                     $mockInvalidOperationForSetOwnerMethod  = $true

--- a/Tests/Unit/MSFT_xSQLServerDatabaseRecoveryModel.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseRecoveryModel.Tests.ps1
@@ -44,8 +44,8 @@ try
             SQLInstanceName = $mockSqlServerInstanceName
             SQLServer       = $mockSqlServerName
         }
-        
-        #region Function mocks        
+
+        #region Function mocks
         $mockConnectSQL = {
             return @(
                 (
@@ -54,7 +54,7 @@ try
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                             return @{
-                                $mockSqlDatabaseName = ( New-Object Object | 
+                                $mockSqlDatabaseName = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                     Add-Member -MemberType NoteProperty -Name RecoveryModel -Value $mockSqlDatabaseRecoveryModel -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name Alter -Value {
@@ -62,7 +62,7 @@ try
                                         {
                                             throw 'Mock Alter Method was called with invalid operation.'
                                         }
-                                        
+
                                         if ( $this.RecoveryModel -ne $mockExpectedRecoveryModel )
                                         {
                                             throw "Called Alter Drop() method without setting the right recovery model. Expected '{0}'. But was '{1}'." `
@@ -71,7 +71,7 @@ try
                                     } -PassThru
                                     )
                                 }
-                            } -PassThru -Force                                        
+                            } -PassThru -Force
                 )
             )
         }
@@ -100,7 +100,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
             }
-               
+
             Context 'When the system is not in the desired state' {
                 It 'Should return wrong RecoveryModel' {
                     $testParameters = $mockDefaultParameters
@@ -123,7 +123,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
             }
-    
+
             Context 'When the system is in the desired state for a database' {
                 It 'Should return the correct RecoveryModel' {
                     $testParameters = $mockDefaultParameters
@@ -131,7 +131,7 @@ try
                         Name = 'AdventureWorks'
                         RecoveryModel = 'Simple'
                     }
-    
+
                     $result = Get-TargetResource @testParameters
                     $result.RecoveryModel | Should Be $testParameters.RecoveryModel
                 }
@@ -149,7 +149,7 @@ try
 
             Assert-VerifiableMocks
         }
-    
+
         Describe "MSFT_xSQLServerDatabaseRecoveryModel\Test-TargetResource" -Tag 'Test'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
@@ -166,10 +166,10 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-            
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }                
+                }
             }
 
             Context 'When the system is in the desired state' {
@@ -186,12 +186,12 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                } 
+                }
             }
 
             Assert-VerifiableMocks
         }
-    
+
         Describe "MSFT_xSQLServerDatabaseRecoveryModel\Set-TargetResource" -Tag 'Set'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
@@ -230,7 +230,7 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                } 
+                }
             }
 
             Context 'When the system is not in the desired state' {
@@ -243,7 +243,7 @@ try
                         RecoveryModel = 'Full'
                     }
 
-                    $throwInvalidOperation = ('Exception calling "Alter" with "0" argument(s): ' + 
+                    $throwInvalidOperation = ('Exception calling "Alter" with "0" argument(s): ' +
                                               '"Mock Alter Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
@@ -251,9 +251,9 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                } 
+                }
             }
-        
+
             Assert-VerifiableMocks
         }
     }

--- a/Tests/Unit/MSFT_xSQLServerDatabaseRole.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabaseRole.Tests.ps1
@@ -51,13 +51,13 @@ try
         $mockExpectedForAddMemberMethod             = 'MySecondRole'
         $mockExpectedForDropMemberMethod            = 'MyRole'
         $mockExpectedForCreateMethod                = 'John'
-        
+
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
             SQLInstanceName = $mockSqlServerInstanceName
             SQLServer       = $mockSqlServerName
         }
-        
+
         #region Function mocks
         $mockConnectSQL = {
             return @(
@@ -67,33 +67,33 @@ try
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                             return @{
-                                $mockSqlDatabaseName = @(( 
-                                    New-Object Object | 
+                                $mockSqlDatabaseName = @((
+                                    New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
                                         Add-Member -MemberType ScriptProperty -Name Users -Value {
                                             return @{
-                                                $mockSqlServerLoginOne = @(( 
+                                                $mockSqlServerLoginOne = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
-                                                            param( 
+                                                            param(
                                                                 [String]
-                                                                $mockSqlDatabaseRole 
+                                                                $mockSqlDatabaseRole
                                                             )
-                                                            if ( $mockSqlDatabaseRole -eq $mockExpectedSqlDatabaseRole ) 
+                                                            if ( $mockSqlDatabaseRole -eq $mockExpectedSqlDatabaseRole )
                                                             {
                                                                 return $true
-                                                            } 
+                                                            }
                                                             else
                                                             {
                                                                 return $false
                                                             }
-                                                        } -PassThru 
+                                                        } -PassThru
                                                 ))
-                                                $mockSqlServerLoginTwo = @(( 
+                                                $mockSqlServerLoginTwo = @((
                                                     New-Object Object |
                                                         Add-Member -MemberType ScriptMethod -Name IsMember -Value {
                                                                 return $true
-                                                        } -PassThru 
+                                                        } -PassThru
                                                 ))
                                             }
                                         } -PassThru |
@@ -175,20 +175,20 @@ try
                         Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @{
                                 $mockSqlServerLoginOne = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                                 $mockSqlServerLoginTwo = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                                 $mockSqlServerLogin = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             }
-                        } -PassThru -Force 
-                                       
+                        } -PassThru -Force
+
                 )
             )
         }
@@ -269,7 +269,7 @@ try
                         Role        = @($mockSqlDatabaseRole,$mockSqlDatabaseRoleSecond)
                     }
 
-                    { Get-TargetResource @testParameters } | Should Not Throw 
+                    { Get-TargetResource @testParameters } | Should Not Throw
                 }
 
                 It 'Should call the mock function Connect-SQL' {
@@ -304,9 +304,9 @@ try
                     Database    = $mockSqlDatabaseName
                     Role        = $mockSqlDatabaseRoleSecond
                 }
-                
+
                 It 'Should return the state as absent' {
-                    $result = Get-TargetResource @testParameters                
+                    $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Absent'
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -339,7 +339,7 @@ try
                 }
 
                 It 'Should return the state as absent' {
-                    $result = Get-TargetResource @testParameters                
+                    $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Absent'
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -362,7 +362,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
                 }
             }
-        
+
             Context 'When the system is not in the desired state, and login is not a member of the database' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
@@ -372,7 +372,7 @@ try
                 }
 
                 It 'Should return the state as absent' {
-                    $result = Get-TargetResource @testParameters                
+                    $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Absent'
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -398,7 +398,7 @@ try
                 }
 
                 It 'Should return the state as absent' {
-                    $result = Get-TargetResource @testParameters               
+                    $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Present'
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -413,7 +413,7 @@ try
                     $result.Role | Should Be $testParameters.Role
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }       
+                }
             }
 
             Assert-VerifiableMocks
@@ -437,7 +437,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -456,7 +456,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -475,7 +475,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $false
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -494,7 +494,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $true
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -513,7 +513,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $true
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -532,7 +532,7 @@ try
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $true
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
@@ -562,13 +562,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Not Throw
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
@@ -591,13 +591,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
@@ -617,13 +617,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Not Throw
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should not call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
@@ -647,13 +647,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should not call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
@@ -671,13 +671,13 @@ try
 
                     { Set-TargetResource @testParameters } | Should Not Throw
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should not call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
@@ -702,19 +702,19 @@ try
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
-                
+
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
                 It 'Should not call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.User' {
-                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 0 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.User'
                     } -Scope Context
                 }
             }
 
-            Assert-VerifiableMocks            
+            Assert-VerifiableMocks
         }
     }
 }

--- a/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerLogin.Tests.ps1
@@ -1,5 +1,6 @@
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
 
 $script:DSCModuleName      = 'xSQLServer'
 $script:DSCResourceName    = 'MSFT_xSQLServerLogin'
@@ -206,7 +207,7 @@ try
         #endregion Pester Test Initialization
 
         Describe 'MSFT_xSQLServerLogin\Get-TargetResource' {
-            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable -Scope Describe
+            Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
             Context 'When the login is Absent' {
 

--- a/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
@@ -46,13 +46,13 @@ try
             SQLInstanceName = $mockSQLServerInstanceName
             SQLServer       = $mockSQLServerName
         }
-        
+
         #region Function mocks
 
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object | 
+                    New-Object Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSQLServerInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSQLServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
@@ -64,7 +64,7 @@ try
                                         Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxDegreeOfParallelism -PassThru |
                                         Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxDegreeOfParallelism -PassThru -Force
                                     ) )
-                                } -PassThru -Force 
+                                } -PassThru -Force
                             ) )
                         } -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {
@@ -96,12 +96,12 @@ try
 
         Describe "MSFT_xSQLServerMaxDop\Get-TargetResource" -Tag 'Get'{
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-        
+
             Context 'When the system is either in the desired state or not in the desired state' {
                 $testParameters = $mockDefaultParameters
 
                 $result = Get-TargetResource @testParameters
-                
+
                 It 'Should return the current value for MaxDop' {
                     $result.MaxDop | Should Be $mockMaxDegreeOfParallelism
                 }
@@ -115,22 +115,22 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
             }
-        
+
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerMaxDop\Test-TargetResource" -Tag 'Test'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
-                Mock -CommandName Get-CimInstance -MockWith $mockCimInstance_Win32Processor -ParameterFilter { 
+                Mock -CommandName Get-CimInstance -MockWith $mockCimInstance_Win32Processor -ParameterFilter {
                     $ClassName -eq 'Win32_Processor'
                 } -Verifiable
 
                 Mock -CommandName Get-CimInstance -MockWith {
                     throw 'Mocked function Get-CimInstance was called with the wrong set of parameter filters.'
                 }
-            }            
+            }
 
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
                 $testParameters = $mockDefaultParameters
@@ -138,7 +138,7 @@ try
                     MaxDop          = 1
                     DynamicAlloc    = $false
                     Ensure = 'Present'
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
                     $result = Test-TargetResource @testParameters
@@ -161,7 +161,7 @@ try
                 $testParameters += @{
                     MaxDop          = 6
                     DynamicAlloc    = $false
-                }      
+                }
 
                 It 'Should return the state as true when desired MaxDop is the correct value' {
                     $result = Test-TargetResource @testParameters
@@ -183,7 +183,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     DynamicAlloc = $true
-                }      
+                }
 
                 It 'Should return the state as true when desired MaxDop is present' {
                     $result = Test-TargetResource @testParameters
@@ -195,7 +195,7 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
@@ -207,7 +207,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     DynamicAlloc = $true
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
                     $result = Test-TargetResource @testParameters
@@ -219,7 +219,7 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
@@ -231,7 +231,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     DynamicAlloc = $true
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
                     $result = Test-TargetResource @testParameters
@@ -243,7 +243,7 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
@@ -256,7 +256,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     DynamicAlloc = $true
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
                     $result = Test-TargetResource @testParameters
@@ -268,7 +268,7 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
@@ -278,7 +278,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure = 'Absent'
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxDop is the wrong value' {
                     $result = Test-TargetResource @testParameters
@@ -296,7 +296,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure = 'Absent'
-                }      
+                }
 
                 It 'Should return the state as true when desired MaxDop is the correct value' {
                     $result = Test-TargetResource @testParameters
@@ -339,12 +339,12 @@ try
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerMaxDop\Set-TargetResource" -Tag 'Set'{
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
-                Mock -CommandName Get-CimInstance -MockWith $mockCimInstance_Win32Processor -ParameterFilter { 
+                Mock -CommandName Get-CimInstance -MockWith $mockCimInstance_Win32Processor -ParameterFilter {
                     $ClassName -eq 'Win32_Processor'
                 } -Verifiable
 
@@ -418,7 +418,7 @@ try
                 $testParameters += @{
                     DynamicAlloc    = $true
                     Ensure          = 'Present'
-                }      
+                }
 
                 It 'Should Not Throw when MaxDop parameter is not null and DynamicAlloc set to false' {
                     { Set-TargetResource @testParameters } | Should Not Throw
@@ -429,7 +429,7 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
@@ -449,8 +449,8 @@ try
                     $throwInvalidOperation = ('Unexpected result when trying to configure the max degree of parallelism ' + `
                                               'server configuration option. InnerException: Exception calling "Alter" ' + `
                                               'with "0" argument(s): "Mock Alter Method was called with invalid operation."')
-                    
-                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation 
+
+                    { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }
 
                 It 'Should call the mock function Connect-SQL' {

--- a/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
@@ -52,7 +52,7 @@ try
         $mockConnectSQL = {
             return @(
                 (
-                    New-Object Object | 
+                    New-Object Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSQLServerInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSQLServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Configuration -Value {
@@ -64,7 +64,7 @@ try
                                         Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMinServerMemory -PassThru |
                                         Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMinServerMemory -PassThru -Force
                                     ) )
-                                } -PassThru | 
+                                } -PassThru |
                                 Add-Member -MemberType ScriptProperty -Name MaxServerMemory -Value {
                                     return @( ( New-Object Object |
                                         Add-Member -MemberType NoteProperty -Name DisplayName -Value 'max server memory (MB)' -PassThru |
@@ -72,7 +72,7 @@ try
                                         Add-Member -MemberType NoteProperty -Name RunValue -Value $mockMaxServerMemory -PassThru |
                                         Add-Member -MemberType NoteProperty -Name ConfigValue -Value $mockMaxServerMemory -PassThru -Force
                                     ) )
-                                } -PassThru -Force 
+                                } -PassThru -Force
                             ) )
                         } -PassThru |
                         Add-Member -MemberType ScriptMethod -Name Alter -Value {
@@ -102,7 +102,7 @@ try
                 It 'Should return the current value for MinMemory' {
                     $result.MinMemory | Should Be 2048
                 }
-                
+
                 It 'Should return the current value for MaxMemory' {
                     $result.MaxMemory | Should Be 10300
                 }
@@ -119,7 +119,7 @@ try
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerMemory\Test-TargetResource" -Tag 'Test'{
             Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
 
@@ -135,30 +135,30 @@ try
                     Tag = 'Physical Memory 0'
                     Capacity = 8589934592
                 }
-                
+
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
                     Name = 'Physical Memory'
                     Tag = 'Physical Memory 1'
                     Capacity = 8589934592
-                }  
-                
-                $mockGetCimInstanceMem 
-            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable  
+                }
+
+                $mockGetCimInstanceMem
+            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceProc = [PSCustomObject]@{
                     NumberOfCores = 2
                 }
-                
-                $mockGetCimInstanceProc 
-            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable        
+
+                $mockGetCimInstanceProc
+            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceOS = [PSCustomObject]@{
                     OSArchitecture = '64-bit'
                 }
-                
-                $mockGetCimInstanceOS 
+
+                $mockGetCimInstanceOS
             } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable
 
             Context 'When the system is not in the desired state and DynamicAlloc is set to false' {
@@ -168,7 +168,7 @@ try
                     MinMemory       = 1024
                     MaxMemory       = 8192
                     DynamicAlloc    = $false
-                }      
+                }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
                     $result = Test-TargetResource @testParameters
@@ -190,7 +190,7 @@ try
                     Ensure          = 'Present'
                     MaxMemory       = 8192
                     DynamicAlloc    = $false
-                }      
+                }
 
                 It 'Should return the state as false when desired MaxMemory is not present' {
                     $result = Test-TargetResource @testParameters
@@ -213,7 +213,7 @@ try
                     MinMemory       = 0
                     MaxMemory       = 10300
                     DynamicAlloc    = $false
-                }      
+                }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
                     $result = Test-TargetResource @testParameters
@@ -244,7 +244,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-                            
+
                 It 'Should not call the mock function Get-CimInstance' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
@@ -264,18 +264,18 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-                            
+
                 It 'Should not call the mock function Get-CimInstance' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
             }
-            
+
             Context 'When the system is not in the desired state and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure          = 'Present'
                     DynamicAlloc    = $true
-                }      
+                }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not present' {
                     $result = Test-TargetResource @testParameters
@@ -287,19 +287,19 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context
                 }
@@ -315,7 +315,7 @@ try
                 $testParameters += @{
                     Ensure          = 'Present'
                     DynamicAlloc    = $true
-                }      
+                }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
                     $result = Test-TargetResource @testParameters
@@ -327,19 +327,19 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context
                 }
@@ -354,7 +354,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure          = 'Absent'
-                }      
+                }
 
                 It 'Should return the state as false when desired MinMemory and MaxMemory are not set to the default values' {
                     $result = Test-TargetResource @testParameters
@@ -379,7 +379,7 @@ try
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     Ensure          = 'Absent'
-                }      
+                }
 
                 It 'Should return the state as true when desired MinMemory and MaxMemory are present' {
                     $result = Test-TargetResource @testParameters
@@ -410,7 +410,7 @@ try
 
             Assert-VerifiableMocks
         }
-        
+
         Describe "MSFT_xSQLServerMemory\Set-TargetResource" -Tag 'Set' {
             $mockMinServerMemory = 0
             $mockMaxServerMemory = 2147483647
@@ -429,31 +429,31 @@ try
                     Tag = 'Physical Memory 0'
                     Capacity = 17179869184
                 }
-                
+
                 $mockGetCimInstanceMem += New-Object -TypeName psobject -Property @{
                     Name = 'Physical Memory'
                     Tag = 'Physical Memory 1'
                     Capacity = 17179869184
-                }  
-                
-                $mockGetCimInstanceMem 
-            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable  
+                }
+
+                $mockGetCimInstanceMem
+            } -ParameterFilter { $ClassName -eq 'Win32_PhysicalMemory' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceProc = [PSCustomObject]@{
                     NumberOfCores = 6
                 }
-                
-                $mockGetCimInstanceProc 
-            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable        
+
+                $mockGetCimInstanceProc
+            } -ParameterFilter { $ClassName -eq 'Win32_Processor' } -Verifiable
 
             Mock -CommandName Get-CimInstance -MockWith {
                 $mockGetCimInstanceOS = [PSCustomObject]@{
                     OSArchitecture = 'IA64-bit'
                 }
-                
-                $mockGetCimInstanceOS 
-            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable   
+
+                $mockGetCimInstanceOS
+            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable
 
             Context 'When the MaxMemory parameter is not null and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
@@ -470,7 +470,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-                            
+
                 It 'Should not call the mock function Get-CimInstance' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
@@ -490,7 +490,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-                            
+
                 It 'Should not call the mock function Get-CimInstance' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
@@ -510,7 +510,7 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-                
+
                 It 'Should not call the mock function Get-CimInstance' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -Scope Context
                 }
@@ -562,19 +562,19 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context
                 }
@@ -584,16 +584,16 @@ try
                 $mockGetCimInstanceOS = [PSCustomObject]@{
                     OSArchitecture = '32-bit'
                 }
-                
-                $mockGetCimInstanceOS 
-            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable   
-            
+
+                $mockGetCimInstanceOS
+            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable
+
             Context 'When the system (OS 32-bit) is not in the desired state and Ensure is set to Present, and DynamicAlloc is set to true' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
                     DynamicAlloc    = $true
                     Ensure          = 'Present'
-                }      
+                }
 
                 It 'Should set the MaxMemory to the correct values when Ensure parameter is set to Present and DynamicAlloc is set to true' {
                     { Set-TargetResource @testParameters } | Should Not Throw
@@ -604,19 +604,19 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context
                 }
@@ -641,7 +641,7 @@ try
                         }
                     }
                 }
-                
+
                 # Add the Alter method
                 $mockSqlServerObject | Add-Member -MemberType ScriptMethod -Name Alter -Value {
                     throw 'Mock Alter Method was called with invalid operation.'
@@ -659,7 +659,7 @@ try
                     Ensure          = 'Present'
                 }
 
-                It 'Should throw the correct error' {                
+                It 'Should throw the correct error' {
                     { Set-TargetResource @testParameters } | Should Throw ("Failed to alter the server configuration memory for $($env:COMPUTERNAME)" + "\" +`
                                                                         "$mockSQLServerInstanceName. InnerException: Exception calling ""Alter"" with ""0"" argument(s): " + `
                                                                         """Mock Alter Method was called with invalid operation.""")
@@ -676,8 +676,8 @@ try
 
             Mock -CommandName Get-CimInstance -MockWith {
                 throw
-            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable  
-            
+            } -ParameterFilter { $ClassName -eq 'Win32_operatingsystem' } -Verifiable
+
             Context 'When the Get-SqlDscDynamicMaxMemory fails to calculate the MaxMemory' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
@@ -685,7 +685,7 @@ try
                     Ensure          = 'Present'
                 }
 
-                It 'Should throw the correct error' {                
+                It 'Should throw the correct error' {
                     { Set-TargetResource @testParameters } | Should Throw 'Failed to calculate dynamically the maximum memory.'
                 }
 
@@ -694,19 +694,19 @@ try
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
                 It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
-                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled Get-CimInstance -Exactly -Times 1 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context
                 }

--- a/Tests/Unit/MSFT_xSQLServerReplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerReplication.Tests.ps1
@@ -79,10 +79,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -93,7 +93,7 @@ try
                     WorkingDirectory = ''
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -118,19 +118,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Absent' {
                     $result.Ensure | Should Be 'Absent'
@@ -189,10 +189,10 @@ try
                         -ParameterFilter { $PublisherName -eq 'SERVERNAME' }
                 }
                 It 'Set method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
             }
         }
@@ -210,10 +210,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -224,7 +224,7 @@ try
                     WorkingDirectory = ''
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -249,19 +249,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Absent' {
                     $result.Ensure | Should Be 'Absent'
@@ -313,7 +313,7 @@ try
                 }
                 It 'Set method calls Register-DistributorPublisher with RemoteDistributor connection' {
                     Assert-MockCalled -CommandName Register-DistributorPublisher -Times 1 `
-                        -ParameterFilter { 
+                        -ParameterFilter {
                             $PublisherName -eq 'SERVERNAME\INSTANCENAME' `
                             -and $ServerConnection.ServerInstance -eq $testParameters.RemoteDistributor
                         }
@@ -323,10 +323,10 @@ try
                         -ParameterFilter { $RemoteDistributor -eq $testParameters.RemoteDistributor }
                 }
                 It 'Set method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Set method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
             }
         }
@@ -343,10 +343,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -357,7 +357,7 @@ try
                     WorkingDirectory = 'C:\temp'
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -382,19 +382,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Present' {
                     $result.Ensure | Should Be 'Present'
@@ -415,13 +415,13 @@ try
                     $result.WorkingDirectory | Should Be 'C:\temp'
                 }
             }
-            
+
             Context 'Test method' {
                 It 'Test method returns true' {
                     Test-TargetResource @testParameters | Should be $true
                 }
             }
-            
+
             Context 'Set method' {
                 Set-TargetResource @testParameters
                 It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
@@ -441,19 +441,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Set method doesnt call New-DistributionDatabase with $DistributionDBName = distribution' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Set method doesnt call Install-LocalDistributor' {
                     Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Set method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Set method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
             }
         }
@@ -471,10 +471,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -485,7 +485,7 @@ try
                     WorkingDirectory = 'C:\temp'
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -510,19 +510,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Present' {
                     $result.Ensure | Should Be 'Present'
@@ -569,19 +569,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
                 }
                 It 'Set method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Set method doesnt call Install-LocalDistributor' {
                     Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Set method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Set method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
             }
         }
@@ -598,10 +598,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -612,7 +612,7 @@ try
                     WorkingDirectory = 'C:\temp'
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -637,19 +637,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Present' {
                     $result.Ensure | Should Be 'Present'
@@ -707,7 +707,7 @@ try
                     Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Set method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Register-DistributorPublisher' {
                     Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
@@ -728,10 +728,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME\INSTANCENAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -742,7 +742,7 @@ try
                     WorkingDirectory = 'C:\temp'
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -767,19 +767,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME\INSTANCENAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Present' {
                     $result.Ensure | Should Be 'Present'
@@ -836,7 +836,7 @@ try
                     Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Set method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Register-DistributorPublisher' {
                     Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
@@ -856,10 +856,10 @@ try
 
             Mock -CommandName Get-SqlServerMajorVersion -MockWith { return '99' }
             Mock -CommandName Get-SqlLocalServerName -MockWith { return 'SERVERNAME' }
-            Mock -CommandName New-ServerConnection -MockWith { 
+            Mock -CommandName New-ServerConnection -MockWith {
                 return [pscustomobject]@{
                     ServerInstance = $SqlServerName
-                } 
+                }
             }
             Mock -CommandName New-ReplicationServer -MockWith {
                 return [pscustomobject]@{
@@ -870,7 +870,7 @@ try
                     WorkingDirectory = ''
                 }
             }
-            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} } 
+            Mock -CommandName New-DistributionDatabase -MockWith { return [pscustomobject]@{} }
             Mock -CommandName Install-LocalDistributor -MockWith { }
             Mock -CommandName Install-RemoteDistributor -MockWith { }
             Mock -CommandName Register-DistributorPublisher -MockWith { }
@@ -895,19 +895,19 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Get method doesnt call New-DistributionDatabase' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Get method doesnt call Install-LocalDistributor' {
-                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
                 }
                 It 'Get method doesnt call Install-RemoteDistributor' {
-                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0 
+                    Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Ger method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Ger method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
                 It 'Get method returns Ensure = Absent' {
                     $result.Ensure | Should Be 'Absent'
@@ -928,13 +928,13 @@ try
                     $result.WorkingDirectory | Should Be $testParameters.WorkingDirectory
                 }
             }
-            
+
             Context 'Test method' {
                 It 'Test method returns true' {
                     Test-TargetResource @testParameters | Should be $true
                 }
             }
-            
+
             Context 'Set method' {
                 Set-TargetResource @testParameters
                 It 'Set method calls Get-SqlServerMajorVersion with $InstanceName = MSSQLSERVER' {
@@ -954,7 +954,7 @@ try
                         -ParameterFilter { $ServerConnection.ServerInstance -eq 'SERVERNAME' }
                 }
                 It 'Set method doesnt call New-DistributionDatabase with $DistributionDBName = distribution' {
-                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0 
+                    Assert-MockCalled -CommandName New-DistributionDatabase -Times 0
                 }
                 It 'Set method doesnt call Install-LocalDistributor' {
                     Assert-MockCalled -CommandName Install-LocalDistributor -Times 0
@@ -963,10 +963,10 @@ try
                     Assert-MockCalled -CommandName Install-RemoteDistributor -Times 0
                 }
                 It 'Set method doesnt call Register-DistributorPublisher' {
-                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0 
+                    Assert-MockCalled -CommandName Register-DistributorPublisher -Times 0
                 }
                 It 'Set method doesnt call Uninstall-Distributor' {
-                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0 
+                    Assert-MockCalled -CommandName Uninstall-Distributor -Times 0
                 }
             }
         }

--- a/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRole.Tests.ps1
@@ -49,9 +49,9 @@ try
             SQLInstanceName = $mockSqlServerInstanceName
             SQLServer       = $mockSqlServerName
         }
-        
+
         #region Function mocks
-        
+
         $mockConnectSQL = {
             return @(
                 (
@@ -60,7 +60,7 @@ try
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Roles -Value {
                             return @{
-                                $mockSqlServerRole = ( New-Object Object | 
+                                $mockSqlServerRole = ( New-Object Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlServerRole -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name EnumMemberNames -Value {
                                         if ($mockInvalidOperationForEnumMethod)
@@ -77,7 +77,7 @@ try
                                         {
                                             throw 'Mock Drop Method was called with invalid operation.'
                                         }
-                            
+
                                         if ( $this.Name -ne $mockExpectedServerRoleToDrop )
                                         {
                                             throw "Called mocked drop() method without dropping the right server role. Expected '{0}'. But was '{1}'." `
@@ -89,7 +89,7 @@ try
                                         {
                                             throw 'Mock AddMember Method was called with invalid operation.'
                                         }
-                            
+
                                         if ( $mockSqlServerLoginToAdd -ne $mockExpectedMemberToAdd )
                                         {
                                             throw "Called mocked AddMember() method without adding the right login. Expected '{0}'. But was '{1}'." `
@@ -101,7 +101,7 @@ try
                                         {
                                             throw 'Mock DropMember Method was called with invalid operation.'
                                         }
-                            
+
                                         if ( $mockSqlServerLoginToDrop -ne $mockExpectedMemberToDrop )
                                         {
                                             throw "Called mocked DropMember() method without removing the right login. Expected '{0}'. But was '{1}'." `
@@ -110,27 +110,27 @@ try
                                     } -PassThru
                                     )
                                 }
-                            } -PassThru | 
+                            } -PassThru |
                             Add-Member -MemberType ScriptProperty -Name Logins -Value {
                             return @{
                                 $mockSqlServerLoginOne = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                                 $mockSqlServerLoginTwo = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                                 $mockSqlServerLoginTree = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                                 $mockSqlServerLoginFour = @((
-                                    New-Object Object | 
-                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru 
+                                    New-Object Object |
+                                        Add-Member -MemberType NoteProperty -Name LoginType -Value $mockSqlServerLoginType -PassThru
                                 ))
                             }
-                        } -PassThru -Force                                       
+                        } -PassThru -Force
                 )
             )
         }
@@ -145,7 +145,7 @@ try
                             {
                                 throw 'Mock Create Method was called with invalid operation.'
                             }
-                            
+
                             if ( $this.Name -ne $mockExpectedServerRoleToCreate )
                             {
                                 throw "Called mocked Create() method without adding the right server role. Expected '{0}'. But was '{1}'." `
@@ -191,7 +191,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
                 }
             }
-    
+
             Context 'When the system is not in the desired state and ensure is set to Absent' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
@@ -331,7 +331,7 @@ try
                 }
             }
 
-            Context 'When the system is not in the desired state, parameter MembersToInclude is assigned a value, parameter Members is assigned a value, and ensure is set to Present' {            
+            Context 'When the system is not in the desired state, parameter MembersToInclude is assigned a value, parameter Members is assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -339,7 +339,7 @@ try
                         Members = $mockEnumMemberNames
                         MembersToInclude = $mockSqlServerLoginTree
                     }
-                    
+
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
                                               'MembersToExclude must not be set, or be set ' + `
                                               'to $null, when parameter Members are used.')
@@ -350,10 +350,10 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-            
+
             }
 
-            Context 'When the system is not in the desired state, parameter MembersToExclude is assigned a value, parameter Members is assigned a value, and ensure is set to Present' {            
+            Context 'When the system is not in the desired state, parameter MembersToExclude is assigned a value, parameter Members is assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -361,7 +361,7 @@ try
                         Members = $mockEnumMemberNames
                         MembersToExclude = $mockSqlServerLoginTree
                     }
-                    
+
                     $throwInvalidOperation = ('The parameter MembersToInclude and/or ' + `
                                               'MembersToExclude must not be set, or be set ' + `
                                               'to $null, when parameter Members are used.')
@@ -371,7 +371,7 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
-                }            
+                }
             }
 
             Context 'When the system is not in the desired state and ensure is set to Present' {
@@ -434,7 +434,7 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
                 }
             }
-                        
+
             Context 'When the system is not in the desired state, parameter MembersToInclude is assigned a value and ensure is set to Present' {
                 $testParameters = $mockDefaultParameters
                 $testParameters += @{
@@ -512,7 +512,7 @@ try
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                } 
+                }
             }
 
             Context 'When the system is in the desired state and ensure is set to Absent' {
@@ -527,7 +527,7 @@ try
                     $result | Should Be $true
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                } 
+                }
             }
 
             Context 'When the system is in the desired state and ensure is set to Present' {
@@ -542,10 +542,10 @@ try
                     $result | Should Be $true
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                } 
+                }
             }
 
-            Context 'When the system is not in the desired state and ensure parameter is set to Present' {            
+            Context 'When the system is not in the desired state and ensure parameter is set to Present' {
                 It 'Should return false when desired members are not in desired server role' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -558,10 +558,10 @@ try
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When both the parameters Members and MembersToInclude are assigned a value and ensure is set to Present' {            
+            Context 'When both the parameters Members and MembersToInclude are assigned a value and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -576,12 +576,12 @@ try
                                               'to $null, when parameter Members are used.')
 
                     { Test-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }               
+                }
             }
 
-            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should return true when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -592,12 +592,12 @@ try
 
                     $result = Test-TargetResource @testParameters
                     $result | Should Be $true
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should return false when desired server role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -610,10 +610,10 @@ try
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When both the parameters Members and MembersToExclude are assigned a value and ensure is set to Present' {            
+            Context 'When both the parameters Members and MembersToExclude are assigned a value and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -630,10 +630,10 @@ try
                     { Test-TargetResource @testParameters } | Should Throw $throwInvalidOperation
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should return true when desired server role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -646,10 +646,10 @@ try
                     $result | Should Be $true
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should return false when desired server role exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -662,7 +662,7 @@ try
                     $result | Should Be $false
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
             Assert-VerifiableMocks
@@ -673,9 +673,9 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName New-Object -MockWith $mockNewObjectServerRole -ParameterFilter {
                     $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ServerRole'
-                } 
+                }
             }
-           
+
             Context 'When the system is not in the desired state and ensure is set to Absent' {
                 It 'Should not throw when calling the drop method' {
                     $mockSqlServerRole = 'ServerRoleToDrop'
@@ -685,7 +685,7 @@ try
                         Ensure = 'Absent'
                         ServerRoleName = $mockSqlServerRole
                     }
-         
+
                     { Set-TargetResource @testParameters } | Should Not Throw
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -700,12 +700,12 @@ try
                         Ensure = 'Absent'
                         ServerRoleName = $mockSqlServerRole
                     }
-                    
+
                     $throwInvalidOperation = ('Failed to drop the server role named AdminSqlforBI on ' + `
                                               'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
                                               '"Drop" with "0" argument(s): "Mock Drop Method ' + `
                                               'was called with invalid operation."')
-                    
+
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
@@ -721,14 +721,14 @@ try
                         Ensure = 'Present'
                         ServerRoleName = $mockSqlServerRoleAdd
                     }
-         
+
                     { Set-TargetResource @testParameters } | Should Not Throw
 
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.ServerRole' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ServerRole'
                     } -Scope Context
                 }
@@ -744,7 +744,7 @@ try
                         Ensure = 'Present'
                         ServerRoleName = $mockSqlServerRoleAdd
                     }
-         
+
                     $throwInvalidOperation = ('Failed to create the server role named ServerRoleToAdd on ' + `
                                               'localhost\MSSQLSERVER. InnerException: Exception calling ' + `
                                               '"Create" with "0" argument(s): "Mock Create Method ' + `
@@ -756,13 +756,13 @@ try
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.ServerRole' {
-                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter { 
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ServerRole'
                     } -Scope Context
                 }
             }
 
-            Context 'When both the parameters Members and MembersToInclude are assigned a value and ensure is set to Present' {            
+            Context 'When both the parameters Members and MembersToInclude are assigned a value and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -777,12 +777,12 @@ try
                                               'to $null, when parameter Members are used.')
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When both the parameters Members and MembersToExclude are assigned a value and ensure is set to Present' {            
+            Context 'When both the parameters Members and MembersToExclude are assigned a value and ensure is set to Present' {
                 It 'Should throw the correct error' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
@@ -797,12 +797,12 @@ try
                                               'to $null, when parameter Members are used.')
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should not thrown when calling the AddMember method' {
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
@@ -814,12 +814,12 @@ try
                     }
 
                     { Set-TargetResource @testParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error when calling the AddMember method' {
                     $mockInvalidOperationForAddMemberMethod = $true
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
@@ -836,12 +836,12 @@ try
                                               'with "1" argument(s): "Mock AddMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToInclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error when login does not exist' {
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
@@ -855,12 +855,12 @@ try
                     $throwInvalidOperation = ("Login 'KingJulian' does not exist on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should not throw when calling the DropMember method' {
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTwo
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTwo
@@ -872,12 +872,12 @@ try
                     }
 
                     { Set-TargetResource @testParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error when calling the DropMember method' {
                     $mockInvalidOperationForDropMemberMethod = $true
                     $mockExpectedMemberToDrop = $mockSqlServerLoginTwo
@@ -894,12 +894,12 @@ try
                                               'with "1" argument(s): "Mock DropMember Method was called with invalid operation."')
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {            
+            Context 'When parameter MembersToExclude is assigned a value, parameter Members is not assigned a value, and ensure is set to Present' {
                 It 'Should throw the correct error when login does not exist' {
                     $mockEnumMemberNames = @('KingJulian',$mockSqlServerLoginOne,$mockSqlServerLoginTwo)
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
@@ -914,12 +914,12 @@ try
                     $throwInvalidOperation = ("Login 'KingJulian' does not exist on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When parameter Members is assigned a value and ensure is set to Present' {            
+            Context 'When parameter Members is assigned a value and ensure is set to Present' {
                 It 'Should throw the correct error when login does not exist' {
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
@@ -933,12 +933,12 @@ try
                     $throwInvalidOperation = ("Login 'KingJulian' does not exist on SQL server 'localhost\MSSQLSERVER'.")
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
-            Context 'When Members parameter is set and ensure parameter is set to Present' {            
+            Context 'When Members parameter is set and ensure parameter is set to Present' {
                 It 'Should not throw when calling both the AddMember and DropMember methods' {
                     $mockExpectedMemberToAdd = $mockSqlServerLoginTree
                     $mockSqlServerLoginToAdd = $mockSqlServerLoginTree
@@ -952,9 +952,9 @@ try
                     }
 
                     { Set-TargetResource @testParameters } | Should Not Throw
-                    
+
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope It
-                }            
+                }
             }
 
             Assert-VerifiableMocks

--- a/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerSetup.Tests.ps1
@@ -3866,7 +3866,7 @@ try
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
+                        } -Verifiable
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
@@ -4206,7 +4206,7 @@ try
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
+                        } -Verifiable
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith {} -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'
@@ -4311,7 +4311,7 @@ try
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
                             ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verfiable
+                        } -Verifiable
 
                         Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
                             $Association -eq 'MSCluster_ResourceToPossibleOwner'


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Fixed typos and the use of wrong parameters in unit tests which was
    found after release of new version of Pester (issue #773).

**This Pull Request (PR) fixes the following issues:**
Fixes #773 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/777)
<!-- Reviewable:end -->
