### PR TITLE
xSQLServer: Fix integration tests. Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
       more information in [issue #806](https://github.com/PowerShell/xFailOverCluster/issues/806)).
     - Fixed wrong variable name for SQL service credential. It was using the
       integration test variable name instead of the parameter name.
+    - Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration
+      ([issue #824](https://github.com/PowerShell/xSQLServer/issues/824)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroup
   - Change the check of the values entered as parameter for
     BasicAvailabilityGroup. It is a boolean, hence it was not possible to
@@ -70,6 +72,8 @@
     find the specified property ([issue #801](https://github.com/PowerShell/xSQLServer/issues/801))
 - Changes to xSQLServerAlwaysOnService
   - Added integration test ([issue #736](https://github.com/PowerShell/xSQLServer/issues/736)).
+    - Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration
+      ([issue #824](https://github.com/PowerShell/xSQLServer/issues/824)).
 - Added new resource xSQLServerAccount ([issue #706](https://github.com/PowerShell/xSQLServer/issues/706))
   - Added localization support for all strings
   - Added examples for usage

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
@@ -62,7 +62,7 @@ try
                         ErrorAction = 'Stop'
                     }
 
-s                    Start-DscConfiguration @startDscConfigurationParameters
+                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should Not Throw
             }
 

--- a/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerAlwaysOnService.Integration.Tests.ps1
@@ -44,14 +44,25 @@ try
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
                 {
-                    # The variable $ConfigurationData was dot-sourced above.
-                    & $configurationName `
-                        -SqlInstallCredential $mockSqlInstallCredential `
-                        -OutputPath $TestDrive `
-                        -ConfigurationData $ConfigurationData
+                    $configurationParameters = @{
+                        SqlInstallCredential = $mockSqlInstallCredential
+                        OutputPath = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData = $ConfigurationData
+                    }
 
-                    Start-DscConfiguration -Path $TestDrive `
-                        -ComputerName localhost -Wait -Verbose -Force
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait = $true
+                        Verbose = $true
+                        Force = $true
+                        ErrorAction = 'Stop'
+                    }
+
+s                    Start-DscConfiguration @startDscConfigurationParameters
                 } | Should Not Throw
             }
 

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -105,17 +105,28 @@ try
     Describe "$($script:DSCResourceName)_Integration" {
         It 'Should compile and apply the MOF without throwing' {
             {
-                # The variable $ConfigurationData was dot-sourced above.
-                & $configurationName `
-                    -SqlInstallCredential $mockSqlInstallCredential `
-                    -SqlAdministratorCredential $mockSqlAdminCredential `
-                    -SqlServiceCredential $mockSqlServiceCredential `
-                    -SqlAgentServiceCredential $mockSqlAgentServiceCredential `
-                    -OutputPath $TestDrive `
-                    -ConfigurationData $ConfigurationData
+                $configurationParameters = @{
+                    SqlInstallCredential = $mockSqlInstallCredential
+                    SqlAdministratorCredential = $mockSqlAdminCredential
+                    SqlServiceCredential = $mockSqlServiceCredential
+                    SqlAgentServiceCredential = $mockSqlAgentServiceCredential
+                    OutputPath = $TestDrive
+                    # The variable $ConfigurationData was dot-sourced above.
+                    ConfigurationData = $ConfigurationData
+                }
 
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
+                & $configurationName @configurationParameters
+
+                $startDscConfigurationParameters = @{
+                    Path = $TestDrive
+                    ComputerName = 'localhost'
+                    Wait = $true
+                    Verbose = $true
+                    Force = $true
+                    ErrorAction = 'Stop'
+                }
+
+                Start-DscConfiguration @startDscConfigurationParameters
             } | Should Not Throw
         } -ErrorVariable itBlockError
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerAlwaysOnService
  - Fix integration tests. Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration (issue #824]).
- Changes to xSQLServerSetup
  - Fix integration tests. Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration (issue #824]).

**This Pull Request (PR) fixes the following issues:**
Fixes #824 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/826)
<!-- Reviewable:end -->
