### PR TITLE
xSQLServer: Using correct assemblies for module SqlServer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
   - Code style clean-up throughout the module to align against the Style Guideline.
   - Fixed typos and the use of wrong parameters in unit tests which was found
     after release of new version of Pester ([issue #773](https://github.com/PowerShell/xFailOverCluster/issues/773)).
+  - Updated appveyor.yml so that integration tests can run in AppVeyor ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.
@@ -83,6 +84,8 @@
     and no longer throws an error when there is just one Analysis Services
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
+    - Fixed so that the integration test copies back the SQLPS module
+      ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@
       parameter Verbose.
     - Moved localization strings from xSQLServer.strings.psd1 to
       xSQLServerHelper.strings.psd1.
+  - Changes to Connect-SQL and Import-SQLPSModule
+    - Now it correctly loads the correct assemblies when SqlServer module is
+      present (issue #649).
+    - Now SQLPS module will be correctly loaded (discovered) after installation
+      of SQL Server. Previously resources depending on SQLPS module could fail
+      because SQLPS was not found after installation because the PSModulePath
+      environment variable in the (LCM) PowerShell session did not contain the new
+      module path.
 - Changes to xSQLServerSetup
   - BREAKING CHANGE: Replaced StartWin32Process helper function with the cmdlet
     Start-Process (issue #41, #93 and #126).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - Fixed so that the integration test renames back the SQLPS module folders if
     they was renamed by AppVeyor (in the appveyor.yml file).
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
+  - Fixed so integration test does not write warnings when SQLPS module is loaded
+    ([issue #798](https://github.com/PowerShell/xFailOverCluster/issues/798)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,26 @@
 
 ## Unreleased
 
+- Changes to xSQLServer
+  - Updated appveyor.yml so that integration tests run in order and so that
+    the SQLPS module folders are renamed to not disturb the units test, but
+    can be renamed back by the integration tests xSQLServerSetup so that the
+    integration tests can run successfully.
+    ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
+- Changes to xSQLServerHelper
+  - Changes to Connect-SQL and Import-SQLPSModule
+    - Now it correctly loads the correct assemblies when SqlServer module is
+      present (issue #649).
+    - Now SQLPS module will be correctly loaded (discovered) after installation
+      of SQL Server. Previously resources depending on SQLPS module could fail
+      because SQLPS was not found after installation because the PSModulePath
+      environment variable in the (LCM) PowerShell session did not contain the new
+      module path.
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' Property ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).
+  - Fixed so that the integration test renames back the SQLPS module folders if
+    they was renamed by AppVeyor (in the appveyor.yml file).
+    ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to
@@ -58,7 +76,6 @@
   - Code style clean-up throughout the module to align against the Style Guideline.
   - Fixed typos and the use of wrong parameters in unit tests which was found
     after release of new version of Pester ([issue #773](https://github.com/PowerShell/xFailOverCluster/issues/773)).
-  - Updated appveyor.yml so that integration tests can run in AppVeyor ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.
@@ -84,8 +101,6 @@
     and no longer throws an error when there is just one Analysis Services
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
-    - Fixed so that the integration test copies back the SQLPS module
-      ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0
@@ -152,14 +167,6 @@
       parameter Verbose.
     - Moved localization strings from xSQLServer.strings.psd1 to
       xSQLServerHelper.strings.psd1.
-  - Changes to Connect-SQL and Import-SQLPSModule
-    - Now it correctly loads the correct assemblies when SqlServer module is
-      present (issue #649).
-    - Now SQLPS module will be correctly loaded (discovered) after installation
-      of SQL Server. Previously resources depending on SQLPS module could fail
-      because SQLPS was not found after installation because the PSModulePath
-      environment variable in the (LCM) PowerShell session did not contain the new
-      module path.
 - Changes to xSQLServerSetup
   - BREAKING CHANGE: Replaced StartWin32Process helper function with the cmdlet
     Start-Process (issue #41, #93 and #126).

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -29,16 +29,26 @@ $TestEnvironment = Initialize-TestEnvironment `
     (see issue #774).
     SQLPS is removed because otherwise the common test will load
     the SMO assembly and fail the unit tests (see issue #239)
+
+    $rootTempPath must be set to the same folder that was created
+    in the appveyor.yml file.
 #>
 $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
-$copyItemParameters = @{
-    Path = Join-Path -Path $rootTempPath -ChildPath '*'
-    Destination = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules'
-    Recurse = $true
-    Force = $true
-}
+if (Test-Path -Path $rootTempPath)
+{
+    $copyItemParameters = @{
+        Path = Join-Path -Path $rootTempPath -ChildPath '*'
+        Destination = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules'
+        Recurse = $true
+        Force = $true
+    }
 
-Copy-Item @copyItemParameters
+    Copy-Item @copyItemParameters
+}
+else
+{
+    Write-Verbose -Message ('The folder ''{0}'' did not exist, ignoring copying SQLPS from temp path. Expecting it to be installed by SQL Server instead.' -f $rootTempPath) -Verbose
+}
 
 $mockInstanceName = 'DSCSQL2016'
 $mockFeatures = 'SQLENGINE,CONN,BC,SDK'

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -24,6 +24,22 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion
 
+<#
+    Copies back the SQLPS module that was removed by AppVeyor.yml
+    (see issue #774).
+    SQLPS is removed because otherwise the common test will load
+    the SMO assembly and fail the unit tests (see issue #239)
+#>
+$rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
+$copyItemParameters = @{
+    Path = Join-Path -Path $rootTempPath -ChildPath '*'
+    Destination = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules'
+    Recurse = $true
+    Force = $true
+}
+
+Copy-Item @copyItemParameters
+
 $mockInstanceName = 'DSCSQL2016'
 $mockFeatures = 'SQLENGINE,CONN,BC,SDK'
 $mockSqlCollation = 'Finnish_Swedish_CI_AS'

--- a/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
@@ -1,3 +1,7 @@
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 1)]
+param()
+
 configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
 {
     param

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -1071,6 +1071,7 @@ InModuleScope $script:moduleName {
     Describe 'Testing Connect-SQL' -Tag ConnectSql {
         BeforeEach {
             Mock -CommandName New-InvalidOperationException -MockWith $mockThrowLocalizedMessage -Verifiable
+            Mock -CommandName Import-SQLPSModule
             Mock -CommandName New-Object `
                 -MockWith $mockNewObject_MicrosoftDatabaseEngine `
                 -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,16 +25,16 @@ build: false
 
 test_script:
     - ps: |
+        # Workaround for issue #774
         $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
-        Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
-        Write-Verbose -Message 'This is a workaround because the integration tests need SQLPS module. More information in issue #774.' -Verbose
+        Write-Verbose -Message ('WORKAROUND FOR ISSUE #774: Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
         New-Item -Path $rootTempPath -Type Directory | Out-Null
         Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force
 
-        Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
-        Write-Verbose -Message 'This is a workaround because the AppVeyor build worker image contains SQL Server. More information in issue #239.' -Verbose
+        # Workaround for issue #239
+        Write-Verbose -Message 'WORKAROUND FOR ISSUE #239: Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
         Write-Verbose -Message 'Modules that are being removed:' -Verbose
-        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Verbose $_.Path -Verbose; Remove-Item $_.Path -Force -Verbose; }
+        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Verbose $_.Path -Verbose; Remove-Item $_.Path -Force; }
 
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,27 +21,16 @@ build: false
 
 test_script:
     - ps: |
-        # Workaround for issue #774
-        $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
-        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #774 ---' -Verbose
-        Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
-        New-Item -Path $rootTempPath -Type Directory | Out-Null
-        Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force
-        Write-Verbose -Message '---------------------------------' -Verbose
-
-        Write-Verbose -Message '' -Verbose
-
-        # Workaround for issue #239
-        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #239 ---' -Verbose
-        Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
-        Write-Verbose -Message 'Modules that are being removed:' -Verbose
-        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process {
-            $parentFolder = Split-Path -Path $_.Path -Parent
-            Write-Verbose $parentFolder -Verbose
-            Remove-Item $_.Path -Recurse -Force
+        # Workaround for issue #239 and issue #774.
+        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #239 AND ISSUE #774 ---' -Verbose
+        $sqlModules = Get-Module -ListAvailable -Name 'sql*'
+        $sqlUniqueModulePath = Split-Path -Path (Split-Path $sqlModules.Path -Parent) -Parent | Sort-Object -Unique
+        $sqlUniqueModulePath | ForEach-Object -Process {
+            $newFolderName = '{0}.old' -f (Split-Path -Path $_ -Leaf)
+            Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
+            Rename-Item $_ -NewName $newFolderName -Force
         }
         Write-Verbose -Message '---------------------------------' -Verbose
-        Write-Verbose -Message '' -Verbose
 
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,14 +27,25 @@ test_script:
     - ps: |
         # Workaround for issue #774
         $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
-        Write-Verbose -Message ('WORKAROUND FOR ISSUE #774: Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
+        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #774 ---' -Verbose
+        Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
         New-Item -Path $rootTempPath -Type Directory | Out-Null
         Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force
+        Write-Verbose -Message '---------------------------------' -Verbose
+
+        Write-Verbose -Message '' -Verbose
 
         # Workaround for issue #239
-        Write-Verbose -Message 'WORKAROUND FOR ISSUE #239: Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
+        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #239 ---' -Verbose
+        Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
         Write-Verbose -Message 'Modules that are being removed:' -Verbose
-        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Verbose $_.Path -Verbose; Remove-Item $_.Path -Force; }
+        Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process {
+            $parentFolder = Split-Path -Path $_.Path -Parent
+            Write-Verbose $parentFolder -Verbose
+            Remove-Item $_.Path -Recurse -Force
+        }
+        Write-Verbose -Message '---------------------------------' -Verbose
+        Write-Verbose -Message '' -Verbose
 
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,11 @@
 version: 6.0.{build}.0
 image: Visual Studio 2017
 install:
-    - git clone https://github.com/PowerShell/DscResource.Tests
+    - git clone https://github.com/johlju/DscResource.Tests
+    - ps: Push-Location
+    - ps: cd "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests"
+    - git checkout ordered-tests
+    - ps: Pop-Location
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
     - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
     - ps: Invoke-AppveyorInstallTask
@@ -21,12 +25,18 @@ build: false
 
 test_script:
     - ps: |
+        $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
+        Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
+        Write-Verbose -Message 'This is a workaround because the integration tests need SQLPS module. More information in issue #774.' -Verbose
+        New-Item -Path $rootTempPath -Type Directory | Out-Null
+        Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force
+
         Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
         Write-Verbose -Message 'This is a workaround because the AppVeyor build worker image contains SQL Server. More information in issue #239.' -Verbose
         Write-Verbose -Message 'Modules that are being removed:' -Verbose
         Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Verbose $_.Path -Verbose; Remove-Item $_.Path -Force -Verbose; }
 
-        Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @()
+        Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 
 #---------------------------------#
 #      deployment configuration   #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,19 @@ test_script:
             Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
             Rename-Item $_ -NewName $newFolderName -Force
         }
-        Write-Verbose -Message '---------------------------------' -Verbose
+
+        Write-Verbose -Message '' -Verbose
+
+        # Workaround for issue #798
+        Write-Verbose -Message '--- WORKAROUND FOR ISSUE #798 ---' -Verbose
+        $azureModules = Get-Module -ListAvailable -Name 'Azure*'
+        $azureUniqueModulePath = Split-Path -Path (Split-Path $azureModules.Path -Parent) -Parent | Sort-Object -Unique
+        $azureUniqueModulePath | ForEach-Object -Process {
+            $newFolderName = '{0}.old' -f (Split-Path -Path $_ -Leaf)
+            Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
+            Rename-Item $_ -NewName $newFolderName -Force
+        }
+        Write-Verbose -Message '' -Verbose
 
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,7 @@
 version: 6.0.{build}.0
 image: Visual Studio 2017
 install:
-    - git clone https://github.com/johlju/DscResource.Tests
-    - ps: Push-Location
-    - ps: cd "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests"
-    - git checkout ordered-tests
-    - ps: Pop-Location
+    - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
     - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
     - ps: Invoke-AppveyorInstallTask

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -37,7 +37,7 @@ function Connect-SQL
         $SetupCredential
     )
 
-    $null = [System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.Smo')
+    Import-SQLPSModule
 
     if ($SQLInstanceName -eq 'MSSQLSERVER')
     {
@@ -697,6 +697,15 @@ function Import-SQLPSModule
     else
     {
         Write-Verbose -Message ($script:localizedData.PreferredModuleNotFound) -Verbose
+
+        <#
+            After installing SQL Server the current PowerShell session doesn't know about the new path
+            that was added for the SQLPS module.
+            This reloads PowerShell session environment variable PSModulePath to make sure it contains
+            all paths.
+        #>
+        $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+
         $module = (Get-Module -FullyQualifiedName 'SQLPS' -ListAvailable).Name
     }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Updated appveyor.yml so that integration tests run in order and so that
    the SQLPS module folders are renamed to not disturb the units test, but
    can be renamed back by the integration tests xSQLServerSetup so that the
    integration tests can run successfully.
    (issue #774).
- Changes to xSQLServerHelper
  - Changes to Connect-SQL and Import-SQLPSModule
    - Now it correctly loads the correct assemblies when SqlServer module is
      present (issue #649).
    - Now SQLPS module will be correctly loaded (discovered) after installation
      of SQL Server. Previously resources depending on SQLPS module could fail
      because SQLPS was not found after installation because the PSModulePath
      environment variable in the (LCM) PowerShell session did not contain the new
      module path.
- Changes to xSQLServerSetup
  - Fixed so that the integration test renames back the SQLPS module folders if
    they was renamed by AppVeyor (in the appveyor.yml file).
    (issue #774).
  - Fixed so integration test does not write warnings when SQLPS module is loaded
    (issue #798).

**This Pull Request (PR) fixes the following issues:**
Fixes #649 
Fixes #774 
Fixes #798 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/800)
<!-- Reviewable:end -->
