### PR TITLE
xSQLServerRSConfig: Throws for two Reporting Services with same major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@
 - Changes to xSQLServerRSConfig
   - No longer returns a null value from Test-TargetResource when Reporting
     Services has not been initialized ([issue #822](https://github.com/PowerShell/xSQLServer/issues/822)).
+  - Fixed so that when two Reporting Services are installed for the same major
+    version the resource does not throw an error ([issue #819](https://github.com/PowerShell/xSQLServer/issues/819)).
 
 ## 8.1.0.0
 

--- a/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
@@ -103,7 +103,7 @@ try
 
         $mockGetWmiObject_ConfigurationSetting_DefaultInstance = {
             return New-Object Object |
-                Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName\$mockReportingServicesDatabaseNamedInstanceName" -PassThru |
+                Add-Member -MemberType NoteProperty -Name 'DatabaseServerName' -Value "$mockReportingServicesDatabaseServerName" -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'IsInitialized' -Value $false -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'InstanceName' -Value $mockDefaultInstanceName -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'VirtualDirectoryReportServer' -Value '' -PassThru |
@@ -212,7 +212,7 @@ try
                     $resultGetTargetResource = Get-TargetResource @testParameters
                     $resultGetTargetResource.InstanceName | Should Be $mockDefaultInstanceName
                     $resultGetTargetResource.RSSQLServer | Should Be $mockReportingServicesDatabaseServerName
-                    $resultGetTargetResource.RSSQLInstanceName | Should Be $mockReportingServicesDatabaseNamedInstanceName
+                    $resultGetTargetResource.RSSQLInstanceName | Should Be $mockReportingServicesDatabaseDefaultInstanceName
                     $resultGetTargetResource | Should BeOfType [System.Collections.Hashtable]
                 }
 


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerRSConfig
  - Fixed so that when two Reporting Services are installed for the same major
    version the resource does not throw an error (issue #819).

**This Pull Request (PR) fixes the following issues:**
Fixes #819 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/827)
<!-- Reviewable:end -->
