### PR TITLE
xSQLServerRSConfig: No longer returns a null value from Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
 - Added new resource xSQLServerAccount ([issue #706](https://github.com/PowerShell/xSQLServer/issues/706))
   - Added localization support for all strings
   - Added examples for usage
+- Changes to xSQLServerRSConfig
+  - No longer returns a null value from Test-TargetResource when Reporting
+    Services has not been initialized ([issue #822](https://github.com/PowerShell/xSQLServer/issues/822)).
 
 ## 8.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
+++ b/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
@@ -53,7 +53,15 @@ function Get-TargetResource
             $RSSQLInstanceName = 'MSSQLSERVER'
         }
 
-        [System.Boolean] $isInitialized = $reportingServicesConfiguration.IsInitialized
+        $isInitialized = $reportingServicesConfiguration.IsInitialized
+        if (-not $isInitialized)
+        {
+            <#
+                Make sure the value returned is false, if the value returned was
+                either empty, $null or $false. Fic for issue #822.
+            #>
+            [System.Boolean] $isInitialized = $false
+        }
     }
     else
     {

--- a/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
+++ b/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
             $RSSQLInstanceName = 'MSSQLSERVER'
         }
 
-        $isInitialized = $reportingServicesConfiguration.IsInitialized
+        [System.Boolean] $isInitialized = $reportingServicesConfiguration.IsInitialized
     }
     else
     {

--- a/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
@@ -180,6 +180,16 @@ try
                     }
                 }
 
+                # Regression test for issue #822.
+                Context 'When Reporting Services has not been initialized (IsInitialized returns empty string)' {
+                    $mockDynamicIsInitialized = ''
+
+                    It 'Should return the state as not initialized' {
+                        $resultGetTargetResource = Get-TargetResource @testParameters
+                        $resultGetTargetResource.IsInitialized | Should Be $false
+                    }
+                }
+
                 Context 'When there is no Reporting Services instance' {
                     BeforeEach {
                         Mock -CommandName Get-ItemProperty

--- a/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
@@ -50,7 +50,7 @@ try
         $mockGetWmiObject_ConfigurationSetting_NamedInstance = {
             return New-Object Object |
                         Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $true -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $mockDynamicIsInitialized -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value '' -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportManager' -Value '' -PassThru |
                         Add-Member -MemberType ScriptMethod -Name SetVirtualDirectory {
@@ -92,7 +92,7 @@ try
         $mockGetWmiObject_ConfigurationSetting_DefaultInstance = {
             return @{
                 DatabaseServerName = $mockReportingServicesDatabaseServerName
-                IsInitialized = $false
+                IsInitialized = $mockDynamicIsInitialized
             }
         }
 
@@ -131,6 +131,8 @@ try
                         -Verifiable
                 }
 
+                $mockDynamicIsInitialized = $true
+
                 It 'Should return the same values as passed as parameters' {
                     $resultGetTargetResource = Get-TargetResource @testParameters
                     $resultGetTargetResource.InstanceName | Should Be $mockNamedInstanceName
@@ -153,6 +155,8 @@ try
                         -Verifiable
                 }
 
+                $mockDynamicIsInitialized = $false
+
                 It 'Should return the same values as passed as parameters' {
                     $resultGetTargetResource = Get-TargetResource @testParameters
                     $resultGetTargetResource.InstanceName | Should Be $mockNamedInstanceName
@@ -161,9 +165,19 @@ try
                     $resultGetTargetResource | Should BeOfType [System.Collections.Hashtable]
                 }
 
-                It 'Should return the the state as initialized' {
+                It 'Should return the state as not initialized' {
                     $resultGetTargetResource = Get-TargetResource @testParameters
                     $resultGetTargetResource.IsInitialized | Should Be $false
+                }
+
+                # Regression test for issue #822.
+                Context 'When Reporting Services has not been initialized (IsInitialized returns $null)' {
+                    $mockDynamicIsInitialized = $null
+
+                    It 'Should return the state as not initialized' {
+                        $resultGetTargetResource = Get-TargetResource @testParameters
+                        $resultGetTargetResource.IsInitialized | Should Be $false
+                    }
                 }
 
                 Context 'When there is no Reporting Services instance' {


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerRSConfig
  - No longer returns a null value from Test-TargetResource when Reporting
    Services has not been initialized (issue #822).

**This Pull Request (PR) fixes the following issues:**
Fixes #822 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/825)
<!-- Reviewable:end -->
