### PR TITLE
xSQLServer: Quick fix for breaking changes in Pester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     can be renamed back by the integration tests xSQLServerSetup so that the
     integration tests can run successfully.
     ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
+  - Changed so the maximum version to be installed is 4.0.6.0. Quick fix until we
+    can resolve the unit tests (see issue #807).
 - Changes to xSQLServerHelper
   - Changes to Connect-SQL and Import-SQLPSModule
     - Now it correctly loads the correct assemblies when SqlServer module is

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
     - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
-    - ps: Invoke-AppveyorInstallTask
+    - ps: Invoke-AppveyorInstallTask -PesterMaximumVersion '4.0.6.0'
 
 #---------------------------------#
 #      build configuration        #


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServer
  - Changed so the maximum version to be installed is 4.0.6.0. Quick fix until we
    can resolve the unit tests (see issue #807).

**This Pull Request (PR) fixes the following issues:**
This does not fix the issue - just a workaround until we fix the problems in the unit tests.

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/813)
<!-- Reviewable:end -->
