### PR TITLE
xSQLServerHelper: Connect-SQL: Throw on failed connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
     - EndpointPort
     - EndpointURL
+- Changes to xSQLServerHelper
+  - Fixed Connect-SQL by ensuring the Status property returns 'Online' prior to
+    returning the SQL Server object. ([issue #333]https://github.com/PowerShell/xSQLServer/issues/333)
 - Changes to xSQLServerRole
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
     - EndpointURL
 - Changes to xSQLServerHelper
   - Fixed Connect-SQL by ensuring the Status property returns 'Online' prior to
-    returning the SQL Server object. ([issue #333]https://github.com/PowerShell/xSQLServer/issues/333)
+    returning the SQL Server object ([issue #333](https://github.com/PowerShell/xSQLServer/issues/333)).
 - Changes to xSQLServerRole
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -50,7 +50,7 @@ function Connect-SQL
 
     if ($SetupCredential)
     {
-        $sql = New-Object Microsoft.SqlServer.Management.Smo.Server
+        $sql = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
         $sql.ConnectionContext.ConnectAsUser = $true
         $sql.ConnectionContext.ConnectAsUserPassword = $SetupCredential.GetNetworkCredential().Password
         $sql.ConnectionContext.ConnectAsUserName = $SetupCredential.GetNetworkCredential().UserName
@@ -59,18 +59,19 @@ function Connect-SQL
     }
     else
     {
-        $sql = New-Object Microsoft.SqlServer.Management.Smo.Server $databaseEngineInstance
+        $sql = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $databaseEngineInstance
     }
 
-    if (-not $sql)
+    if ( $sql.Status -match '^Online$' )
+    {
+        Write-Verbose -Message ($script:localizedData.ConnectedToDatabaseEngineInstance -f $databaseEngineInstance) -Verbose
+        return $sql
+    }
+    else
     {
         $errorMessage = $script:localizedData.FailedToConnectToDatabaseEngineInstance -f $databaseEngineInstance
         New-InvalidOperationException -Message $errorMessage
     }
-
-    Write-Verbose -Message ($script:localizedData.ConnectedToDatabaseEngineInstance -f $databaseEngineInstance) -Verbose
-
-    return $sql
 }
 
 <#


### PR DESCRIPTION
**Pull Request (PR) description**
Fixed Connect-SQL by ensuring the Status property returns 'Online' prior to returning the SQL Server object.

**This Pull Request (PR) fixes the following issues:**
Fixes #333 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/799)
<!-- Reviewable:end -->
