### PR TITLE
xSQLServerAlwaysOnService: Adding integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
   - Fixed PS Script Analyzer errors ([issue #724](https://github.com/PowerShell/xSQLServer/issues/724))
   - Casting the result of the property IsHadrEnabled to [System.Boolean] so that
     $null is never returned, which resulted in an exception ([issue #763](https://github.com/PowerShell/xFailOverCluster/issues/763)).
+  - Added integration test ([issue #736](https://github.com/PowerShell/xSQLServer/issues/736)).
 - Changes to xSQLServerDatabasePermission
   - Fixed PS Script Analyzer errors ([issue #725](https://github.com/PowerShell/xSQLServer/issues/725))
 - Changes to xSQLServerScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
     and no longer throws an error when there is just one Analysis Services
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
+    - Cleanup code for integration test a bit.
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
     - Cleanup code for integration test a bit.
+    - Refactor integration test to be able to handle ordered testing.
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,15 @@
     can be renamed back by the integration tests xSQLServerSetup so that the
     integration tests can run successfully.
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
-  - Changed so the maximum version to be installed is 4.0.6.0. Quick fix until we
-    can resolve the unit tests (see issue #807).
-  - Moved the code block that contains workarounds so it is run during the
-    install phase instead of the test phase.
+  - Changed so the maximum version to be installed is 4.0.6.0, when running unit
+    tests in AppVeyor. Quick fix until we can resolve the unit tests (see
+    [issue #807](https://github.com/PowerShell/xFailOverCluster/issues/807)).
+  - Moved the code block, that contains workarounds in appveyor.yml, so it is run
+    during the install phase instead of the test phase.
 - Changes to xSQLServerHelper
   - Changes to Connect-SQL and Import-SQLPSModule
     - Now it correctly loads the correct assemblies when SqlServer module is
-      present (issue #649).
+      present ([issue #649](https://github.com/PowerShell/xFailOverCluster/issues/649)).
     - Now SQLPS module will be correctly loaded (discovered) after installation
       of SQL Server. Previously resources depending on SQLPS module could fail
       because SQLPS was not found after installation because the PSModulePath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Fixed so integration test does not write warnings when SQLPS module is loaded
     ([issue #798](https://github.com/PowerShell/xFailOverCluster/issues/798)).
+  - Cleanup code for integration test a bit.
+  - Refactor integration test to be able to handle ordered testing.
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to
@@ -46,9 +48,11 @@
 - Changes to xSQLServerRole
   - Running Get-DscConfiguration no longer throws an error saying property
     Members is not an array ([issue #790](https://github.com/PowerShell/xSQLServer/issues/790)).
-- Changes to xSqlServerMaxDop
+- Changes to xSQLServerMaxDop
   - Fixed error where Measure-Object cmdlet would fail claiming it could not
-  find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
+    find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
+- Changes to xSQLServerAlwaysOnService
+  - Added integration test ([issue #736](https://github.com/PowerShell/xSQLServer/issues/736)).
 
 ## 8.1.0.0
 
@@ -106,7 +110,6 @@
   - Fixed PS Script Analyzer errors ([issue #724](https://github.com/PowerShell/xSQLServer/issues/724))
   - Casting the result of the property IsHadrEnabled to [System.Boolean] so that
     $null is never returned, which resulted in an exception ([issue #763](https://github.com/PowerShell/xFailOverCluster/issues/763)).
-  - Added integration test ([issue #736](https://github.com/PowerShell/xSQLServer/issues/736)).
 - Changes to xSQLServerDatabasePermission
   - Fixed PS Script Analyzer errors ([issue #725](https://github.com/PowerShell/xSQLServer/issues/725))
 - Changes to xSQLServerScript
@@ -117,8 +120,6 @@
     and no longer throws an error when there is just one Analysis Services
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
-    - Cleanup code for integration test a bit.
-    - Refactor integration test to be able to handle ordered testing.
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Changed so the maximum version to be installed is 4.0.6.0. Quick fix until we
     can resolve the unit tests (see issue #807).
+  - Moved the code block that contains workarounds so it is run during the
+    install phase instead of the test phase.
 - Changes to xSQLServerHelper
   - Changes to Connect-SQL and Import-SQLPSModule
     - Now it correctly loads the correct assemblies when SqlServer module is
@@ -26,8 +28,19 @@
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Fixed so integration test does not write warnings when SQLPS module is loaded
     ([issue #798](https://github.com/PowerShell/xFailOverCluster/issues/798)).
-  - Cleanup code for integration test a bit.
-  - Refactor integration test to be able to handle ordered testing.
+  - Changes to integration tests.
+    - Moved the configuration block from the MSFT\_xSQLServerSetup.Integration.Tests.ps1
+      to the MSFT\_xSQLServerSetup.config.ps1 to align with the other integration
+      test. And also get most of the configuration in one place.
+    - Changed the tests so that the local SqlInstall account is added as a member
+      of the local administrators group.
+    - Changed the tests so that the local SqlInstall account is added as a member
+      of the system administrators in SQL Server (Database Engine) - needed for the
+      xSQLServerAlwaysOnService integration tests.
+    - Changed so that only one of the Modules-folder for the SQLPS PowerShell module
+      for SQL Server 2016 is renamed back so it can be used with the integration
+      tests. There was an issue when more than one SQLPS module was present (see
+      more information in issue #806).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
@@ -25,29 +25,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion
 
-$mockComputerName = $env:COMPUTERNAME
-$mockInstanceName = 'DSCSQL2016'
-$mockRestartTimeout = 120
-
 $mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 $mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
 $mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
 
 try
 {
-    $ConfigurationData = @{
-        AllNodes = @(
-            @{
-                NodeName                    = 'localhost'
-                ComputerName                = $mockComputerName
-                InstanceName                = $mockInstanceName
-                RestartTimeout              = $mockRestartTimeout
-
-                PSDscAllowPlainTextPassword = $true
-            }
-        )
-    }
-
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $configFile
 
@@ -57,6 +40,7 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         It 'Should compile and apply the MOF without throwing' {
             {
+                # The variable $ConfigurationData was dot-sourced above.
                 & $configurationName `
                     -SqlInstallCredential $mockSqlInstallCredential `
                     -OutputPath $TestDrive `

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
@@ -1,0 +1,94 @@
+$script:DSCModuleName = 'xSQLServer'
+$script:DSCResourceFriendlyName = 'xSQLServerAlwaysOnService'
+$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+
+if (-not $env:APPVEYOR -eq $true)
+{
+    Write-Warning -Message ('Integration test for {0} will be skipped unless $env:APPVEYOR equals $true' -f $script:DSCResourceName)
+    return
+}
+
+#region HEADER
+# Integration Test Template Version: 1.1.2
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+$mockComputerName = $env:COMPUTERNAME
+$mockInstanceName = 'DSCSQL2016'
+$mockRestartTimeout = 120
+
+$mockSqlInstallAccountPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+$mockSqlInstallAccountUserName = "$env:COMPUTERNAME\SqlInstall"
+$mockSqlInstallCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockSqlInstallAccountUserName, $mockSqlInstallAccountPassword
+
+try
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName                    = 'localhost'
+                ComputerName                = $mockComputerName
+                InstanceName                = $mockInstanceName
+                RestartTimeout              = $mockRestartTimeout
+
+                PSDscAllowPlainTextPassword = $true
+            }
+        )
+    }
+
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    $configurationName = "$($script:DSCResourceName)_EnableAlwaysOn_Config"
+    $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & $configurationName `
+                    -SqlInstallCredential $mockSqlInstallCredential `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $ConfigurationData
+
+                Start-DscConfiguration -Path $TestDrive `
+                    -ComputerName localhost -Wait -Verbose -Force
+            } | Should Not Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+        }
+
+        It 'Should have set the resource and all the parameters should match' {
+            $currentConfiguration = Get-DscConfiguration
+
+            $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
+                $_.ConfigurationName -eq $configurationName
+            } | Where-Object -FilterScript {
+                $_.ResourceId -eq $resourceId
+            }
+
+            $resourceCurrentState.IsHadrEnabled | Should Be $true
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
@@ -162,12 +162,6 @@ Configuration MSFT_xSQLServerAlwaysOnService_DisableAlwaysOn_Config
             RestartTimeout       = $Node.RestartTimeout
 
             PsDscRunAsCredential = $SqlInstallCredential
-
-            DependsOn            = @(
-                '[WindowsFeature]AddFeatureFailoverClustering'
-                '[WindowsFeature]AddFeatureFailoverClusteringPowerShellModule'
-                '[Script]CreateActiveDirectoryDetachedCluster'
-            )
         }
     }
 }

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
@@ -1,4 +1,21 @@
-configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
+# This is used to make sure the integration test run in the correct order.
+[Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 2)]
+param()
+
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName                    = 'localhost'
+            ComputerName                = $env:COMPUTERNAME
+            InstanceName                = 'DSCSQL2016'
+            RestartTimeout              = 120
+
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+Configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
 {
     param
     (

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
@@ -140,3 +140,34 @@ Configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
         }
     }
 }
+
+Configuration MSFT_xSQLServerAlwaysOnService_DisableAlwaysOn_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'xSQLServer'
+
+    node localhost {
+        xSQLServerAlwaysOnService 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            SQLServer            = $Node.ComputerName
+            SQLInstanceName      = $Node.InstanceName
+            RestartTimeout       = $Node.RestartTimeout
+
+            PsDscRunAsCredential = $SqlInstallCredential
+
+            DependsOn            = @(
+                '[WindowsFeature]AddFeatureFailoverClustering'
+                '[WindowsFeature]AddFeatureFailoverClusteringPowerShellModule'
+                '[Script]CreateActiveDirectoryDetachedCluster'
+            )
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
@@ -1,0 +1,24 @@
+configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential
+    )
+
+    Import-DscResource -ModuleName 'xSQLServer'
+
+    node localhost {
+        xSQLServerAlwaysOnService 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            SQLServer            = $Node.ComputerName
+            SQLInstanceName      = $Node.InstanceName
+            RestartTimeout       = $Node.RestartTimeout
+
+            PsDscRunAsCredential = $SqlInstallCredential
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.config.ps1
@@ -25,9 +25,104 @@ Configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
         $SqlInstallCredential
     )
 
+    Import-DscResource -ModuleName 'PSDscResources'
     Import-DscResource -ModuleName 'xSQLServer'
 
     node localhost {
+        WindowsFeature 'AddFeatureFailoverClustering'
+        {
+            Ensure = "Present"
+            Name   = "Failover-clustering"
+        }
+
+        WindowsFeature 'AddFeatureFailoverClusteringPowerShellModule'
+        {
+            Ensure = "Present"
+            Name   = "RSAT-Clustering-PowerShell"
+        }
+
+        <#
+            This is not using a dedicated DSC resource because xFailOverCluster
+            does not support administrative access point at this time.
+            Issue https://github.com/PowerShell/xFailOverCluster/issues/147.
+        #>
+        Script 'CreateActiveDirectoryDetachedCluster'
+        {
+            SetScript  = {
+                <#
+                    This is used to get the correct IP address in AppVeyor.
+                    The logic is to get the IP address of the first NIC not
+                    named something like 'Internal' and then addition 1 to the
+                    last number. For example if the NIC has and IP address
+                    of 10.0.0.10, then cluster IP address will be 10.0.0.11.
+                #>
+                $ipAddress = Get-NetIPConfiguration | Where-Object -FilterScript {
+                    $_.InterfaceAlias -notlike '*Internal*'
+                } | Select-Object -ExpandProperty IPv4Address | Select-Object IPAddress
+                $ipAddressParts = ($ipAddress[0].IPAddress -split '\.')
+                [System.UInt32] $ipAddressParts[3] += 1
+                $clusterStaticIpAddress = ($ipAddressParts -join '.')
+
+                $newClusterParameters = @{
+                    Name                      = 'DSCCLU01'
+                    Node                      = $env:COMPUTERNAME
+                    StaticAddress             = $clusterStaticIpAddress
+                    NoStorage                 = $true
+                    AdministrativeAccessPoint = 'Dns'
+
+                    # Ignoring warnings that cluster might not be able to start correctly.
+                    WarningAction             = 'SilentlyContinue'
+                }
+
+                Write-Verbose -Message ('Creating Active Directory-Detached cluster ''{0}'' with IP address ''{1}''.' -f $newClusterParameters.Name, $clusterStaticIpAddress)
+
+                New-Cluster @newClusterParameters | Out-Null
+            }
+
+            TestScript = {
+                $result = $false
+
+                <#
+                    Only create Active Directory-Detached cluster if the computer
+                    is not part of a domain.
+                #>
+                if (-not (Get-CimInstance Win32_ComputerSystem).PartOfDomain)
+                {
+                    $clusterName = 'DSCCLU01'
+                    if (Get-Cluster -Name $clusterName -ErrorAction SilentlyContinue)
+                    {
+                        Write-Verbose -Message ('Cluster ''{0}'' exist.' -f $clusterName)
+                        $result = $true
+                    }
+                    else
+                    {
+                        Write-Verbose -Message ('Cluster ''{0}'' does not exist.' -f $clusterName)
+                    }
+                }
+                else
+                {
+                    Write-Verbose -Message 'Computer is domain-joined. Skipping creation of Active Directory-Detached cluster. Expecting a cluster to be present by other means than thru the integration test.'
+                    $result = $true
+                }
+
+                return $result
+            }
+
+            GetScript  = {
+                [System.String] $clusterName = $null
+
+                $cluster = Get-Cluster -Name 'DSCCLU01' -ErrorAction SilentlyContinue
+                if ($cluster)
+                {
+                    $clusterName = $cluster.Name
+                }
+
+                return @{
+                    Result = $clusterName
+                }
+            }
+        }
+
         xSQLServerAlwaysOnService 'Integration_Test'
         {
             Ensure               = 'Present'
@@ -36,6 +131,12 @@ Configuration MSFT_xSQLServerAlwaysOnService_EnableAlwaysOn_Config
             RestartTimeout       = $Node.RestartTimeout
 
             PsDscRunAsCredential = $SqlInstallCredential
+
+            DependsOn            = @(
+                '[WindowsFeature]AddFeatureFailoverClustering'
+                '[WindowsFeature]AddFeatureFailoverClusteringPowerShellModule'
+                '[Script]CreateActiveDirectoryDetachedCluster'
+            )
         }
     }
 }

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -25,6 +25,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion
 
+
 <#
     Workaround for issue #774. In the appveyor.yml file the folder
     C:\Program Files (x86)\Microsoft SQL Server\**\Tools\PowerShell\Modules
@@ -33,7 +34,7 @@ $TestEnvironment = Initialize-TestEnvironment `
     here we rename back the folder to the correct name. Only the version need
     for our tests are renamed.
 #>
-$sqlModulePath = Get-ChildItem -Path 'C:\Program Files (x86)\Microsoft SQL Server\**\Tools\PowerShell\*.old'
+$sqlModulePath = Get-ChildItem -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\*.old'
 $sqlModulePath | ForEach-Object -Process {
     $newFolderName = (Split-Path -Path $_ -Leaf) -replace '\.old'
     Write-Verbose ('Renaming ''{0}'' to ''..\{1}''' -f $_, $newFolderName) -Verbose
@@ -201,6 +202,7 @@ try
             $resourceCurrentState.SQLSvcAccountUsername      | Should Be ('.\{0}' -f (Split-Path -Path $mockSqlServiceAccountUserName -Leaf))
             $resourceCurrentState.SQLSysAdminAccounts        | Should Be @(
                 $mockSqlAdminAccountUserName,
+                $mockSqlInstallAccountUserName,
                 "NT SERVICE\MSSQL`$$mockInstanceName",
                 "NT SERVICE\SQLAgent`$$mockInstanceName",
                 'NT SERVICE\SQLWriter',

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -1,5 +1,6 @@
 $script:DSCModuleName = 'xSQLServer'
-$script:DSCResourceName = 'MSFT_xSQLServerSetup'
+$script:DSCResourceFriendlyName = 'xSQLServerSetup'
+$script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
 
 if (-not $env:APPVEYOR -eq $true)
 {
@@ -119,10 +120,13 @@ try
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $configFile
 
+    $configurationName = "$($script:DSCResourceName)_InstallSqlEngineAsSystem_Config"
+    $resourceId = "[$($script:DSCResourceFriendlyName)]Integration_Test"
+
     Describe "$($script:DSCResourceName)_Integration" {
         It 'Should compile and apply the MOF without throwing' {
             {
-                & "$($script:DSCResourceName)_InstallSqlEngineAsSystem_Config" `
+                & $configurationName `
                     -SqlInstallCredential $mockSqlInstallCredential `
                     -SqlAdministratorCredential $mockSqlAdminCredential `
                     -SqlServiceCredential $mockSqlServiceCredential `
@@ -170,9 +174,9 @@ try
             $currentConfiguration = Get-DscConfiguration
 
             $resourceCurrentState = $currentConfiguration | Where-Object -FilterScript {
-                $_.ConfigurationName -eq "$($script:DSCResourceName)_InstallSqlEngineAsSystem_Config"
+                $_.ConfigurationName -eq $configurationName
             } | Where-Object -FilterScript {
-                $_.ResourceId -eq '[xSQLServerSetup]Integration_Test'
+                $_.ResourceId -eq $resourceId
             }
 
             $resourceCurrentState.Action                     | Should BeNullOrEmpty

--- a/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
@@ -2,7 +2,33 @@
 [Microsoft.DscResourceKit.IntegrationTest(OrderNumber = 1)]
 param()
 
-configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
+# Get a spare drive letter
+$mockLastDrive = ((Get-Volume).DriveLetter | Sort-Object | Select-Object -Last 1)
+$mockIsoMediaDriveLetter = [char](([int][char]$mockLastDrive) + 1)
+
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName                    = 'localhost'
+
+            InstanceName                = 'DSCSQL2016'
+            Features                    = 'SQLENGINE,CONN,BC,SDK'
+            SQLCollation                = 'Finnish_Swedish_CI_AS'
+            InstallSharedDir            = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir         = 'C:\Program Files (x86)\Microsoft SQL Server'
+            UpdateEnabled               = 'False'
+            SuppressReboot              = $true # Make sure we don't reboot during testing.
+            ForceReboot                 = $false
+
+            ImagePath                   = "$env:TEMP\SQL2016.iso"
+            DriveLetter                 = $mockIsoMediaDriveLetter
+
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+Configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
 {
     param
     (

--- a/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
@@ -93,6 +93,13 @@ Configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
             Password = $SqlInstallCredential
         }
 
+        Group 'AddSqlInstallAsAdministrator'
+        {
+            Ensure = 'Present'
+            GroupName = 'Administrators'
+            MembersToInclude = $SqlInstallCredential.UserName
+        }
+
         User 'CreateSqlAdminAccount'
         {
             Ensure   = 'Present'
@@ -125,6 +132,11 @@ Configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
             # This must be set if using SYSTEM account to install.
             SQLSysAdminAccounts   = @(
                 $SqlAdministratorCredential.UserName
+                <#
+                    Must have permission to properties IsClustered and
+                    IsHadrEnable for xSQLServerAlwaysOnService.
+                #>
+                $SqlInstallCredential.UserName
             )
 
             DependsOn             = @(
@@ -132,6 +144,7 @@ Configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
                 '[User]CreateSqlServiceAccount'
                 '[User]CreateSqlAgentServiceAccount'
                 '[User]CreateSqlInstallAccount'
+                '[Group]AddSqlInstallAsAdministrator'
                 '[User]CreateSqlAdminAccount'
                 '[WindowsFeature]NetFramework45'
             )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,18 +44,6 @@ test_script:
         }
         Write-Verbose -Message '' -Verbose
 
-#---------------------------------#
-#      build configuration        #
-#---------------------------------#
-
-build: false
-
-#---------------------------------#
-#      test configuration         #
-#---------------------------------#
-
-test_script:
-    - ps: |
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,18 @@ test_script:
         }
         Write-Verbose -Message '' -Verbose
 
+#---------------------------------#
+#      build configuration        #
+#---------------------------------#
+
+build: false
+
+#---------------------------------#
+#      test configuration         #
+#---------------------------------#
+
+test_script:
+    - ps: |
         Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 
 #---------------------------------#


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Moved the code block, that contains workarounds in appveyor.yml, so it is run
    during the install phase instead of the test phase.
- Changes to xSQLServerSetup
  - Changes to integration tests.
    - Moved the configuration block from the MSFT\_xSQLServerSetup.Integration.Tests.ps1
      to the MSFT\_xSQLServerSetup.config.ps1 to align with the other integration
      test. And also get most of the configuration in one place.
    - Changed the tests so that the local SqlInstall account is added as a member
      of the local administrators group.
    - Changed the tests so that the local SqlInstall account is added as a member
      of the system administrators in SQL Server (Database Engine) - needed for the
      xSQLServerAlwaysOnService integration tests.
    - Changed so that only one of the Modules-folder for the SQLPS PowerShell module
      for SQL Server 2016 is renamed back so it can be used with the integration
      tests. There was an issue when more than one SQLPS module was present (see
      more information in issue #806).
- Changes to xSQLServerAlwaysOnService
  - Added integration test (issue #736).

**This Pull Request (PR) fixes the following issues:**
Fixes #736 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/810)
<!-- Reviewable:end -->
