### PR TITLE
xSqlServerMaxDop: Measure-Resource value of Property is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).
 - Changes to xSqlServerMaxDop
-  - Fixed error where Measure-Object cmdlet would fail claiming it could not find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
+  - Fixed error where Measure-Object cmdlet would fail claiming it could not 
+  find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Changes to xSQLServerRole
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).
+- Changes to xSqlServerMaxDop
+  - Fixed error where Measure-Object cmdlet would fail claiming it could not find the specified property
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).
 - Changes to xSqlServerMaxDop
-  - Fixed error where Measure-Object cmdlet would fail claiming it could not find the specified property
+  - Fixed error where Measure-Object cmdlet would fail claiming it could not find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).
 - Changes to xSqlServerMaxDop
-  - Fixed error where Measure-Object cmdlet would fail claiming it could not 
+  - Fixed error where Measure-Object cmdlet would fail claiming it could not
   find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
 
 ## 8.1.0.0

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -265,14 +265,14 @@ function Get-SqlDscDynamicMaxDop
     $numProcs = 0
     $numCores = 0
     
-    # loop through returned objects
-    foreach($Processor in $cimInstanceProc)
+    # Loop through returned objects
+    foreach ($processor in $cimInstanceProc)
     {
         # increment number of processors
-        $numProcs += $Processor.NumberOfLogicalProcessors
+        $numProcs += $processor.NumberOfLogicalProcessors
         
         # increment number of cores
-        $numCores += $Processor.NumberOfCores
+        $numCores += $processor.NumberOfCores
     }
 
 

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -212,7 +212,8 @@ function Test-TargetResource
     switch ($Ensure)
     {
         'Absent'
-        {            if ($getMaxDop -ne 0)
+        {            
+            if ($getMaxDop -ne 0)
             {
                 New-VerboseMessage -Message "Current MaxDop is $getMaxDop should be updated to 0"
                 $isMaxDopInDesiredState = $false

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -212,8 +212,7 @@ function Test-TargetResource
     switch ($Ensure)
     {
         'Absent'
-        {
-            if ($getMaxDop -ne 0)
+        {            if ($getMaxDop -ne 0)
             {
                 New-VerboseMessage -Message "Current MaxDop is $getMaxDop should be updated to 0"
                 $isMaxDopInDesiredState = $false
@@ -260,8 +259,21 @@ function Test-TargetResource
 function Get-SqlDscDynamicMaxDop
 {
     $cimInstanceProc = Get-CimInstance -ClassName Win32_Processor
-    $numProcs = (Measure-Object -InputObject $cimInstanceProc -Property NumberOfLogicalProcessors -Sum).Sum
-    $numCores = (Measure-Object -InputObject $cimInstanceProc -Property NumberOfCores -Sum).Sum
+    
+    # init variables
+    $numProcs = 0
+    $numCores = 0
+    
+    # loop through returned objects
+    foreach($Processor in $cimInstanceProc)
+    {
+        # increment number of processors
+        $numProcs += $Processor.NumberOfLogicalProcessors
+        
+        # increment number of cores
+        $numCores += $Processor.NumberOfCores
+    }
+
 
     if ($numProcs -eq 1)
     {


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSqlServerMaxDop
  - Fixed error where Measure-Object cmdlet would fail claiming it could not
    find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))

**This Pull Request (PR) fixes the following issues:**
Fixes #801 
Fixes #805 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/802)
<!-- Reviewable:end -->
