### PR TITLE
xSQLServerAlwaysOnAvailabilityGroupReplica: Added EndpointPort and EndpointUrl as read-only properties to the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
     Group is created.
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
+  - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
+    - EndpointPort
+    - EndpointURL
 - Changes to xSQLServerRole
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
@@ -16,5 +16,7 @@ class MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica : OMI_BaseResource
     [Write, Description("Specifies the failover mode. Default is 'Manual'."), ValueMap{"Automatic","Manual"}, Values{"Automatic","Manual"}] String FailoverMode;
     [Write, Description("Specifies the fully-qualified domain name (FQDN) and port to use when routing to the replica for read only connections.")] String ReadOnlyRoutingConnectionUrl;
     [Write, Description("Specifies an ordered list of replica server names that represent the probe sequence for connection director to use when redirecting read-only connections through this availability replica. This parameter applies if the availability replica is the current primary replica of the availability group.")] String ReadOnlyRoutingList[];
-    [Read, Description("Output the NetName property from the SQL Server object. Used by Get-TargetResource")] String SqlServerNetName;
+    [Read, Description("Output the network port the endpoint is listening on. Used by Get-TargetResource.")] Uint16 EndpointPort;
+    [Read, Description("Output the endpoint URL of the Availability Group Replica. Used by Get-TargetResource.")] String EndpointUrl;
+    [Read, Description("Output the NetName property from the SQL Server object. Used by Get-TargetResource.")] String SqlServerNetName;
 };

--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ Always On Availability Group Replica.
 
 #### Read-Only Properties from Get-TargetResource
 
+* **`[Uint16]` EndpointPort** _(Read)_: Output the network port the endpoint is
+  listening on. Used by Get-TargetResource.
+* **`[String]` EndpointUrl** _(Read)_: Output the endpoint URL of the
+  Availability Group Replica. Used by Get-TargetResource.
 * **`[String]` SQLServerNetName** _(Read)_: Output the NetName property from the
   SQL Server object.
 


### PR DESCRIPTION
**Pull Request (PR) description**
Added EndpointPort and EndpointUrl as read-only properties to the schema.

**This Pull Request (PR) fixes the following issues:**
Fixes: #477 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/803)
<!-- Reviewable:end -->
