### PR TITLE
xSQLServerSetup: Used wrong variable in integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
       for SQL Server 2016 is renamed back so it can be used with the integration
       tests. There was an issue when more than one SQLPS module was present (see
       more information in [issue #806](https://github.com/PowerShell/xFailOverCluster/issues/806)).
+    - Fixed wrong variable name for SQL service credential. It was using the
+      integration test variable name instead of the parameter name.
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to

--- a/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.config.ps1
@@ -75,8 +75,8 @@ Configuration MSFT_xSQLServerSetup_InstallSqlEngineAsSystem_Config
         User 'CreateSqlServiceAccount'
         {
             Ensure   = 'Present'
-            UserName = Split-Path -Path $mockSqlServiceCredential.UserName -Leaf
-            Password = $mockSqlServiceCredential
+            UserName = Split-Path -Path $SqlServiceCredential.UserName -Leaf
+            Password = $SqlServiceCredential
         }
 
         User 'CreateSqlAgentServiceAccount'


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerSetup
  - Changes to integration tests.
    - Fixed wrong variable name for SQL service credential. It was using the
      integration test variable name instead of the parameter name.

**This Pull Request (PR) fixes the following issues:**
n/a

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/821)
<!-- Reviewable:end -->
