### PR TITLE
xSQLServerHelper: Create helper function Test-ClusterPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
       because SQLPS was not found after installation because the PSModulePath
       environment variable in the (LCM) PowerShell session did not contain the new
       module path.
+  - Added new helper function ""Test-ClusterPermissions". ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446))
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' property
     ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).
@@ -57,11 +58,14 @@
   - Add possibility to enable the feature DtcSupportEnabled (SQL Server 2016 or
     later only). The feature currently can't be altered once the Availability
     Group is created.
+  - Use the new helper function "Test-ClusterPermissions".
+  - Refactored the unit tests to allow them to be more user friendly.
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
     - EndpointPort
     - EndpointURL
+  - Use the new helper function "Test-ClusterPermissions".
 - Changes to xSQLServerHelper
   - Fixed Connect-SQL by ensuring the Status property returns 'Online' prior to
     returning the SQL Server object ([issue #333](https://github.com/PowerShell/xSQLServer/issues/333)).
@@ -75,6 +79,15 @@
   - Added integration test ([issue #736](https://github.com/PowerShell/xSQLServer/issues/736)).
     - Added ErrorAction 'Stop' to the cmdlet Start-DscConfiguration
       ([issue #824](https://github.com/PowerShell/xSQLServer/issues/824)).
+- Changes to SMO.cs
+  - Added default properties to the Server class
+    - AvailabilityGroups
+    - Databases
+    - EndpointCollection
+  - Added a new overload to the Login class
+  - Added default properties to the AvailabilityReplicas class
+    - AvailabilityDatabases
+    - AvailabilityReplicas
 - Added new resource xSQLServerAccount ([issue #706](https://github.com/PowerShell/xSQLServer/issues/706))
   - Added localization support for all strings
   - Added examples for usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
       because SQLPS was not found after installation because the PSModulePath
       environment variable in the (LCM) PowerShell session did not contain the new
       module path.
-  - Added new helper function "Test-ClusterPermissions". ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446))
+  - Added new helper function "Test-ClusterPermissions" ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446)).
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' property
     ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
       because SQLPS was not found after installation because the PSModulePath
       environment variable in the (LCM) PowerShell session did not contain the new
       module path.
-  - Added new helper function ""Test-ClusterPermissions". ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446))
+  - Added new helper function "Test-ClusterPermissions". ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446))
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' property
     ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -275,6 +275,7 @@ function Set-TargetResource
             # Ensure the appropriate cluster permissions are present
             Test-ClusterPermissions -ServerObject $serverObject
 
+            # Make sure a database mirroring endpoint exists.
             $endpoint = $serverObject.Endpoints | Where-Object { $_.EndpointType -eq 'DatabaseMirroring' }
             if ( -not $endpoint )
             {

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -290,7 +290,6 @@ function Set-TargetResource
             # If the availability group does not exist, create it
             if ( -not $availabilityGroup )
             {
-
                 # Set up the parameters to create the AG Replica
                 $newReplicaParams = @{
                     Name             = $serverObject.Name

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
@@ -269,62 +269,8 @@ function Set-TargetResource
 
         Present
         {
-            $clusterServiceName = 'NT SERVICE\ClusSvc'
-            $ntAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
-            $availabilityGroupManagementPerms = @('Connect SQL', 'Alter Any Availability Group', 'View Server State')
-            $clusterPermissionsPresent = $false
-
-            foreach ( $loginName in @( $clusterServiceName, $ntAuthoritySystemName ) )
-            {
-                if ( $serverObject.Logins[$loginName] -and -not $clusterPermissionsPresent )
-                {
-                    $testLoginEffectivePermissionsParams = @{
-                        SQLServer       = $SQLServer
-                        SQLInstanceName = $SQLInstanceName
-                        LoginName       = $loginName
-                        Permissions     = $availabilityGroupManagementPerms
-                    }
-
-                    $clusterPermissionsPresent = Test-LoginEffectivePermissions @testLoginEffectivePermissionsParams
-
-                    if ( -not $clusterPermissionsPresent )
-                    {
-                        switch ( $loginName )
-                        {
-                            $clusterServiceName
-                            {
-                                New-VerboseMessage -Message "The recommended account '$loginName' is missing one or more of the following permissions: $( $availabilityGroupManagementPerms -join ', ' ). Trying with '$ntAuthoritySystemName'."
-                            }
-
-                            $ntAuthoritySystemName
-                            {
-                                New-VerboseMessage -Message "'$loginName' is missing one or more of the following permissions: $( $availabilityGroupManagementPerms -join ', ' )"
-                            }
-                        }
-                    }
-                }
-                elseif ( -not $clusterPermissionsPresent )
-                {
-                    switch ( $loginName )
-                    {
-                        $clusterServiceName
-                        {
-                            New-VerboseMessage -Message "The recommended login '$loginName' is not present. Trying with '$ntAuthoritySystemName'."
-                        }
-
-                        $ntAuthoritySystemName
-                        {
-                            New-VerboseMessage -Message "The login '$loginName' is not present."
-                        }
-                    }
-                }
-            }
-
-            # If neither 'NT SERVICE\ClusSvc' or 'NT AUTHORITY\SYSTEM' have the required permissions, throw an error.
-            if ( -not $clusterPermissionsPresent )
-            {
-                throw New-TerminatingError -ErrorType ClusterPermissionsMissing -FormatArgs $SQLServer, $SQLInstanceName -ErrorCategory SecurityError
-            }
+            # Ensure the appropriate cluster permissions are present
+            Test-ClusterPermissions -ServerObject $serverObject
 
             # Make sure a database mirroring endpoint exists.
             $endpoint = $serverObject.Endpoints | Where-Object { $_.EndpointType -eq 'DatabaseMirroring' }

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -1,12 +1,12 @@
-$script:DSCModuleName      = 'xSQLServer'
-$script:DSCResourceName    = 'MSFT_xSQLServerAlwaysOnAvailabilityGroup'
+$script:DSCModuleName = 'xSQLServer'
+$script:DSCResourceName = 'MSFT_xSQLServerAlwaysOnAvailabilityGroup'
 
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -26,77 +26,77 @@ try
 
         #region mock server object variables
 
-            $mockServer1Name = 'Server1'
-            $mockServer1ServiceName = 'MSSQLSERVER'
+        $mockServer1Name = 'Server1'
+        $mockServer1ServiceName = 'MSSQLSERVER'
 
-            $mockServer2Name = 'Server2'
-            $mockServer2ServiceName = 'MSSQLSERVER'
+        $mockServer2Name = 'Server2'
+        $mockServer2ServiceName = 'MSSQLSERVER'
 
         #endregion mock server object variables
 
         #region mock availability group variables
 
-            # Define the properties that are SQL 2016 and newer
-            $sql13AvailabilityGroupProperties = @(
-                'BasicAvailabilityGroup'
-                'DatabaseHealthTrigger'
-                'DtcSupportEnabled'
-            )
+        # Define the properties that are SQL 2016 and newer
+        $sql13AvailabilityGroupProperties = @(
+            'BasicAvailabilityGroup'
+            'DatabaseHealthTrigger'
+            'DtcSupportEnabled'
+        )
 
-            # Define properties that are Availability Replica properties
-            $availabilityGroupReplicaProperties = @(
-                'AvailabilityMode',
-                'BackupPriority',
-                'ConnectionModeInPrimaryRole',
-                'ConnectionModeInSecondaryRole',
-                'EndpointHostName',
-                'FailoverMode'
-            )
+        # Define properties that are Availability Replica properties
+        $availabilityGroupReplicaProperties = @(
+            'AvailabilityMode',
+            'BackupPriority',
+            'ConnectionModeInPrimaryRole',
+            'ConnectionModeInSecondaryRole',
+            'EndpointHostName',
+            'FailoverMode'
+        )
 
-            # The following will be set dynamically during tests
-            $mockAvailabilityGroupName = ''
-            $mockAvailabilityReplicaEndpointProtocol = ''
-            $mockAvailabilityReplicaEndpointPort = 0
-            $mockDatabaseMirroringEndpointProtocol = ''
-            $mockDatabaseMirroringEndpointPort = 0
+        # The following will be set dynamically during tests
+        $mockAvailabilityGroupName = ''
+        $mockAvailabilityReplicaEndpointProtocol = ''
+        $mockAvailabilityReplicaEndpointPort = 0
+        $mockDatabaseMirroringEndpointProtocol = ''
+        $mockDatabaseMirroringEndpointPort = 0
 
-            $mockAvailabilityGroupAbsentName = 'AbsentAvailabilityGroup'
-            $mockAvailabilityGroupCreateErrorName = 'ErrorCreateAvailabilityGroup'
-            $mockAvailabilityGroupPresentName = 'NewAvailabilityGroup'
-            $mockAvailabilityGroupRemoveErrorName = 'ErrorRemoveAvailabilityGroup'
-            $mockAvailabilityGroupReplicaAbsentName = $mockServer2Name
-            $mockAvailabilityGroupReplicaPresentName = $mockServer1Name
+        $mockAvailabilityGroupAbsentName = 'AbsentAvailabilityGroup'
+        $mockAvailabilityGroupCreateErrorName = 'ErrorCreateAvailabilityGroup'
+        $mockAvailabilityGroupPresentName = 'NewAvailabilityGroup'
+        $mockAvailabilityGroupRemoveErrorName = 'ErrorRemoveAvailabilityGroup'
+        $mockAvailabilityGroupReplicaAbsentName = $mockServer2Name
+        $mockAvailabilityGroupReplicaPresentName = $mockServer1Name
 
-            $mockAvailabilityGroup1Name = 'AvailabilityGroup1'
-            $mockAvailabilityGroup1BasicAvailabilityGroup = $false
-            $mockAvailabilityGroup1DatabaseHealthTrigger = $false
-            $mockAvailabilityGroup1DtcSupportEnabled = $false
-            $mockAvailabilityGroup1AutomatedBackupPreference = 'Secondary'
-            $mockAvailabilityGroup1FailureConditionLevel = 'OnCriticalServerErrors'
-            $mockAvailabilityGroup1HealthCheckTimeout = 30000
-            $mockAvailabilityGroup1PrimaryReplicaServerName = $mockServer1Name
+        $mockAvailabilityGroup1Name = 'AvailabilityGroup1'
+        $mockAvailabilityGroup1BasicAvailabilityGroup = $false
+        $mockAvailabilityGroup1DatabaseHealthTrigger = $false
+        $mockAvailabilityGroup1DtcSupportEnabled = $false
+        $mockAvailabilityGroup1AutomatedBackupPreference = 'Secondary'
+        $mockAvailabilityGroup1FailureConditionLevel = 'OnCriticalServerErrors'
+        $mockAvailabilityGroup1HealthCheckTimeout = 30000
+        $mockAvailabilityGroup1PrimaryReplicaServerName = $mockServer1Name
 
-            $mockAvailabilityReplica1Name = $mockServer1Name
-            $mockAvailabilityReplica1AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityReplica1BackupPriority = 50
-            $mockAvailabilityReplica1ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityReplica1ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityReplica1EndpointHostName = $mockServer1Name
-            $mockAvailabilityReplica1EndpointProtocol = 'TCP'
-            $mockAvailabilityReplica1EndpointPort = 5022
-            $mockAvailabilityReplica1FailoverMode = 'Manual'
-            $mockAvailabilityReplica1Role = 'Primary'
+        $mockAvailabilityReplica1Name = $mockServer1Name
+        $mockAvailabilityReplica1AvailabilityMode = 'AsynchronousCommit'
+        $mockAvailabilityReplica1BackupPriority = 50
+        $mockAvailabilityReplica1ConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockAvailabilityReplica1ConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockAvailabilityReplica1EndpointHostName = $mockServer1Name
+        $mockAvailabilityReplica1EndpointProtocol = 'TCP'
+        $mockAvailabilityReplica1EndpointPort = 5022
+        $mockAvailabilityReplica1FailoverMode = 'Manual'
+        $mockAvailabilityReplica1Role = 'Primary'
 
-            $mockAvailabilityReplica2Name = $mockServer2Name
-            $mockAvailabilityReplica2AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityReplica2BackupPriority = 50
-            $mockAvailabilityReplica2ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityReplica2ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityReplica2EndpointHostName = $mockServer2Name
-            $mockAvailabilityReplica2EndpointProtocol = 'TCP'
-            $mockAvailabilityReplica2EndpointPort = 5022
-            $mockAvailabilityReplica2FailoverMode = 'Manual'
-            $mockAvailabilityReplica2Role = 'Primary'
+        $mockAvailabilityReplica2Name = $mockServer2Name
+        $mockAvailabilityReplica2AvailabilityMode = 'AsynchronousCommit'
+        $mockAvailabilityReplica2BackupPriority = 50
+        $mockAvailabilityReplica2ConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockAvailabilityReplica2ConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockAvailabilityReplica2EndpointHostName = $mockServer2Name
+        $mockAvailabilityReplica2EndpointProtocol = 'TCP'
+        $mockAvailabilityReplica2EndpointPort = 5022
+        $mockAvailabilityReplica2FailoverMode = 'Manual'
+        $mockAvailabilityReplica2Role = 'Primary'
 
         #endregion mock availability group variables
 
@@ -327,35 +327,39 @@ try
         }
 
         #region configuration parameters
-            $getTargetResourceParameters = @{
-                SQLServer = $mockServer1Name
-                SQLInstanceName = $mockServer1ServiceName
-            }
+        $getTargetResourceParameters = @{
+            SQLServer       = $mockServer1Name
+            SQLInstanceName = $mockServer1ServiceName
+        }
 
-            $mockResourceParameters = @{
-                Name = $mockAvailabilityGroup1Name
-                SQLServer = $mockServer1Name
-                SQLInstanceName = $mockServer1ServiceName
-                AutomatedBackupPreference = $mockAvailabilityGroup1AutomatedBackupPreference
-                AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
-                BackupPriority = $mockAvailabilityReplica1BackupPriority
-                BasicAvailabilityGroup = $mockAvailabilityGroup1BasicAvailabilityGroup
-                DatabaseHealthTrigger = $mockAvailabilityGroup1DatabaseHealthTrigger
-                DtcSupportEnabled = $mockAvailabilityGroup1DtcSupportEnabled
-                EndpointHostName = $mockServer1Name
-                Ensure = 'Present'
-                ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
-                ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
-                FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
-                FailoverMode = $mockAvailabilityReplica1FailoverMode
-                HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
-            }
+        $mockResourceParameters = @{
+            Name                          = $mockAvailabilityGroup1Name
+            SQLServer                     = $mockServer1Name
+            SQLInstanceName               = $mockServer1ServiceName
+            AutomatedBackupPreference     = $mockAvailabilityGroup1AutomatedBackupPreference
+            AvailabilityMode              = $mockAvailabilityReplica1AvailabilityMode
+            BackupPriority                = $mockAvailabilityReplica1BackupPriority
+            BasicAvailabilityGroup        = $mockAvailabilityGroup1BasicAvailabilityGroup
+            DatabaseHealthTrigger         = $mockAvailabilityGroup1DatabaseHealthTrigger
+            DtcSupportEnabled             = $mockAvailabilityGroup1DtcSupportEnabled
+            EndpointHostName              = $mockServer1Name
+            Ensure                        = 'Present'
+            ConnectionModeInPrimaryRole   = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+            ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+            FailureConditionLevel         = $mockAvailabilityGroup1FailureConditionLevel
+            FailoverMode                  = $mockAvailabilityReplica1FailoverMode
+            HealthCheckTimeout            = $mockAvailabilityGroup1HealthCheckTimeout
+        }
         #endregion configuration parameters
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroup\Get-TargetResource' {
             BeforeAll {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer1Name
+                }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer2Name
+                }
 
                 $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
                 $mockAvailabilityReplicaEndpointPort = 5022
@@ -365,43 +369,43 @@ try
                 $mockDatabaseMirroringEndpointPort = 5022
 
                 #region test cases
-                    $absentTestCases = @(
-                        @{
-                            Name =$mockAvailabilityGroupAbsentName
-                            Version = 12
-                        },
-                        @{
-                            Name =$mockAvailabilityGroupAbsentName
-                            Version = 13
-                        }
-                    )
+                $absentTestCases = @(
+                    @{
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Version = 12
+                    },
+                    @{
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Version = 13
+                    }
+                )
 
-                    $presentTestCases = @(
-                        @{
-                            Ensure = 'Present'
-                            Name =$mockAvailabilityGroup1Name
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Present'
-                            Name =$mockAvailabilityGroup1Name
-                            Version = 13
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name =$mockAvailabilityGroup1Name
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name =$mockAvailabilityGroup1Name
-                            Version = 13
-                        }
-                    )
+                $presentTestCases = @(
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroup1Name
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroup1Name
+                        Version = 13
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroup1Name
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroup1Name
+                        Version = 13
+                    }
+                )
                 #endregion test cases
             }
 
-            Context 'When the Availability Group is Absent'{
+            Context 'When the Availability Group is Absent' {
 
                 It 'Should not return an Availability Group when Ensure is set to Present and the SQL version is <Version>' -TestCases $absentTestCases {
                     param
@@ -413,12 +417,16 @@ try
                     $result = Get-TargetResource @getTargetResourceParameters -Name $Name
                     $result.Ensure | Should Be 'Absent'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                 }
             }
 
-            Context 'When the Availability Group is Present'{
+            Context 'When the Availability Group is Present' {
                 It 'Should return the correct Availability Group properties when Ensure is set to <Ensure> and the SQL version is <Version>' -TestCases $presentTestCases {
                     param
                     (
@@ -463,135 +471,163 @@ try
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroup\Set-TargetResource' {
             BeforeAll {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer1Name
+                }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer2Name
+                }
                 Mock -CommandName Invoke-Query -MockWith {} -Verifiable
                 Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
-                Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                Mock -CommandName New-SqlAvailabilityGroup { throw 'CreateAvailabilityGroupFailed' } -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
-                Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -Verifiable
-                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
-                Mock -CommandName Test-ClusterPermissions -MockWith { $mockClusterPermissionsExist } -Verifiable
+                Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter {
+                    $Name -eq $mockAvailabilityGroupPresentName
+                }
+                Mock -CommandName New-SqlAvailabilityGroup {
+                    throw 'CreateAvailabilityGroupFailed'
+                } -Verifiable -ParameterFilter {
+                    $Name -eq $mockAvailabilityGroupCreateErrorName
+                }
+                Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -ParameterFilter {
+                    $Name -eq $mockAvailabilityGroupReplicaPresentName
+                }
+                Mock -CommandName New-SqlAvailabilityReplica -MockWith {
+                    throw 'CreateAvailabilityGroupReplicaFailed'
+                } -Verifiable -ParameterFilter {
+                    $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                }
+                Mock -CommandName New-TerminatingError -MockWith {
+                    $ErrorType
+                } -Verifiable
+                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -ParameterFilter {
+                    $InputObject.Name -eq $mockAvailabilityGroup1Name
+                }
+                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {
+                    throw 'RemoveAvailabilityGroupFailed'
+                } -Verifiable -ParameterFilter {
+                    $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                }
+                Mock -CommandName Test-ClusterPermissions -MockWith {
+                    $mockClusterPermissionsExist
+                } -Verifiable
                 Mock -CommandName Update-AvailabilityGroup -MockWith $mockUpdateAvailabiltyGroup -Verifiable
                 Mock -CommandName Update-AvailabilityGroupReplica -MockWith $mockUpdateAvailabiltyGroupReplica -Verifiable
 
                 #region test cases
-                    $versionsToTest = @(12,13)
+                $versionsToTest = @(12, 13)
 
-                    $createAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
+                $createAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
 
-                        return @{
-                            Name = $mockAvailabilityGroupPresentName
-                            Version = $versionToTest
-                        }
+                    return @{
+                        Name    = $mockAvailabilityGroupPresentName
+                        Version = $versionToTest
                     }
+                }
 
-                    $removeAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
+                $removeAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
 
-                        return @{
-                            Version = $versionToTest
-                        }
+                    return @{
+                        Version = $versionToTest
                     }
+                }
 
-                    [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
+                [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
 
-                        $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
-                            if ( @('Name','SQLServer','SQLInstanceName','DtcSupportEnabled') -notcontains $_.Key )
+                    $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
+                        if ( @('Name', 'SQLServer', 'SQLInstanceName', 'DtcSupportEnabled') -notcontains $_.Key )
+                        {
+                            $currentParameter = $_.Key
+
+                            # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
+                            if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
                             {
-                                $currentParameter = $_.Key
+                                # Move to the next parameter
+                                return
+                            }
 
-                                # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
-                                if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
+                            # Get the current parameter object
+                            $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
+
+                            switch ( $currentParameterObject.ParameterType.ToString() )
+                            {
+                                'System.Boolean'
                                 {
-                                    # Move to the next parameter
-                                    return
+                                    # Get the opposite value of what is supplied
+                                    $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
                                 }
 
-                                # Get the current parameter object
-                                $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
-
-                                switch ( $currentParameterObject.ParameterType.ToString() )
+                                'System.UInt32'
                                 {
-                                    'System.Boolean'
+                                    # Change the supplied number to something else. Absolute value is to protect against zero minus 1
+                                    $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter - 1 ) )
+                                }
+
+                                'System.String'
+                                {
+                                    # Get the valid values for the current parameter
+                                    $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
+
+                                    # Select a value other than what is defined in the mocks
+                                    $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript {
+                                        $_ -ne $mockResourceParameters.$currentParameter
+                                    } | Select-Object -First 1
+
+                                    # If the value is null or empty, set it to something
+                                    if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
                                     {
-                                        # Get the opposite value of what is supplied
-                                        $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
-                                    }
-
-                                    'System.UInt32'
-                                    {
-                                        # Change the supplied number to something else. Absolute value is to protect against zero minus 1
-                                        $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter -1 ) )
-                                    }
-
-                                    'System.String'
-                                    {
-                                        # Get the valid values for the current parameter
-                                        $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
-
-                                        # Select a value other than what is defined in the mocks
-                                        $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript { $_ -ne $mockResourceParameters.$currentParameter } | Select-Object -First 1
-
-                                        # If the value is null or empty, set it to something
-                                        if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
-                                        {
-                                            $testCaseParameterValue = 'IncorrectValue'
-                                        }
-                                    }
-
-                                    default
-                                    {
-                                        $testCaseParameterValue = $null
+                                        $testCaseParameterValue = 'IncorrectValue'
                                     }
                                 }
 
-                                return @{
-                                    Ensure = 'Present'
-                                    Parameter = $currentParameter
-                                    ParameterValue = $testCaseParameterValue
-                                    Version = $versionToTest
+                                default
+                                {
+                                    $testCaseParameterValue = $null
                                 }
                             }
-                        }
 
-                        # One-off test for when the endpoint host name is not specified
-                        return @{
-                            Ensure = 'Present'
-                            Parameter = 'EndpointHostName'
-                            ParameterValue = ''
-                            Version = $versionToTest
+                            return @{
+                                Ensure         = 'Present'
+                                Parameter      = $currentParameter
+                                ParameterValue = $testCaseParameterValue
+                                Version        = $versionToTest
+                            }
                         }
                     }
 
-                    # Build a few test cases specifically for the EndpointUrl components
-                    [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
-
-                        return @(
-                             @{
-                                Ensure = 'Present'
-                                MockVariableName = 'mockAvailabilityReplicaEndpointProtocol'
-                                MockVariableValue = 'UDP'
-                                Version = $versionToTest
-                            },
-                            @{
-                                Ensure = 'Present'
-                                MockVariableName = 'mockAvailabilityReplicaEndpointPort'
-                                MockVariableValue = 1234
-                                Version = $versionToTest
-                            }
-                        )
+                    # One-off test for when the endpoint host name is not specified
+                    return @{
+                        Ensure         = 'Present'
+                        Parameter      = 'EndpointHostName'
+                        ParameterValue = ''
+                        Version        = $versionToTest
                     }
+                }
+
+                # Build a few test cases specifically for the EndpointUrl components
+                [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
+
+                    return @(
+                        @{
+                            Ensure            = 'Present'
+                            MockVariableName  = 'mockAvailabilityReplicaEndpointProtocol'
+                            MockVariableValue = 'UDP'
+                            Version           = $versionToTest
+                        },
+                        @{
+                            Ensure            = 'Present'
+                            MockVariableName  = 'mockAvailabilityReplicaEndpointPort'
+                            MockVariableValue = 1234
+                            Version           = $versionToTest
+                        }
+                    )
+                }
                 #endregion test cases
             }
 
-            BeforeEach{
+            BeforeEach {
                 $mockAvailabilityReplicaEndpointPort = 5022
                 $mockAvailabilityReplicaEndpointProtocol = $mockAvailabilityReplica1EndpointProtocol
                 $mockClusterPermissionsExist = $true
@@ -618,13 +654,25 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -638,13 +686,25 @@ try
 
                     { Set-TargetResource @mockResourceParameters } | Should Throw 'HadrNotEnabled'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
@@ -658,13 +718,25 @@ try
 
                     { Set-TargetResource @mockResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -685,13 +757,25 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -711,16 +795,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Throw 'CreateAvailabilityGroupFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
@@ -744,16 +844,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
@@ -772,16 +888,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Throw 'InstanceNotPrimaryReplica'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
@@ -801,16 +933,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
@@ -827,16 +975,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
@@ -891,16 +1055,32 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times $assertConnectSql -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times $assertConnectSql -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times $assertRemoveSqlAvailabilityGroup -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times $assertRemoveSqlAvailabilityGroup -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times $assertTestClusterPermissions -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times $assertUpdateAvailabilityGroup -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times $assertUpdateAvailabilityGroupReplica -Exactly
@@ -919,16 +1099,32 @@ try
 
                     { Set-TargetResource @mockResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaAbsentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupReplicaPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupPresentName
+                    }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $Name -eq $mockAvailabilityGroupCreateErrorName
+                    }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroup1Name
+                    }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName
+                    }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
@@ -938,8 +1134,12 @@ try
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Test-TargetResource" {
             BeforeAll {
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer1Name
+                }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer2Name
+                }
 
                 $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
                 $mockAvailabilityReplicaEndpointPort = 5022
@@ -949,155 +1149,157 @@ try
                 $mockDatabaseMirroringEndpointPort = 5022
 
                 #region test cases
-                    $versionsToTest = @(12,13)
-                    $absentTestCases = @(
-                        @{
-                            Ensure = 'Present'
-                            Name = $mockAvailabilityGroupAbsentName
-                            Result = $false
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Present'
-                            Name = $mockAvailabilityGroupAbsentName
-                            Result = $false
-                            Version = 13
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name = $mockAvailabilityGroupAbsentName
-                            Result = $true
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name = $mockAvailabilityGroupAbsentName
-                            Result = $true
-                            Version = 13
-                        }
-                    )
+                $versionsToTest = @(12, 13)
+                $absentTestCases = @(
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Result  = $false
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Result  = $false
+                        Version = 13
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Result  = $true
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroupAbsentName
+                        Result  = $true
+                        Version = 13
+                    }
+                )
 
-                    $presentTestCases = @(
-                        @{
-                            Ensure = 'Present'
-                            Name =$mockAvailabilityGroup1Name
-                            Result = $true
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Present'
-                            Name =$mockAvailabilityGroup1Name
-                            Result = $true
-                            Version = 13
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name =$mockAvailabilityGroup1Name
-                            Result = $false
-                            Version = 12
-                        },
-                        @{
-                            Ensure = 'Absent'
-                            Name =$mockAvailabilityGroup1Name
-                            Result = $false
-                            Version = 13
-                        }
-                    )
+                $presentTestCases = @(
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroup1Name
+                        Result  = $true
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Present'
+                        Name    = $mockAvailabilityGroup1Name
+                        Result  = $true
+                        Version = 13
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroup1Name
+                        Result  = $false
+                        Version = 12
+                    },
+                    @{
+                        Ensure  = 'Absent'
+                        Name    = $mockAvailabilityGroup1Name
+                        Result  = $false
+                        Version = 13
+                    }
+                )
 
-                    [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
+                [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
 
-                        $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
-                            if ( @('Name','SQLServer','SQLInstanceName','DtcSupportEnabled') -notcontains $_.Key )
+                    $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
+                        if ( @('Name', 'SQLServer', 'SQLInstanceName', 'DtcSupportEnabled') -notcontains $_.Key )
+                        {
+                            $currentParameter = $_.Key
+
+                            # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
+                            if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
                             {
-                                $currentParameter = $_.Key
+                                # Move to the next parameter
+                                return
+                            }
 
-                                # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
-                                if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
+                            # Get the current parameter object
+                            $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
+
+                            switch ( $currentParameterObject.ParameterType.ToString() )
+                            {
+                                'System.Boolean'
                                 {
-                                    # Move to the next parameter
-                                    return
+                                    # Get the opposite value of what is supplied
+                                    $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
                                 }
 
-                                # Get the current parameter object
-                                $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
-
-                                switch ( $currentParameterObject.ParameterType.ToString() )
+                                'System.UInt32'
                                 {
-                                    'System.Boolean'
+                                    # Change the supplied number to something else. Absolute value is to protect against zero minus 1
+                                    $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter - 1 ) )
+                                }
+
+                                'System.String'
+                                {
+                                    # Get the valid values for the current parameter
+                                    $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
+
+                                    # Select a value other than what is defined in the mocks
+                                    $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript {
+                                        $_ -ne $mockResourceParameters.$currentParameter
+                                    } | Select-Object -First 1
+
+                                    # If the value is null or empty, set it to something
+                                    if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
                                     {
-                                        # Get the opposite value of what is supplied
-                                        $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
-                                    }
-
-                                    'System.UInt32'
-                                    {
-                                        # Change the supplied number to something else. Absolute value is to protect against zero minus 1
-                                        $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter -1 ) )
-                                    }
-
-                                    'System.String'
-                                    {
-                                        # Get the valid values for the current parameter
-                                        $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
-
-                                        # Select a value other than what is defined in the mocks
-                                        $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript { $_ -ne $mockResourceParameters.$currentParameter } | Select-Object -First 1
-
-                                        # If the value is null or empty, set it to something
-                                        if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
-                                        {
-                                            $testCaseParameterValue = 'IncorrectValue'
-                                        }
-                                    }
-
-                                    default
-                                    {
-                                        $testCaseParameterValue = $null
+                                        $testCaseParameterValue = 'IncorrectValue'
                                     }
                                 }
 
-                                return @{
-                                    Ensure = 'Present'
-                                    Result = $false
-                                    Parameter = $currentParameter
-                                    ParameterValue = $testCaseParameterValue
-                                    Version = $versionToTest
+                                default
+                                {
+                                    $testCaseParameterValue = $null
                                 }
                             }
-                        }
 
-                        # One-off test for when the endpoint host name is not specified
-                        return @{
-                            Ensure = 'Present'
-                            Result = $true
-                            Parameter = 'EndpointHostName'
-                            ParameterValue = ''
-                            Version = $versionToTest
+                            return @{
+                                Ensure         = 'Present'
+                                Result         = $false
+                                Parameter      = $currentParameter
+                                ParameterValue = $testCaseParameterValue
+                                Version        = $versionToTest
+                            }
                         }
                     }
 
-                    # Build a few test cases specifically for the EndpointUrl components
-                    [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
-                        $versionToTest = $_
-
-                        return @(
-                             @{
-                                Ensure = 'Present'
-                                Result = $false
-                                MockVariableName = 'mockAvailabilityReplicaEndpointProtocol'
-                                MockVariableValue = 'UDP'
-                                Version = $versionToTest
-                            },
-                            @{
-                                Ensure = 'Present'
-                                Result = $false
-                                MockVariableName = 'mockAvailabilityReplicaEndpointPort'
-                                MockVariableValue = 1234
-                                Version = $versionToTest
-                            }
-                        )
+                    # One-off test for when the endpoint host name is not specified
+                    return @{
+                        Ensure         = 'Present'
+                        Result         = $true
+                        Parameter      = 'EndpointHostName'
+                        ParameterValue = ''
+                        Version        = $versionToTest
                     }
+                }
+
+                # Build a few test cases specifically for the EndpointUrl components
+                [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
+                    $versionToTest = $_
+
+                    return @(
+                        @{
+                            Ensure            = 'Present'
+                            Result            = $false
+                            MockVariableName  = 'mockAvailabilityReplicaEndpointProtocol'
+                            MockVariableValue = 'UDP'
+                            Version           = $versionToTest
+                        },
+                        @{
+                            Ensure            = 'Present'
+                            Result            = $false
+                            MockVariableName  = 'mockAvailabilityReplicaEndpointPort'
+                            MockVariableValue = 1234
+                            Version           = $versionToTest
+                        }
+                    )
+                }
                 #endregion test cases
             }
 
@@ -1118,8 +1320,10 @@ try
 
                     Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name }
                 }
             }
 
@@ -1140,8 +1344,12 @@ try
 
                     Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                 }
 
                 It 'Should be "<Result>" when the desired state is "<Ensure>", the parameter "<Parameter>" is not "<ParameterValue>", and the SQL version is "<Version>"' -TestCases $presentParameterTestCases {
@@ -1159,8 +1367,12 @@ try
 
                     Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                 }
 
                 It 'Should be "<Result>" when the desired state is "<Ensure>", the mock "<MockVariableName>" is "<ParameterValue>", and the SQL version is "<Version>"' -TestCases $presentEndpointUrlTestCases {
@@ -1177,8 +1389,12 @@ try
 
                     Test-TargetResource @mockResourceParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    }
                 }
 
             }
@@ -1186,7 +1402,9 @@ try
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Update-AvailabilityGroup" {
             BeforeAll {
-                Mock -CommandName New-TerminatingError -MockWith { $ErrorType }
+                Mock -CommandName New-TerminatingError -MockWith {
+                    $ErrorType
+                }
 
                 $mockAvailabilityGroup = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
             }

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -19,8 +19,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
 Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SMO.cs )
 
-
-
 # Begin Testing
 try
 {
@@ -45,8 +43,19 @@ try
                 'DtcSupportEnabled'
             )
 
+            # The following will be set dynamically during tests
+            $mockAvailabilityGroupName = ''
+            $mockAvailabilityReplicaEndpointProtocol = ''
+            $mockAvailabilityReplicaEndpointPort = 0
+            $mockDatabaseMirroringEndpointProtocol = ''
+            $mockDatabaseMirroringEndpointPort = 0
+
             $mockAvailabilityGroupAbsentName = 'AbsentAvailabilityGroup'
+            $mockAvailabilityGroupCreateErrorName = 'ErrorCreateAvailabilityGroup'
             $mockAvailabilityGroupPresentName = 'NewAvailabilityGroup'
+            $mockAvailabilityGroupRemoveErrorName = 'ErrorRemoveAvailabilityGroup'
+            $mockAvailabilityGroupReplicaAbsentName = $mockServer2Name
+            $mockAvailabilityGroupReplicaPresentName = $mockServer1Name
 
             $mockAvailabilityGroup1Name = 'AvailabilityGroup1'
             $mockAvailabilityGroup1BasicAvailabilityGroup = $false
@@ -55,6 +64,7 @@ try
             $mockAvailabilityGroup1AutomatedBackupPreference = 'Secondary'
             $mockAvailabilityGroup1FailureConditionLevel = 'OnCriticalServerErrors'
             $mockAvailabilityGroup1HealthCheckTimeout = 30000
+            $mockAvailabilityGroup1PrimaryReplicaServerName = $mockServer1Name
 
             $mockAvailabilityReplica1Name = $mockServer1Name
             $mockAvailabilityReplica1AvailabilityMode = 'AsynchronousCommit'
@@ -66,6 +76,17 @@ try
             $mockAvailabilityReplica1EndpointPort = 5022
             $mockAvailabilityReplica1FailoverMode = 'Manual'
             $mockAvailabilityReplica1Role = 'Primary'
+
+            $mockAvailabilityReplica2Name = $mockServer2Name
+            $mockAvailabilityReplica2AvailabilityMode = 'AsynchronousCommit'
+            $mockAvailabilityReplica2BackupPriority = 50
+            $mockAvailabilityReplica2ConnectionModeInPrimaryRole = 'AllowAllConnections'
+            $mockAvailabilityReplica2ConnectionModeInSecondaryRole = 'AllowNoConnections'
+            $mockAvailabilityReplica2EndpointHostName = $mockServer2Name
+            $mockAvailabilityReplica2EndpointProtocol = 'TCP'
+            $mockAvailabilityReplica2EndpointPort = 5022
+            $mockAvailabilityReplica2FailoverMode = 'Manual'
+            $mockAvailabilityReplica2Role = 'Primary'
 
         #endregion mock availability group variables
 
@@ -96,7 +117,8 @@ try
             $mockAvailabilityGroup1Object.AutomatedBackupPreference = $mockAvailabilityGroup1AutomatedBackupPreference
             $mockAvailabilityGroup1Object.FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
             $mockAvailabilityGroup1Object.HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
-            $mockAvailabilityGroup1Object.Name = $mockAvailabilityGroup1Name
+            $mockAvailabilityGroup1Object.Name = $mockAvailabilityGroupName
+            $mockAvailabilityGroup1Object.PrimaryReplicaServerName = $mockAvailabilityGroup1PrimaryReplicaServerName
             if ( $Version -ge 13 )
             {
                 $mockAvailabilityGroup1Object.BasicAvailabilityGroup = $mockAvailabilityGroup1BasicAvailabilityGroup
@@ -108,23 +130,28 @@ try
             $mockAvailabilityReplica1Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityReplica1Object.Name = $mockAvailabilityReplica1Name
             $mockAvailabilityReplica1Object.AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
-            $mockAvailabilityReplica1Object.BackupPriority = $mockAvailabilityReplica1BackupPriority
+            $mockAvailabilityReplica1Object.BackupPriority = $mockAvailabilityReplica2BackupPriority
             $mockAvailabilityReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
             $mockAvailabilityReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
-            $mockAvailabilityReplica1Object.EndpointUrl = "$($mockAvailabilityReplica1EndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplica1EndpointPort)"
+            $mockAvailabilityReplica1Object.EndpointUrl = "$($mockAvailabilityReplicaEndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplicaEndpointPort)"
             $mockAvailabilityReplica1Object.FailoverMode = $mockAvailabilityReplica1FailoverMode
             $mockAvailabilityReplica1Object.Role = $mockAvailabilityReplica1Role
 
+            # Define the availability replica 2 object
+            $mockAvailabilityReplica2Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityReplica2Object.Name = $mockAvailabilityReplica2Name
+            $mockAvailabilityReplica2Object.AvailabilityMode = $mockAvailabilityReplica2AvailabilityMode
+            $mockAvailabilityReplica2Object.BackupPriority = $mockAvailabilityReplica1BackupPriority
+            $mockAvailabilityReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityReplica2ConnectionModeInPrimaryRole
+            $mockAvailabilityReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityReplica2ConnectionModeInSecondaryRole
+            $mockAvailabilityReplica2Object.EndpointUrl = "$($mockAvailabilityReplica2EndpointProtocol)://$($mockAvailabilityReplica2EndpointHostName):$($mockAvailabilityReplica2EndpointPort)"
+            $mockAvailabilityReplica2Object.FailoverMode = $mockAvailabilityReplica2FailoverMode
+            $mockAvailabilityReplica2Object.Role = $mockAvailabilityReplica2Role
+
             # Add the availability group to the server object
             $mockAvailabilityGroup1Object.AvailabilityReplicas.Add($mockAvailabilityReplica1Object)
+            $mockAvailabilityGroup1Object.AvailabilityReplicas.Add($mockAvailabilityReplica2Object)
             $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1Object)
-
-            # Add the master database
-            <#
-            $mockMasterDatabase = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database
-            $mockMasterDatabase.Name = 'master'
-            $mockServerObject.Databases.Add($mockMasterDatabase)
-            #>
 
             # Define the database mirroring endpoint object
             if ( $mockDatabaseMirroringEndpointPresent )
@@ -132,18 +159,12 @@ try
                 $mockDatabaseMirroringEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
                 $mockDatabaseMirroringEndpoint.EndpointType = 'DatabaseMirroring'
                 $mockDatabaseMirroringEndpoint.Protocol = @{
-                    TCP = @{
-                        ListenerPort = $mockAvailabilityReplica1EndpointPort
+                    $mockDatabaseMirroringEndpointProtocol = @{
+                        ListenerPort = $mockDatabaseMirroringEndpointPort
                     }
                 }
                 $mockServerObject.Endpoints.Add($mockDatabaseMirroringEndpoint)
             }
-
-            # Add the login the cluster will use to authenticate to SQL Server
-            <#
-            $mockClusterLoginObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockClusterLoginName)
-            $mockServerObject.Logins.Add($mockClusterLoginName,$mockClusterLoginObject)
-            #>
 
             return $mockServerObject
         }
@@ -159,6 +180,61 @@ try
                 [string]
                 $SQLInstanceName
             )
+
+            # Define the server object
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $mockServerObject.IsHadrEnabled = $mockIsHadrEnabled
+            $mockServerObject.Name = $mockServer2Name
+            $mockServerObject.NetName = $mockServer2Name
+            $mockServerObject.ServiceName = $mockServer2ServiceName
+            $mockServerObject.Version = @{
+                Major = $Version
+            }
+
+            # Define the database mirroring endpoint object
+            if ( $mockDatabaseMirroringEndpointPresent )
+            {
+                $mockDatabaseMirroringEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
+                $mockDatabaseMirroringEndpoint.EndpointType = 'DatabaseMirroring'
+                $mockDatabaseMirroringEndpoint.Protocol = @{
+                    TCP = @{
+                        ListenerPort = $mockAvailabilityReplica1EndpointPort
+                    }
+                }
+                $mockServerObject.Endpoints.Add($mockDatabaseMirroringEndpoint)
+            }
+
+            # Define the availability group 1 object
+            $mockAvailabilityGroup1Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup1Object.AutomatedBackupPreference = $mockAvailabilityGroup1AutomatedBackupPreference
+            $mockAvailabilityGroup1Object.FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
+            $mockAvailabilityGroup1Object.HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
+            $mockAvailabilityGroup1Object.Name = $mockAvailabilityGroupName
+            $mockAvailabilityGroup1Object.LocalReplicaRole = 'Secondary'
+            $mockAvailabilityGroup1Object.PrimaryReplicaServerName = $mockAvailabilityGroup1PrimaryReplicaServerName
+            if ( $Version -ge 13 )
+            {
+                $mockAvailabilityGroup1Object.BasicAvailabilityGroup = $mockAvailabilityGroup1BasicAvailabilityGroup
+                $mockAvailabilityGroup1Object.DatabaseHealthTrigger = $mockAvailabilityGroup1DatabaseHealthTrigger
+                $mockAvailabilityGroup1Object.DtcSupportEnabled = $mockAvailabilityGroup1DtcSupportEnabled
+            }
+
+            # Define the availability replica 1 object
+            $mockAvailabilityReplica1Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityReplica1Object.Name = $mockAvailabilityReplica1Name
+            $mockAvailabilityReplica1Object.AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
+            $mockAvailabilityReplica1Object.BackupPriority = $mockAvailabilityReplica1BackupPriority
+            $mockAvailabilityReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+            $mockAvailabilityReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+            $mockAvailabilityReplica1Object.EndpointUrl = "$($mockAvailabilityReplicaEndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplica1EndpointPort)"
+            $mockAvailabilityReplica1Object.FailoverMode = $mockAvailabilityReplica1FailoverMode
+            $mockAvailabilityReplica1Object.Role = $mockAvailabilityReplica1Role
+
+            # Add the availability group to the server object
+            $mockAvailabilityGroup1Object.AvailabilityReplicas.Add($mockAvailabilityReplica1Object)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1Object)
+
+            return $mockServerObject
         }
 
         $mockNewSqlAvailabilityReplica = {
@@ -168,11 +244,76 @@ try
             $mock.BackupPriority = $mockAvailabilityReplica1BackupPriority
             $mock.ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
             $mock.ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
-            $mock.EndpointUrl = "$($mockAvailabilityReplica1EndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplica1EndpointPort)"
+            $mock.EndpointUrl = "$($mockAvailabilityReplicaEndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplicaEndpointPort)"
             $mock.FailoverMode = $mockAvailabilityReplica1FailoverMode
             $mock.Role = $mockAvailabilityReplica1Role
 
             return $mock
+        }
+
+        # Mock the Update-AvailabilityGroup function to ensure the specified property was set correctly
+        $mockUpdateAvailabiltyGroup = {
+            param
+            (
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup
+            )
+
+            # If the current value of the property that was set is not equal to the desired value
+            if ( $ParameterValue -ne $AvailabilityGroup.$Parameter )
+            {
+                $AvailabilityGroup | Get-Member -MemberType Property | Select-Object -ExpandProperty Name | ForEach-Object -Process {
+                    $currentProperty = $_
+
+                    Write-Verbose -Message "The property '$($currentProperty)' value is '$($AvailabilityGroup.$Parameter)' but should be '$($ParameterValue)'." -Verbose
+                }
+
+                throw "Update-AvailabilityGroup should be setting the property '$($Parameter)' to '$($ParameterValue)'."
+            }
+        }
+
+        # Mock the Update-AvailabilityGroupReplica function to ensure the specified property was set correctly
+        $mockUpdateAvailabiltyGroupReplica = {
+            param
+            (
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityReplica]
+                $AvailabilityGroupReplica
+            )
+
+            if ( [string]::IsNullOrEmpty($Parameter) -and [string]::IsNullOrEmpty($ParameterValue) )
+            {
+                return
+            }
+
+            # Some parameters don't align directly with a property
+            switch ( $Parameter )
+            {
+                EndpointHostName
+                {
+                    $validatedParameter = 'EndpointUrl'
+                    $validatedParameterValue = "$($mockAvailabilityReplicaEndpointProtocol)://$($ParameterValue):$($mockAvailabilityReplicaEndpointPort)"
+                }
+
+                default
+                {
+                    $validatedParameter = $Parameter
+                    $validatedParameterValue = $ParameterValue
+                }
+            }
+
+            # If the current value of the property that was set is not equal to the desired value
+            if ( $validatedParameterValue -ne $AvailabilityGroupReplica.$validatedParameter )
+            {
+                $AvailabilityGroupReplica | Get-Member -MemberType Property | Select-Object -ExpandProperty Name | ForEach-Object -Process {
+                    $currentProperty = $_
+
+                    Write-Verbose -Message "The property '$($currentProperty)' value is '$($AvailabilityGroupReplica.$validatedParameter)' but should be '$($validatedParameterValue)'." -Verbose
+                }
+
+                throw "Update-AvailabilityGroupReplica should be setting the property '$($validatedParameter)' to '$($validatedParameterValue)'."
+            }
         }
 
         #region configuration parameters
@@ -196,6 +337,7 @@ try
                 ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
                 ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
                 FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
+                FailoverMode = $mockAvailabilityReplica1FailoverMode
                 HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
             }
         #endregion configuration parameters
@@ -205,7 +347,12 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
 
+                $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
+                $mockAvailabilityReplicaEndpointPort = 5022
+                $mockAvailabilityReplicaEndpointProtocol = $mockAvailabilityReplica1EndpointProtocol
                 $mockDatabaseMirroringEndpointPresent = $true
+                $mockDatabaseMirroringEndpointProtocol = 'TCP'
+                $mockDatabaseMirroringEndpointPort = 5022
 
                 #region test cases
                     $absentTestCases = @(
@@ -305,40 +452,148 @@ try
         }
 
         Describe 'xSQLServerAlwaysOnAvailabilityGroup\Set-TargetResource' {
+            BeforeAll {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                Mock -CommandName Invoke-Query -MockWith {} -Verifiable
+                Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
+                Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                Mock -CommandName New-SqlAvailabilityGroup { throw 'CreateAvailabilityGroupFailed' } -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -Verifiable
+                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                Mock -CommandName Test-ClusterPermissions -MockWith { $mockClusterPermissionsExist } -Verifiable
+                Mock -CommandName Update-AvailabilityGroup -MockWith $mockUpdateAvailabiltyGroup -Verifiable
+                Mock -CommandName Update-AvailabilityGroupReplica -MockWith $mockUpdateAvailabiltyGroupReplica -Verifiable
+
+                #region test cases
+                    $versionsToTest = @(12,13)
+
+                    $createAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        return @{
+                            Name = $mockAvailabilityGroupPresentName
+                            Version = $versionToTest
+                        }
+                    }
+
+                    $removeAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        return @{
+                            Version = $versionToTest
+                        }
+                    }
+
+                    [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
+                            if ( @('Name','SQLServer','SQLInstanceName','DtcSupportEnabled') -notcontains $_.Key )
+                            {
+                                $currentParameter = $_.Key
+
+                                # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
+                                if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
+                                {
+                                    # Move to the next parameter
+                                    return
+                                }
+
+                                # Get the current parameter object
+                                $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
+
+                                switch ( $currentParameterObject.ParameterType.ToString() )
+                                {
+                                    'System.Boolean'
+                                    {
+                                        # Get the opposite value of what is supplied
+                                        $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
+                                    }
+
+                                    'System.UInt32'
+                                    {
+                                        # Change the supplied number to something else. Absolute value is to protect against zero minus 1
+                                        $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter -1 ) )
+                                    }
+
+                                    'System.String'
+                                    {
+                                        # Get the valid values for the current parameter
+                                        $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
+
+                                        # Select a value other than what is defined in the mocks
+                                        $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript { $_ -ne $mockResourceParameters.$currentParameter } | Select-Object -First 1
+
+                                        # If the value is null or empty, set it to something
+                                        if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
+                                        {
+                                            $testCaseParameterValue = 'IncorrectValue'
+                                        }
+                                    }
+
+                                    default
+                                    {
+                                        $testCaseParameterValue = $null
+                                    }
+                                }
+
+                                return @{
+                                    Ensure = 'Present'
+                                    Parameter = $currentParameter
+                                    ParameterValue = $testCaseParameterValue
+                                    Version = $versionToTest
+                                }
+                            }
+                        }
+
+                        # One-off test for when the endpoint host name is not specified
+                        return @{
+                            Ensure = 'Present'
+                            Parameter = 'EndpointHostName'
+                            ParameterValue = ''
+                            Version = $versionToTest
+                        }
+                    }
+
+                    # Build a few test cases specifically for the EndpointUrl components
+                    [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        return @(
+                             @{
+                                Ensure = 'Present'
+                                MockVariableName = 'mockAvailabilityReplicaEndpointProtocol'
+                                MockVariableValue = 'UDP'
+                                Version = $versionToTest
+                            },
+                            @{
+                                Ensure = 'Present'
+                                MockVariableName = 'mockAvailabilityReplicaEndpointPort'
+                                MockVariableValue = 1234
+                                Version = $versionToTest
+                            }
+                        )
+                    }
+                #endregion test cases
+            }
+
+            BeforeEach{
+                $mockAvailabilityReplicaEndpointPort = 5022
+                $mockAvailabilityReplicaEndpointProtocol = $mockAvailabilityReplica1EndpointProtocol
+                $mockClusterPermissionsExist = $true
+                $mockDatabaseMirroringEndpointPresent = $true
+                $mockDatabaseMirroringEndpointProtocol = 'TCP'
+                $mockDatabaseMirroringEndpointPort = 5022
+                $mockIsHadrEnabled = $true
+            }
 
             Context 'When the Availability Group is Absent' {
                 BeforeAll {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
-                    Mock -CommandName Invoke-Query -MockWith {} -Verifiable
-                    Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -Verifiable
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
-                    Mock -CommandName Test-ClusterPermissions -MockWith { $mockClusterPermissionsExist } -Verifiable
-                    Mock -CommandName Update-AvailabilityGroup -MockWith {} -Verifiable
-                    Mock -CommandName Update-AvailabilityGroupReplica -MockWith {} -Verifiable
-
-                    #region test cases
-                        $versionsToTest = @(12,13)
-                        $loginsToTest = @('NT SERVICE\ClusSvc','NT AUTHORITY\System')
-
-                        $createAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
-                            $versionToTest = $_
-
-                            return @{
-                                Name = $mockAvailabilityGroupPresentName
-                                Version = $versionToTest
-                            }
-                        }
-                    #endregion test cases
-                }
-
-                BeforeEach{
-                    $mockClusterPermissionsExist = $true
-                    $mockDatabaseMirroringEndpointPresent = $true
-                    $mockIsHadrEnabled = $true
+                    $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
                 }
 
                 It 'Should create the Availability Group when Ensure is set to Present and the SQL version is "<Version>"' -TestCases $createAvailabilityGroupTestCases {
@@ -356,8 +611,10 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
                     Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -365,16 +622,19 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error "HadrNotEnabled" when Ensure is set to Present, but Always On is not enabled' {
+                It 'Should throw the correct error "HadrNotEnabled" when Ensure is set to Present, but HADR is not enabled' {
 
                     $mockIsHadrEnabled = $false
 
                     { Set-TargetResource @mockResourceParameters } | Should Throw 'HadrNotEnabled'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
                     Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
@@ -388,10 +648,13 @@ try
 
                     { Set-TargetResource @mockResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
                     Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -399,16 +662,26 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
+                It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is <Version>'  -TestCases $createAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Name,
+                        $Version
+                    )
 
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Name = $Name
+                    $currentTestParameters.SQLServer = $mockServer2Name
 
-                It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 12' {
+                    { Set-TargetResource @currentTestParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
 
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -416,48 +689,28 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 13' {
+                It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is <Version>' -TestCases $createAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Name,
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Name = $mockAvailabilityGroupCreateErrorName
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    { Set-TargetResource @currentTestParameters } | Should Throw 'CreateAvailabilityGroupFailed'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-
-
-                It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 12' {
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 13' {
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
@@ -465,339 +718,175 @@ try
             }
 
             Context 'When the Availability Group is Present' {
+                BeforeEach {
+                    $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
+                    $mockAvailabilityGroup1PrimaryReplicaServerName = $mockServer1Name
+                }
 
-                It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 12' {
+                It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is <Version>' -TestCases $removeAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultPresentParameters } | Should Not Throw
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Ensure = 'Absent'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    { Set-TargetResource @currentTestParameters } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 13' {
+                It 'Should throw the correct error message "InstanceNotPrimaryReplica" when Ensure is "Absent", the primary replica is not on the current instance, and the SQL Version is <Version>' -TestCases $removeAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultPresentParameters } | Should Not Throw
+                    $mockAvailabilityGroup1PrimaryReplicaServerName = $mockServer2Name
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Ensure = 'Absent'
+
+                    { Set-TargetResource @currentTestParameters } | Should Throw 'InstanceNotPrimaryReplica'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should throw the correct error message, InstanceNotPrimaryReplica, when Ensure is set to Absent and the primary replica is not on the current instance' {
-
-                    { Set-TargetResource @defaultPresentParameters } | Should Throw 'InstanceNotPrimaryReplica'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 12' {
+                It 'Should throw the correct error message when Ensure is "Absent", the Availability Group remove fails, and the SQL version is <Version>' -TestCases $removeAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
+                    $mockAvailabilityGroupName = $mockAvailabilityGroupRemoveErrorName
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Ensure = 'Absent'
+                    $currentTestParameters.Name = $mockAvailabilityGroupRemoveErrorName
+
+                    { Set-TargetResource @currentTestParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 13' {
+                It 'Should connect to the instance hosting the primary replica when the LocalReplicaRole is not Primary and the SQL version is <Version>' -TestCases $removeAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.SQLServer = $mockServer2Name
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    { Set-TargetResource @currentTestParameters } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should connect to the instance hosting the primary replica when the LocalReplicaRole is not Primary' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq 'Server2' }
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $Query -match 'NT SERVICE\\ClusSvc' }
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should set the AutomatedBackupPreference to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AutomatedBackupPreference = $defaultPresentParameters.AutomatedBackupPreference
-                }
-
-                It 'Should set the AvailabilityMode to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].AvailabilityMode = $defaultPresentParameters.AvailabilityMode
-                }
-
-                It 'Should set the BackupPriority to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].BackupPriority = $defaultPresentParameters.BackupPriority
-                }
-
-                It 'Should set the BasicAvailabilityGroup to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion13ServerObject.AvailabilityGroups['PresentAG'].BasicAvailabilityGroup = $defaultPresentParameters.BasicAvailabilityGroup
-                }
-
-                It 'Should set the DatabaseHealthTrigger to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion13ServerObject.AvailabilityGroups['PresentAG'].DatabaseHealthTrigger = $defaultPresentParameters.DatabaseHealthTrigger
-                }
-
-                It 'Should not set the DtcSupportEnabled to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion13ServerObject.AvailabilityGroups['PresentAG'].DtcSupportEnabled = $defaultPresentParameters.DtcSupportEnabled
-                }
-
-                It 'Should set the ConnectionModeInPrimaryRole to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].ConnectionModeInPrimaryRole = $defaultPresentParameters.ConnectionModeInPrimaryRole
-                    $mockConnectSqlVersion13ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].ConnectionModeInPrimaryRole = $defaultPresentParameters.ConnectionModeInPrimaryRole
-                }
-
-                It 'Should set the ConnectionModeInSecondaryRole to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].ConnectionModeInSecondaryRole = $defaultPresentParameters.ConnectionModeInSecondaryRole
-                }
-
-                It 'Should set the EndpointUrl to the desired state when the endpoint port is changed' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
 
-                It 'Should set the EndpointUrl to the desired state when the EndpointHostName is specified' {
+                It 'Should set the property "<Parameter>" to the desired state "<ParameterValue>" when the version is "<Version>"' -TestCases $presentParameterTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Parameter,
+                        $ParameterValue,
+                        $Version
+                    )
 
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.$Parameter = $ParameterValue
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    { Set-TargetResource @currentTestParameters } | Should Not Throw
+
+                    #Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    #Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    #Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    #Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
+                    #Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
+                    #Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
+                    #Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
+                }
+
+                It 'Should set the property "EndpointUrl" to the desired state when the mock "<MockVariableName>" is "<MockVariableValue>" and the version is "<Version>"' -TestCases $presentEndpointUrlTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $MockVariableName,
+                        $MockVariableValue,
+                        $Version
+                    )
+
+                    Set-Variable -Name $MockVariableName -Value $MockVariableValue
+
+                    { Set-TargetResource @mockResourceParameters } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaAbsentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupReplicaPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupCreateErrorName }
+                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroup1Name }
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $InputObject.Name -eq $mockAvailabilityGroupRemoveErrorName }
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should set the EndpointUrl to the desired state when the EndpointHostName is not specified' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should set the EndpointUrl to the desired state when the endpoint protocol is changed' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should set the FailureConditionLevel to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should set the FailoverMode to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should set the HealthCheckTimeout to the desired state' {
-
-                    { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
             }
         }
@@ -807,7 +896,12 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
 
+                $mockAvailabilityGroupName = $mockAvailabilityGroup1Name
+                $mockAvailabilityReplicaEndpointPort = 5022
+                $mockAvailabilityReplicaEndpointProtocol = $mockAvailabilityReplica1EndpointProtocol
                 $mockDatabaseMirroringEndpointPresent = $true
+                $mockDatabaseMirroringEndpointProtocol = 'TCP'
+                $mockDatabaseMirroringEndpointPort = 5022
 
                 #region test cases
                     $versionsToTest = @(12,13)
@@ -927,6 +1021,37 @@ try
                                 }
                             }
                         }
+
+                        # One-off test for when the endpoint host name is not specified
+                        return @{
+                            Ensure = 'Present'
+                            Result = $true
+                            Parameter = 'EndpointHostName'
+                            ParameterValue = ''
+                            Version = $versionToTest
+                        }
+                    }
+
+                    # Build a few test cases specifically for the EndpointUrl components
+                    [array]$presentEndpointUrlTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        return @(
+                             @{
+                                Ensure = 'Present'
+                                Result = $false
+                                MockVariableName = 'mockAvailabilityReplicaEndpointProtocol'
+                                MockVariableValue = 'UDP'
+                                Version = $versionToTest
+                            },
+                            @{
+                                Ensure = 'Present'
+                                Result = $false
+                                MockVariableName = 'mockAvailabilityReplicaEndpointPort'
+                                MockVariableValue = 1234
+                                Version = $versionToTest
+                            }
+                        )
                     }
                 #endregion test cases
             }
@@ -993,37 +1118,24 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
 
-                <#It 'Should be $true when the desired state is Present and the Endpoint Host Name is not specified' {
+                It 'Should be "<Result>" when the desired state is "<Ensure>", the mock "<MockVariableName>" is "<ParameterValue>", and the SQL version is "<Version>"' -TestCases $presentEndpointUrlTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Result,
+                        $MockVariableName,
+                        $MockVariableValue,
+                        $Version
+                    )
 
-                    $currentTestParameters = $mockResourceParameters.Clone()
-                    $currentTestParameters.Remove('EndpointHostName')
+                    Set-Variable -Name $MockVariableName -Value $MockVariableValue
 
-                    Test-TargetResource @currentTestParameters | Should Be $true
+                    Test-TargetResource @mockResourceParameters | Should Be $Result
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
 
-                It 'Should be $false when the desired state is Present and the Endpoint Hostname is incorrectly configured' {
-
-                    Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $false when the desired state is Present and the Endpoint Protocol is incorrectly configured' {
-
-                    Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $false when the desired state is Present and the Endpoint Port is incorrectly configured' {
-
-                    Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }#>
             }
         }
 

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -25,604 +25,356 @@ Add-Type -Path ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stub
 try
 {
     InModuleScope $script:DSCResourceName {
-        $defaultAbsentParameters = @{
-            Name = 'AbsentAG'
-            SQLInstanceName = 'MSSQLSERVER'
-            SQLServer = 'Server1'
-            Ensure = 'Present'
-            AutomatedBackupPreference = 'Secondary'
-            AvailabilityMode = 'AsynchronousCommit'
-            BackupPriority = 50
-            BasicAvailabilityGroup = $false
-            DatabaseHealthTrigger = $false
-            DtcSupportEnabled = $false
-            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            FailureConditionLevel = 'OnServerDown'
-            FailoverMode = 'Manual'
-            HealthCheckTimeout = '30000'
-            EndpointHostName = 'Server1'
-        }
 
-        $defaultPresentParameters = @{
-            Name = 'PresentAG'
-            SQLInstanceName = 'MSSQLSERVER'
-            SQLServer = 'Server1'
-            Ensure = 'Present'
-            AutomatedBackupPreference = 'Secondary'
-            AvailabilityMode = 'AsynchronousCommit'
-            BackupPriority = 50
-            BasicAvailabilityGroup = $false
-            DatabaseHealthTrigger = $false
-            DtcSupportEnabled = $false
-            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            FailureConditionLevel = 'OnServerDown'
-            FailoverMode = 'Manual'
-            HealthCheckTimeout = '30000'
-            EndpointHostName = 'Server1'
-        }
+        #region mock server object variables
 
-        #region Login mocks
+            $mockServer1Name = 'Server1'
+            $mockServer1ServiceName = 'MSSQLSERVER'
 
-            $mockLogins = @{} # Will be dynamically set during tests
+            $mockServer2Name = 'Server2'
+            $mockServer2ServiceName = 'MSSQLSERVER'
 
-            $mockNtServiceClusSvcName = 'NT SERVICE\ClusSvc'
-            $mockNtAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
+        #endregion mock server object variables
 
-            $mockAllLoginsAbsent = @{}
+        #region mock availability group variables
 
-            $mockNtServiceClusSvcPresent = @{
-                $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtServiceClusSvcName) )
-            }
+            # Define the properties that are SQL 2016 and newer
+            $sql13AvailabilityGroupProperties = @(
+                'BasicAvailabilityGroup'
+                'DatabaseHealthTrigger'
+                'DtcSupportEnabled'
+            )
 
-            $mockNtAuthoritySystemPresent = @{
-                $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtAuthoritySystemName) )
-            }
+            $mockAvailabilityGroupAbsentName = 'AbsentAvailabilityGroup'
+            $mockAvailabilityGroupPresentName = 'NewAvailabilityGroup'
 
-            $mockAllLoginsPresent = @{
-                $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtServiceClusSvcName) )
-                $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtAuthoritySystemName) )
-            }
+            $mockAvailabilityGroup1Name = 'AvailabilityGroup1'
+            $mockAvailabilityGroup1BasicAvailabilityGroup = $false
+            $mockAvailabilityGroup1DatabaseHealthTrigger = $false
+            $mockAvailabilityGroup1DtcSupportEnabled = $false
+            $mockAvailabilityGroup1AutomatedBackupPreference = 'Secondary'
+            $mockAvailabilityGroup1FailureConditionLevel = 'OnCriticalServerErrors'
+            $mockAvailabilityGroup1HealthCheckTimeout = 30000
 
-        #endregion
+            $mockAvailabilityReplica1Name = $mockServer1Name
+            $mockAvailabilityReplica1AvailabilityMode = 'AsynchronousCommit'
+            $mockAvailabilityReplica1BackupPriority = 50
+            $mockAvailabilityReplica1ConnectionModeInPrimaryRole = 'AllowAllConnections'
+            $mockAvailabilityReplica1ConnectionModeInSecondaryRole = 'AllowNoConnections'
+            $mockAvailabilityReplica1EndpointHostName = $mockServer1Name
+            $mockAvailabilityReplica1EndpointProtocol = 'TCP'
+            $mockAvailabilityReplica1EndpointPort = 5022
+            $mockAvailabilityReplica1FailoverMode = 'Manual'
+            $mockAvailabilityReplica1Role = 'Primary'
 
-        foreach ( $sqlVersion in @(12,13) )
-        {
-            # Create the availability replica
-            $mockAvailabilityReplica = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-            $mockAvailabilityReplica.Name = 'Server1'
-            $mockAvailabilityReplica.AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityReplica.BackupPriority = 50
-            $mockAvailabilityReplica.ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityReplica.ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityReplica.EndpointUrl = 'TCP://Server1:5022'
-            $mockAvailabilityReplica.FailoverMode = 'Manual'
+        #endregion mock availability group variables
 
-            # Create the availability replica collection to store the availability replicas in
-            $mockAvailabilityReplicaCollection = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplicaCollection
-            $mockAvailabilityReplicaCollection.Add($mockAvailabilityReplica)
+        $mockConnectSqlServer1 = {
+            Param
+            (
+                [Parameter()]
+                [string]
+                $SQLServer,
 
-            # Create the Availability Group
-            $mockAvailabilityGroup = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroup
-            $mockAvailabilityGroup.Name = 'PresentAG'
-            $mockAvailabilityGroup.AutomatedBackupPreference = 'Secondary'
-            $mockAvailabilityGroup.FailureConditionLevel = 'OnServerDown'
-            $mockAvailabilityGroup.HealthCheckTimeout = 30000
-            $mockAvailabilityGroup.PrimaryReplicaServerName = 'Server1'
-            $mockAvailabilityGroup.LocalReplicaRole = 'Primary'
-            $mockAvailabilityGroup.AvailabilityReplicas = $mockAvailabilityReplicaCollection
-            $mockAvailabilityGroup.BasicAvailabilityGroup = $False
-            $mockAvailabilityGroup.DatabaseHealthTrigger = $False
-            $mockAvailabilityGroup.DtcSupportEnabled = $False
+                [Parameter()]
+                [string]
+                $SQLInstanceName
+            )
 
-            # Create the availability group collectionto store the availability groups in
-            $mockAvailabilityGroupCollection = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroupCollection
-            $mockAvailabilityGroupCollection.Add($mockAvailabilityGroup)
-
-            # Create the master database
-            $mockMasterDatabaseObject = New-Object Microsoft.SqlServer.Management.Smo.Database
-            $mockMasterDatabaseObject.ID = 1
-            $mockMasterDatabaseObject.Name = 'master'
-
-            # Create the databases collection
-            $mockDatabaseCollection = New-Object Microsoft.SqlServer.Management.Smo.DatabaseCollection
-            $mockDatabaseCollection.Add($mockMasterDatabaseObject)
-
-            # Create the database mirroring endpoint
-            $mockDatabaseMirroringEndpoint = New-Object Microsoft.SqlServer.Management.Smo.Endpoint
-            $mockDatabaseMirroringEndpoint.Name = 'Hadr_endpoint'
-            $mockDatabaseMirroringEndpoint.EndpointType = 'DatabaseMirroring'
-            $mockDatabaseMirroringEndpoint.Protocol = @{
-                TCP = @{
-                    ListenerPort = 5022
-                }
-            }
-
-            # Create the endpointcollection object
-            $mockEndpointCollection = New-Object Microsoft.SqlServer.Management.Smo.EndpointCollection
-            $mockEndpointCollection.Add($mockDatabaseMirroringEndpoint)
-
-            # Create the server object
-            $mockServerObject = New-Object Microsoft.SqlServer.Management.Smo.Server
-            $mockServerObject.AvailabilityGroups = $mockAvailabilityGroupCollection
-            $mockServerObject.Databases = $mockDatabaseCollection
-            $mockServerObject.Endpoints = $mockEndpointCollection
-            $mockServerObject.IsHadrEnabled = $true
-            $mockServerObject.Logins = $mockLogins
-            $mockServerObject.Name = 'Server1'
-            $mockServerObject.NetName = 'Server1'
-            $mockServerObject.Roles = @{}
+            # Define the server object
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $mockServerObject.IsHadrEnabled = $mockIsHadrEnabled
+            $mockServerObject.Name = $mockServer1Name
+            $mockServerObject.NetName = $mockServer1Name
+            $mockServerObject.ServiceName = $mockServer1ServiceName
             $mockServerObject.Version = @{
-                Major = $sqlVersion
+                Major = $Version
             }
 
-            # Clone the server object to a version specific variable
-            $mockConnectSqlServerObjectVariableName = "mockConnectSqlVersion$($sqlVersion)ServerObject"
-            New-Variable -Name $mockConnectSqlServerObjectVariableName
-            Set-Variable -Name $mockConnectSqlServerObjectVariableName -Value $mockServerObject.Clone()
+            # Define the availability group 1 object
+            $mockAvailabilityGroup1Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup1Object.AutomatedBackupPreference = $mockAvailabilityGroup1AutomatedBackupPreference
+            $mockAvailabilityGroup1Object.FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
+            $mockAvailabilityGroup1Object.HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
+            $mockAvailabilityGroup1Object.Name = $mockAvailabilityGroup1Name
+            if ( $Version -ge 13 )
+            {
+                $mockAvailabilityGroup1Object.BasicAvailabilityGroup = $mockAvailabilityGroup1BasicAvailabilityGroup
+                $mockAvailabilityGroup1Object.DatabaseHealthTrigger = $mockAvailabilityGroup1DatabaseHealthTrigger
+                $mockAvailabilityGroup1Object.DtcSupportEnabled = $mockAvailabilityGroup1DtcSupportEnabled
+            }
+
+            # Define the availability replica 1 object
+            $mockAvailabilityReplica1Object = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityReplica1Object.Name = $mockAvailabilityReplica1Name
+            $mockAvailabilityReplica1Object.AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
+            $mockAvailabilityReplica1Object.BackupPriority = $mockAvailabilityReplica1BackupPriority
+            $mockAvailabilityReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+            $mockAvailabilityReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+            $mockAvailabilityReplica1Object.EndpointUrl = "$($mockAvailabilityReplica1EndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplica1EndpointPort)"
+            $mockAvailabilityReplica1Object.FailoverMode = $mockAvailabilityReplica1FailoverMode
+            $mockAvailabilityReplica1Object.Role = $mockAvailabilityReplica1Role
+
+            # Add the availability group to the server object
+            $mockAvailabilityGroup1Object.AvailabilityReplicas.Add($mockAvailabilityReplica1Object)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1Object)
+
+            # Add the master database
+            <#
+            $mockMasterDatabase = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database
+            $mockMasterDatabase.Name = 'master'
+            $mockServerObject.Databases.Add($mockMasterDatabase)
+            #>
+
+            # Define the database mirroring endpoint object
+            if ( $mockDatabaseMirroringEndpointPresent )
+            {
+                $mockDatabaseMirroringEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
+                $mockDatabaseMirroringEndpoint.EndpointType = 'DatabaseMirroring'
+                $mockDatabaseMirroringEndpoint.Protocol = @{
+                    TCP = @{
+                        ListenerPort = $mockAvailabilityReplica1EndpointPort
+                    }
+                }
+                $mockServerObject.Endpoints.Add($mockDatabaseMirroringEndpoint)
+            }
+
+            # Add the login the cluster will use to authenticate to SQL Server
+            <#
+            $mockClusterLoginObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockClusterLoginName)
+            $mockServerObject.Logins.Add($mockClusterLoginName,$mockClusterLoginObject)
+            #>
+
+            return $mockServerObject
         }
 
-        $mockConnectSqlVersion12 = { $mockConnectSqlVersion12ServerObject }
-        $mockConnectSqlVersion13 = { $mockConnectSqlVersion13ServerObject }
+        $mockConnectSqlServer2 = {
+            Param
+            (
+                [Parameter()]
+                [string]
+                $SQLServer,
 
-        $mockConnectSqlVersion12IncorrectEndpointProtocol = {
-            $mock = New-Object PSObject -Property @{
-                AvailabilityGroups = @{
-                    PresentAG = @{
-                        AutomatedBackupPreference = 'Secondary'
-                        FailureConditionLevel = 'OnServerDown'
-                        HealthCheckTimeout = 30000
-                        Name = 'AvailabilityGroup1'
-                        PrimaryReplicaServerName = 'Server1'
-                        LocalReplicaRole = 'Primary'
-                        AvailabilityReplicas = @{
-                            Server1 = @{
-                                AvailabilityMode = 'AsynchronousCommit'
-                                BackupPriority = 50
-                                ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                EndpointUrl = 'UDP://Server1:5022'
-                                FailoverMode = 'Manual'
-                            }
-                        }
-                    }
-                }
-                Databases = @{
-                    'master' = @{
-                        Name = 'master'
-                    }
-                }
-                Endpoints = @(
-                    New-Object PSObject -Property @{
-                        EndpointType = 'DatabaseMirroring'
-                        Protocol = @{
-                            TCP = @{
-                                ListenerPort = 5022
-                            }
-                        }
-                    }
-                )
-                IsHadrEnabled = $true
-                Logins = $mockLogins
-                Name = 'Server1'
-                NetName = 'Server1'
-                Roles = @{}
-                Version = @{
-                    Major = 12
-                }
-            }
-
-            # Add the ExecuteWithResults method
-            $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                return New-Object PSObject -Property @{
-                    Tables = @{
-                        Rows = @{
-                            permission_name = @(
-                                'testing'
-                            )
-                        }
-                    }
-                }
-            }
-
-            # Type the mock as a server object
-            $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-            return $mock
-        }
-
-        $mockConnectSqlVersion12IncorrectEndpointPort = {
-            $mock = New-Object PSObject -Property @{
-                AvailabilityGroups = @{
-                    PresentAG = @{
-                        AutomatedBackupPreference = 'Secondary'
-                        FailureConditionLevel = 'OnServerDown'
-                        HealthCheckTimeout = 30000
-                        Name = 'AvailabilityGroup1'
-                        PrimaryReplicaServerName = 'Server1'
-                        LocalReplicaRole = 'Primary'
-                        AvailabilityReplicas = @{
-                            Server1 = @{
-                                AvailabilityMode = 'AsynchronousCommit'
-                                BackupPriority = 50
-                                ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                EndpointUrl = 'TCP://Server1:1000'
-                                FailoverMode = 'Manual'
-                            }
-                        }
-                    }
-                }
-                Databases = @{
-                    'master' = @{
-                        Name = 'master'
-                    }
-                }
-                Endpoints = @(
-                    New-Object PSObject -Property @{
-                        EndpointType = 'DatabaseMirroring'
-                        Protocol = @{
-                            TCP = @{
-                                ListenerPort = 5022
-                            }
-                        }
-                    }
-                )
-                IsHadrEnabled = $true
-                Logins = $mockLogins
-                Name = 'Server1'
-                NetName = 'Server1'
-                Roles = @{}
-                Version = @{
-                    Major = 12
-                }
-            }
-
-            # Add the ExecuteWithResults method
-            $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                return New-Object PSObject -Property @{
-                    Tables = @{
-                        Rows = @{
-                            permission_name = @(
-                                'testing'
-                            )
-                        }
-                    }
-                }
-            }
-
-            # Type the mock as a server object
-            $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-            return $mock
+                [Parameter()]
+                [string]
+                $SQLInstanceName
+            )
         }
 
         $mockNewSqlAvailabilityReplica = {
-            $mock = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-            $mock.AvailabilityMode = 'AsynchronousCommit'
-            $mock.BackupPriority = 50
-            $mock.ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mock.ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mock.EndpointUrl = 'TCP://Server1:5022'
-            $mock.FailoverMode = 'Manual'
-            $mock.Name = 'Server1'
+            $mock = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mock.Name = $mockAvailabilityReplica1Name
+            $mock.AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
+            $mock.BackupPriority = $mockAvailabilityReplica1BackupPriority
+            $mock.ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+            $mock.ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+            $mock.EndpointUrl = "$($mockAvailabilityReplica1EndpointProtocol)://$($mockAvailabilityReplica1EndpointHostName):$($mockAvailabilityReplica1EndpointPort)"
+            $mock.FailoverMode = $mockAvailabilityReplica1FailoverMode
+            $mock.Role = $mockAvailabilityReplica1Role
 
             return $mock
         }
 
-        $mockAvailabilityGroupProperty = '' # Set dynamically during runtime
-        $mockAvailabilityGroupPropertyValue = '' # Set dynamically during runtime
-
-        $mockUpdateAvailabilityGroup = {
-            Param
-            (
-                [Parameter()]
-                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
-                $AvailabilityGroup
-            )
-
-            if ( $mockAvailabilityGroupPropertyValue -ne $AvailabilityGroup.$mockAvailabilityGroupProperty )
-            {
-                foreach ( $property in ( $AvailabilityGroup | Get-Member -MemberType Property | Select-Object -ExpandProperty Name ) )
-                {
-                    New-VerboseMessage -Message "$($property): $($AvailabilityGroup.$property) ($($defaultPresentParameters.$property))"
-                }
-
-                throw "Update-AvailabilityGroup should be setting the property '$($mockAvailabilityGroupProperty)' to '$($mockAvailabilityGroupPropertyValue)'"
-            }
-        }
-
-        $mockAvailabilityGroupReplicaProperty = '' # Set dynamically during runtime
-        $mockAvailabilityGroupReplicaPropertyValue = '' # Set dynamically during runtime
-
-        $mockUpdateAvailabilityGroupReplica = {
-            Param
-            (
-                [Parameter()]
-                [Microsoft.SqlServer.Management.Smo.AvailabilityReplica]
-                $AvailabilityGroupReplica
-            )
-
-            if ( [string]::IsNullOrEmpty($mockAvailabilityGroupReplicaProperty) -and [string]::IsNullOrEmpty($mockAvailabilityGroupReplicaPropertyValue) )
-            {
-                return
+        #region configuration parameters
+            $getTargetResourceParameters = @{
+                SQLServer = $mockServer1Name
+                SQLInstanceName = $mockServer1ServiceName
             }
 
-            if ( $mockAvailabilityGroupReplicaPropertyValue -ne $AvailabilityGroupReplica.$mockAvailabilityGroupReplicaProperty )
-            {
-                foreach ( $property in ( $AvailabilityGroupReplica | Get-Member -MemberType Property | Select-Object -ExpandProperty Name ) )
-                {
-                    New-VerboseMessage -Message "$($property): $($AvailabilityGroupReplica.$property) ($($defaultPresentParameters.$property))"
-                }
-
-                throw "Update-AvailabilityGroupReplica should be setting the property '$($mockAvailabilityGroupReplicaProperty)' to '$($mockAvailabilityGroupReplicaPropertyValue)'"
+            $mockResourceParameters = @{
+                Name = $mockAvailabilityGroup1Name
+                SQLServer = $mockServer1Name
+                SQLInstanceName = $mockServer1ServiceName
+                AutomatedBackupPreference = $mockAvailabilityGroup1AutomatedBackupPreference
+                AvailabilityMode = $mockAvailabilityReplica1AvailabilityMode
+                BackupPriority = $mockAvailabilityReplica1BackupPriority
+                BasicAvailabilityGroup = $mockAvailabilityGroup1BasicAvailabilityGroup
+                DatabaseHealthTrigger = $mockAvailabilityGroup1DatabaseHealthTrigger
+                DtcSupportEnabled = $mockAvailabilityGroup1DtcSupportEnabled
+                EndpointHostName = $mockServer1Name
+                Ensure = 'Present'
+                ConnectionModeInPrimaryRole = $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+                ConnectionModeInSecondaryRole = $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+                FailureConditionLevel = $mockAvailabilityGroup1FailureConditionLevel
+                HealthCheckTimeout = $mockAvailabilityGroup1HealthCheckTimeout
             }
-        }
+        #endregion configuration parameters
 
-        Describe "xSQLServerAlwaysOnAvailabilityGroup\Get-TargetResource" {
+        Describe 'xSQLServerAlwaysOnAvailabilityGroup\Get-TargetResource' {
+            BeforeAll {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
 
-            BeforeEach {
-                $mockLogins = $mockAllLoginsPresent
+                $mockDatabaseMirroringEndpointPresent = $true
+
+                #region test cases
+                    $absentTestCases = @(
+                        @{
+                            Name =$mockAvailabilityGroupAbsentName
+                            Version = 12
+                        },
+                        @{
+                            Name =$mockAvailabilityGroupAbsentName
+                            Version = 13
+                        }
+                    )
+
+                    $presentTestCases = @(
+                        @{
+                            Ensure = 'Present'
+                            Name =$mockAvailabilityGroup1Name
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Present'
+                            Name =$mockAvailabilityGroup1Name
+                            Version = 13
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name =$mockAvailabilityGroup1Name
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name =$mockAvailabilityGroup1Name
+                            Version = 13
+                        }
+                    )
+                #endregion test cases
             }
 
             Context 'When the Availability Group is Absent'{
 
-                It 'Should not return an Availability Group when Ensure is set to Present and the version is 12' {
+                It 'Should not return an Availability Group when Ensure is set to Present and the SQL version is <Version>' -TestCases $absentTestCases {
+                    param
+                    (
+                        $Name,
+                        $Version
+                    )
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultAbsentParameters.Name
-                        SQLServer = $defaultAbsentParameters.SQLServer
-                        SQLInstanceName = $defaultAbsentParameters.SQLInstanceName
-                    }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
+                    $result = Get-TargetResource @getTargetResourceParameters -Name $Name
                     $result.Ensure | Should Be 'Absent'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should not return an Availability Group when Ensure is set to Present and the version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultAbsentParameters.Name
-                        SQLServer = $defaultAbsentParameters.SQLServer
-                        SQLInstanceName = $defaultAbsentParameters.SQLInstanceName
-                    }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
-                    $result.Ensure | Should Be 'Absent'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
             }
 
             Context 'When the Availability Group is Present'{
+                It 'Should return the correct Availability Group properties when Ensure is set to <Ensure> and the SQL version is <Version>' -TestCases $presentTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Name,
+                        $Version
+                    )
 
-                It 'Should return the correct Availability Group properties when Ensure is set to Present and the SQL version is 12' {
+                    $result = Get-TargetResource @getTargetResourceParameters -Name $Name
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultPresentParameters.Name
-                        SQLServer = $defaultPresentParameters.SQLServer
-                        SQLInstanceName = $defaultPresentParameters.SQLInstanceName
-                    }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
-                    $result.Name | Should Be $defaultPresentParameters.Name
-                    $result.SQLServer | Should Be $defaultPresentParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $defaultPresentParameters.SQLInstanceName
+                    $result.Name | Should Be $mockAvailabilityGroup1Name
+                    $result.SQLServer | Should Be $getTargetResourceParameters.SQLServer
+                    $result.SQLInstanceName | Should Be $getTargetResourceParameters.SQLInstanceName
                     $result.Ensure | Should Be 'Present'
-                    $result.AutomatedBackupPreference | Should Be 'Secondary'
-                    $result.AvailabilityMode | Should Be 'AsynchronousCommit'
-                    $result.BackupPriority | Should Be 50
-                    $result.ConnectionModeInPrimaryRole | Should Be 'AllowAllConnections'
-                    $result.ConnectionModeInSecondaryRole | Should Be 'AllowNoConnections'
-                    $result.FailureConditionLevel | Should Be 'OnServerDown'
-                    $result.FailoverMode | Should Be 'Manual'
-                    $result.HealthCheckTimeout | Should Be 30000
-                    $result.BasicAvailabilityGroup | Should BeNullOrEmpty
-                    $result.DatabaseHealthTrigger | Should BeNullOrEmpty
-                    $result.DtcSupportEnabled | Should BeNullOrEmpty
+                    $result.AutomatedBackupPreference | Should Be $mockAvailabilityGroup1AutomatedBackupPreference
+                    $result.AvailabilityMode | Should Be $mockAvailabilityReplica1AvailabilityMode
+                    $result.BackupPriority | Should Be $mockAvailabilityReplica1BackupPriority
+                    $result.ConnectionModeInPrimaryRole | Should Be $mockAvailabilityReplica1ConnectionModeInPrimaryRole
+                    $result.ConnectionModeInSecondaryRole | Should Be $mockAvailabilityReplica1ConnectionModeInSecondaryRole
+                    #result.EndpointURL #### Need this as well!
+                    $result.FailureConditionLevel | Should Be $mockAvailabilityGroup1FailureConditionLevel
+                    $result.FailoverMode | Should Be $mockAvailabilityReplica1FailoverMode
+                    $result.HealthCheckTimeout | Should Be $mockAvailabilityGroup1HealthCheckTimeout
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should return the correct Availability Group properties when Ensure is set to Absent and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultPresentParameters.Name
-                        SQLServer = $defaultPresentParameters.SQLServer
-                        SQLInstanceName = $defaultPresentParameters.SQLInstanceName
+                    if ( $Version -ge 13 )
+                    {
+                        $result.BasicAvailabilityGroup | Should Be $mockAvailabilityGroup1BasicAvailabilityGroup
+                        $result.DatabaseHealthTrigger | Should Be $mockAvailabilityGroup1DatabaseHealthTrigger
+                        $result.DtcSupportEnabled | Should Be $mockAvailabilityGroup1DtcSupportEnabled
                     }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
-                    $result.Name | Should Be $defaultPresentParameters.Name
-                    $result.SQLServer | Should Be $defaultPresentParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $defaultPresentParameters.SQLInstanceName
-                    $result.Ensure | Should Be 'Present'
-                    $result.AutomatedBackupPreference | Should Be 'Secondary'
-                    $result.AvailabilityMode | Should Be 'AsynchronousCommit'
-                    $result.BackupPriority | Should Be 50
-                    $result.ConnectionModeInPrimaryRole | Should Be 'AllowAllConnections'
-                    $result.ConnectionModeInSecondaryRole | Should Be 'AllowNoConnections'
-                    $result.FailureConditionLevel | Should Be 'OnServerDown'
-                    $result.FailoverMode | Should Be 'Manual'
-                    $result.HealthCheckTimeout | Should Be 30000
-                    $result.BasicAvailabilityGroup | Should BeNullOrEmpty
-                    $result.DatabaseHealthTrigger | Should BeNullOrEmpty
-                    $result.DtcSupportEnabled | Should BeNullOrEmpty
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should return the correct Availability Group properties when Ensure is set to Present and the SQL version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultPresentParameters.Name
-                        SQLServer = $defaultPresentParameters.SQLServer
-                        SQLInstanceName = $defaultPresentParameters.SQLInstanceName
+                    else
+                    {
+                        $result.BasicAvailabilityGroup | Should BeNullOrEmpty
+                        $result.DatabaseHealthTrigger | Should BeNullOrEmpty
+                        $result.DtcSupportEnabled | Should BeNullOrEmpty
                     }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
-                    $result.Name | Should Be $defaultPresentParameters.Name
-                    $result.SQLServer | Should Be $defaultPresentParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $defaultPresentParameters.SQLInstanceName
-                    $result.Ensure | Should Be 'Present'
-                    $result.AutomatedBackupPreference | Should Be 'Secondary'
-                    $result.AvailabilityMode | Should Be 'AsynchronousCommit'
-                    $result.BackupPriority | Should Be 50
-                    $result.ConnectionModeInPrimaryRole | Should Be 'AllowAllConnections'
-                    $result.ConnectionModeInSecondaryRole | Should Be 'AllowNoConnections'
-                    $result.FailureConditionLevel | Should Be 'OnServerDown'
-                    $result.FailoverMode | Should Be 'Manual'
-                    $result.HealthCheckTimeout | Should Be 30000
-                    $result.BasicAvailabilityGroup | Should Be $false
-                    $result.DatabaseHealthTrigger | Should Be $false
-                    $result.DtcSupportEnabled | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should return the correct Availability Group properties when Ensure is set to Absent and the SQL version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    $getParams = @{
-                        Name = $defaultPresentParameters.Name
-                        SQLServer = $defaultPresentParameters.SQLServer
-                        SQLInstanceName = $defaultPresentParameters.SQLInstanceName
-                    }
-
-                    # Get the current state
-                    $result = Get-TargetResource @getParams
-
-                    $result.Name | Should Be $defaultPresentParameters.Name
-                    $result.SQLServer | Should Be $defaultPresentParameters.SQLServer
-                    $result.SQLInstanceName | Should Be $defaultPresentParameters.SQLInstanceName
-                    $result.Ensure | Should Be 'Present'
-                    $result.AutomatedBackupPreference | Should Be 'Secondary'
-                    $result.AvailabilityMode | Should Be 'AsynchronousCommit'
-                    $result.BackupPriority | Should Be 50
-                    $result.ConnectionModeInPrimaryRole | Should Be 'AllowAllConnections'
-                    $result.ConnectionModeInSecondaryRole | Should Be 'AllowNoConnections'
-                    $result.FailureConditionLevel | Should Be 'OnServerDown'
-                    $result.FailoverMode | Should Be 'Manual'
-                    $result.HealthCheckTimeout | Should Be 30000
-                    $result.BasicAvailabilityGroup | Should Be $false
-                    $result.DatabaseHealthTrigger | Should Be $false
-                    $result.DtcSupportEnabled | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                 }
             }
         }
 
-        Describe "xSQLServerAlwaysOnAvailabilityGroup\Set-TargetResource" {
-
-            BeforeEach {
-                $mockLogins = $mockAllLoginsPresent # Need this for legacy purposes
-                $mockConnectSqlVersion12ServerObject.Logins = $mockAllLoginsPresent
-                $mockConnectSqlVersion13ServerObject.Logins = $mockAllLoginsPresent
-
-                Mock -CommandName Test-ClusterPermissions -MockWith { $null } -Verifiable
-            }
-
-            Mock -CommandName Invoke-Query -MockWith {} -Verifiable
-            Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
-            Mock -CommandName New-TerminatingError { $ErrorType } -Verifiable
+        Describe 'xSQLServerAlwaysOnAvailabilityGroup\Set-TargetResource' {
 
             Context 'When the Availability Group is Absent' {
-
-                Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
-                Mock -CommandName Update-AvailabilityGroup -MockWith {} -Verifiable
-                Mock -CommandName Update-AvailabilityGroupReplica -MockWith {} -Verifiable
-
-                It 'Should create the Availability Group when Ensure is set to Present and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName Test-ClusterPermissions
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should create the Availability Group when Ensure is set to Present and the SQL version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable -ParameterFilter { $LoginName -eq 'NT SERVICE\ClusSvc' }
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable -ParameterFilter { $LoginName -eq 'NT AUTHORITY\SYSTEM' }
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-                    $defaultAbsentParameters.BasicAvailabilityGroup = $true
-                    $defaultAbsentParameters.DatabaseHealthTrigger = $true
-                    $defaultAbsentParameters.DtcSupportEnabled = $true
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should throw the correct error, HadrNotEnabled, when Ensure is set to Present, but Always On is not enabled' {
-                    Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{
-                            IsHadrEnabled = $false
-                        }
-                    } -Verifiable
+                BeforeAll {
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
                     Mock -CommandName Invoke-Query -MockWith {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
+                    Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
+                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
                     Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
+                    Mock -CommandName New-TerminatingError -MockWith { $ErrorType } -Verifiable
+                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
+                    Mock -CommandName Test-ClusterPermissions -MockWith { $mockClusterPermissionsExist } -Verifiable
+                    Mock -CommandName Update-AvailabilityGroup -MockWith {} -Verifiable
+                    Mock -CommandName Update-AvailabilityGroupReplica -MockWith {} -Verifiable
 
-                    $defaultAbsentParameters.Ensure = 'Present'
+                    #region test cases
+                        $versionsToTest = @(12,13)
+                        $loginsToTest = @('NT SERVICE\ClusSvc','NT AUTHORITY\System')
 
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'HadrNotEnabled'
+                        $createAvailabilityGroupTestCases = $versionsToTest | ForEach-Object -Process {
+                            $versionToTest = $_
+
+                            return @{
+                                Name = $mockAvailabilityGroupPresentName
+                                Version = $versionToTest
+                            }
+                        }
+                    #endregion test cases
+                }
+
+                BeforeEach{
+                    $mockClusterPermissionsExist = $true
+                    $mockDatabaseMirroringEndpointPresent = $true
+                    $mockIsHadrEnabled = $true
+                }
+
+                It 'Should create the Availability Group when Ensure is set to Present and the SQL version is "<Version>"' -TestCases $createAvailabilityGroupTestCases {
+                    param
+                    (
+                        $Name,
+                        $Version
+                    )
+
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Name = $Name
+
+                    { Set-TargetResource @currentTestParameters } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
+                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
+                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should throw the correct error "HadrNotEnabled" when Ensure is set to Present, but Always On is not enabled' {
+
+                    $mockIsHadrEnabled = $false
+
+                    { Set-TargetResource @mockResourceParameters } | Should Throw 'HadrNotEnabled'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
@@ -630,70 +382,16 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It "Should throw when the logins '$($mockNtServiceClusSvcName)' or '$($mockNtAuthoritySystemName)' are absent or do not have the correct permissions" {
+                It 'Should throw the correct error "DatabaseMirroringEndpointNotFound" when Ensure is set to Present, but no DatabaseMirroring endpoints are present' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName Test-ClusterPermissions -MockWith { throw } -Verifiable
+                    $mockDatabaseMirroringEndpointPresent = $false
 
-                    $defaultAbsentParameters.Ensure = 'Present'
-                    $mockConnectSqlVersion12ServerObject.Logins = $mockAllLoginsAbsent.Clone()
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw
+                    { Set-TargetResource @mockResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should create the Availability Group when Ensure is set to Present and NT AUTHORITY\SYSTEM has the correct permissions' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should throw the correct error, DatabaseMirroringEndpointNotFound, when Ensure is set to Present, but no DatabaseMirroring endpoints are present' {
-                    Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{
-                            AvailabilityGroups = @()
-                            Endpoints = @()
-                            IsHadrEnabled = $true
-                            Logins = $mockNtServiceClusSvcPresent
-                        }
-                    } -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-
-                    { Set-TargetResource @defaultAbsentParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
@@ -701,19 +399,15 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
+
+
                 It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable
-
-                    $defaultAbsentParameters.Ensure = 'Present'
 
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter { $Name -eq $mockAvailabilityGroupPresentName }
                     Assert-MockCalled -CommandName New-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
@@ -724,12 +418,6 @@ try
 
                 It 'Should throw the correct error, CreateAvailabilityGroupReplicaFailed, when Ensure is set to Present, but the Availability Group Replica failed to create and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith { throw 'CreateAvailabilityGroupReplicaFailed' } -Verifiable
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -743,14 +431,9 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
+
+
                 It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup -MockWith { throw 'CreateAvailabilityGroupFailed' } -Verifiable
-                    Mock -CommandName Test-TargetResource -MockWith { $false } -Verifiable
-
-                    $defaultAbsentParameters.Ensure = 'Present'
 
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
 
@@ -767,13 +450,6 @@ try
 
                 It 'Should throw the correct error "CreateAvailabilityGroupFailed" when Ensure is set to Present, but the Availability Group failed to create and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName New-SqlAvailabilityGroup -MockWith { throw 'CreateAvailabilityGroupFailed' } -Verifiable
-                    Mock -CommandName Test-TargetResource -MockWith {$false}
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-
                     { Set-TargetResource @defaultAbsentParameters } | Should Throw 'CreateAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -789,19 +465,8 @@ try
             }
 
             Context 'When the Availability Group is Present' {
-                BeforeEach {
-                    Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable
-                    Mock -CommandName New-SqlAvailabilityReplica -MockWith $mockNewSqlAvailabilityReplica -Verifiable
-                    Mock -CommandName Update-AvailabilityGroup -MockWith $mockUpdateAvailabilityGroup -Verifiable
-                    Mock -CommandName Update-AvailabilityGroupReplica -MockWith $mockUpdateAvailabilityGroupReplica -Verifiable
-                }
 
                 It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
-
-                    $defaultPresentParameters.Ensure = 'Absent'
 
                     { Set-TargetResource @defaultPresentParameters } | Should Not Throw
 
@@ -817,11 +482,6 @@ try
                 }
 
                 It 'Should remove the Availability Group when Ensure is set to Absent and the SQL version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
-
-                    $defaultPresentParameters.Ensure = 'Absent'
 
                     { Set-TargetResource @defaultPresentParameters } | Should Not Throw
 
@@ -839,36 +499,6 @@ try
 
                 It 'Should throw the correct error message, InstanceNotPrimaryReplica, when Ensure is set to Absent and the primary replica is not on the current instance' {
 
-                    Mock -CommandName Connect-SQL -MockWith {
-                        return New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server1'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'TCP://Server1:5022'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            IsHadrEnabled = $true
-                            NetName = 'Server2'
-                        }
-                    } -Verifiable
-
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith {} -Verifiable
-
-                    $defaultPresentParameters.Ensure = 'Absent'
-
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'InstanceNotPrimaryReplica'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -883,11 +513,6 @@ try
                 }
 
                 It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 12' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable
-
-                    $defaultPresentParameters.Ensure = 'Absent'
 
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
 
@@ -904,11 +529,6 @@ try
 
                 It 'Should throw the correct error message when Ensure is set to Absent but the Availability Group remove fails, and the SQL version is 13' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-                    Mock -CommandName Remove-SqlAvailabilityGroup -MockWith { throw 'RemoveAvailabilityGroupFailed' } -Verifiable
-
-                    $defaultPresentParameters.Ensure = 'Absent'
-
                     { Set-TargetResource @defaultPresentParameters } | Should Throw 'RemoveAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -923,143 +543,6 @@ try
                 }
 
                 It 'Should connect to the instance hosting the primary replica when the LocalReplicaRole is not Primary' {
-
-                    Mock -CommandName Connect-SQL -MockWith {
-                        $mock = New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server2'
-                                    LocalReplicaRole = 'Secondary'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'TCP://Server1:5022'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            Databases = @{
-                                'master' = @{
-                                    Name = 'master'
-                                }
-                            }
-                            Endpoints = @(
-                                New-Object PSObject -Property @{
-                                    EndpointType = 'DatabaseMirroring'
-                                    Protocol = @{
-                                        TCP = @{
-                                            ListenerPort = 5022
-                                        }
-                                    }
-                                }
-                            )
-                            IsHadrEnabled = $true
-                            Logins = $mockLogins
-                            Name = 'Server1'
-                            NetName = 'Server1'
-                            Roles = @{}
-                            Version = @{
-                                Major = 12
-                            }
-                        }
-
-                        # Add the ExecuteWithResults method
-                        $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                            return New-Object PSObject -Property @{
-                                Tables = @{
-                                    Rows = @{
-                                        permission_name = @(
-                                            'testing'
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        # Type the mock as a server object
-                        $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-                        return $mock
-                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    Mock -CommandName Connect-SQL -MockWith {
-                        $mock = New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server2'
-                                    LocalReplicaRole = 'Primary'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'TCP://Server2:5022'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            Databases = @{
-                                'master' = @{
-                                    Name = 'master'
-                                }
-                            }
-                            Endpoints = @(
-                                New-Object PSObject -Property @{
-                                    EndpointType = 'DatabaseMirroring'
-                                    Protocol = @{
-                                        TCP = @{
-                                            ListenerPort = 5022
-                                        }
-                                    }
-                                }
-                            )
-                            IsHadrEnabled = $true
-                            Logins = $mockLogins
-                            Name = 'Server1'
-                            NetName = 'Server1'
-                            Roles = @{}
-                            Version = @{
-                                Major = 12
-                            }
-                        }
-
-                        # Add the ExecuteWithResults method
-                        $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                            return New-Object PSObject -Property @{
-                                Tables = @{
-                                    Rows = @{
-                                        permission_name = @(
-                                            'testing'
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        # Type the mock as a server object
-                        $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-                        return $mock
-                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server2' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $mockAvailabilityGroupReplicaProperty = ''
-                    $mockAvailabilityGroupReplicaPropertyValue = ''
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1076,14 +559,6 @@ try
                 }
 
                 It 'Should set the AutomatedBackupPreference to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.AutomatedBackupPreference = 'Primary'
-                    $mockAvailabilityGroupProperty = 'AutomatedBackupPreference'
-                    $mockAvailabilityGroupPropertyValue = 'Primary'
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1102,14 +577,6 @@ try
 
                 It 'Should set the AvailabilityMode to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.AvailabilityMode = 'SynchronousCommit'
-                    $mockAvailabilityGroupReplicaProperty = 'AvailabilityMode'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'SynchronousCommit'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1126,14 +593,6 @@ try
                 }
 
                 It 'Should set the BackupPriority to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.BackupPriority = 42
-                    $mockAvailabilityGroupReplicaProperty = 'BackupPriority'
-                    $mockAvailabilityGroupReplicaPropertyValue = 42
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1152,14 +611,6 @@ try
 
                 It 'Should set the BasicAvailabilityGroup to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.BasicAvailabilityGroup = $true
-                    $mockAvailabilityGroupProperty = 'BasicAvailabilityGroup'
-                    $mockAvailabilityGroupPropertyValue = $true
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1176,14 +627,6 @@ try
                 }
 
                 It 'Should set the DatabaseHealthTrigger to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.DatabaseHealthTrigger = $true
-                    $mockAvailabilityGroupProperty = 'DatabaseHealthTrigger'
-                    $mockAvailabilityGroupPropertyValue = $true
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1202,14 +645,6 @@ try
 
                 It 'Should not set the DtcSupportEnabled to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.DtcSupportEnabled = $true
-                    $mockAvailabilityGroupProperty = 'DtcSupportEnabled'
-                    $mockAvailabilityGroupPropertyValue = $true
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1226,14 +661,6 @@ try
                 }
 
                 It 'Should set the ConnectionModeInPrimaryRole to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.ConnectionModeInPrimaryRole = 'AllowReadWriteConnections'
-                    $mockAvailabilityGroupReplicaProperty = 'ConnectionModeInPrimaryRole'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'AllowReadWriteConnections'
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1253,14 +680,6 @@ try
 
                 It 'Should set the ConnectionModeInSecondaryRole to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.ConnectionModeInSecondaryRole = 'AllowReadIntentConnectionsOnly'
-                    $mockAvailabilityGroupReplicaProperty = 'ConnectionModeInSecondaryRole'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'AllowReadIntentConnectionsOnly'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1278,77 +697,6 @@ try
 
                 It 'Should set the EndpointUrl to the desired state when the endpoint port is changed' {
 
-                    Mock -CommandName Connect-SQL -MockWith {
-                        $mock = New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server1'
-                                    LocalReplicaRole = 'Primary'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'TCP://Server1:5021'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            Databases = @{
-                                'master' = @{
-                                    Name = 'master'
-                                }
-                            }
-                            Endpoints = @(
-                                New-Object PSObject -Property @{
-                                    EndpointType = 'DatabaseMirroring'
-                                    Protocol = @{
-                                        TCP = @{
-                                            ListenerPort = 5022
-                                        }
-                                    }
-                                }
-                            )
-                            IsHadrEnabled = $true
-                            Logins = $mockLogins
-                            Name = 'Server1'
-                            NetName = 'Server1'
-                            Roles = @{}
-                            Version = @{
-                                Major = 12
-                            }
-                        }
-
-                        # Add the ExecuteWithResults method
-                        $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                            return New-Object PSObject -Property @{
-                                Tables = @{
-                                    Rows = @{
-                                        permission_name = @(
-                                            'testing'
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        # Type the mock as a server object
-                        $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-                        return $mock
-                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1360,20 +708,10 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].EndpointUrl = $mockAvailabilityReplica.EndpointUrl
                 }
 
                 It 'Should set the EndpointUrl to the desired state when the EndpointHostName is specified' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.EndpointHostName = 'TestServer.Contoso.com'
-                    $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'TCP://TestServer.Contoso.com:5022'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1385,84 +723,10 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].EndpointUrl = $mockAvailabilityReplica.EndpointUrl
                 }
 
                 It 'Should set the EndpointUrl to the desired state when the EndpointHostName is not specified' {
 
-                    Mock -CommandName Connect-SQL -MockWith {
-                        $mock = New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server1'
-                                    LocalReplicaRole = 'Primary'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'TCP://Server1.contoso.com:5022'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            Databases = @{
-                                'master' = @{
-                                    Name = 'master'
-                                }
-                            }
-                            Endpoints = @(
-                                New-Object PSObject -Property @{
-                                    EndpointType = 'DatabaseMirroring'
-                                    Protocol = @{
-                                        TCP = @{
-                                            ListenerPort = 5022
-                                        }
-                                    }
-                                }
-                            )
-                            IsHadrEnabled = $true
-                            Logins = $mockLogins
-                            Name = 'Server1'
-                            NetName = 'Server1'
-                            Roles = @{}
-                            Version = @{
-                                Major = 12
-                            }
-                        }
-
-                        # Add the ExecuteWithResults method
-                        $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                            return New-Object PSObject -Property @{
-                                Tables = @{
-                                    Rows = @{
-                                        permission_name = @(
-                                            'testing'
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        # Type the mock as a server object
-                        $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-                        return $mock
-                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.Remove('EndpointHostName')
-                    $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1474,83 +738,10 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].EndpointUrl = $mockAvailabilityReplica.EndpointUrl
                 }
 
                 It 'Should set the EndpointUrl to the desired state when the endpoint protocol is changed' {
 
-                    Mock -CommandName Connect-SQL -MockWith {
-                        $mock = New-Object PSObject -Property @{
-                            AvailabilityGroups = @{
-                                PresentAG = @{
-                                    AutomatedBackupPreference = 'Secondary'
-                                    FailureConditionLevel = 'OnServerDown'
-                                    HealthCheckTimeout = 30000
-                                    Name = 'AvailabilityGroup1'
-                                    PrimaryReplicaServerName = 'Server1'
-                                    LocalReplicaRole = 'Primary'
-                                    AvailabilityReplicas = @{
-                                        Server1 = @{
-                                            AvailabilityMode = 'AsynchronousCommit'
-                                            BackupPriority = 50
-                                            ConnectionModeInPrimaryRole = 'AllowAllConnections'
-                                            ConnectionModeInSecondaryRole = 'AllowNoConnections'
-                                            EndpointUrl = 'HTTP://Server1:5022'
-                                            FailoverMode = 'Manual'
-                                        }
-                                    }
-                                }
-                            }
-                            Databases = @{
-                                'master' = @{
-                                    Name = 'master'
-                                }
-                            }
-                            Endpoints = @(
-                                New-Object PSObject -Property @{
-                                    EndpointType = 'DatabaseMirroring'
-                                    Protocol = @{
-                                        TCP = @{
-                                            ListenerPort = 5022
-                                        }
-                                    }
-                                }
-                            )
-                            IsHadrEnabled = $true
-                            Logins = $mockLogins
-                            Name = 'Server1'
-                            NetName = 'Server1'
-                            Roles = @{}
-                            Version = @{
-                                Major = 12
-                            }
-                        }
-
-                        # Add the ExecuteWithResults method
-                        $mock.Databases['master'] | Add-Member -MemberType ScriptMethod -Name ExecuteWithResults -Value {
-                            return New-Object PSObject -Property @{
-                                Tables = @{
-                                    Rows = @{
-                                        permission_name = @(
-                                            'testing'
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        # Type the mock as a server object
-                        $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-                        return $mock
-                    } -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $mockAvailabilityGroupReplicaProperty = 'EndpointUrl'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'TCP://Server1:5022'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1562,20 +753,10 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].EndpointUrl = $mockAvailabilityReplica.EndpointUrl
                 }
 
                 It 'Should set the FailureConditionLevel to the desired state' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.FailureConditionLevel = 'OnAnyQualifiedFailureCondition'
-                    $mockAvailabilityGroupProperty = 'FailureConditionLevel'
-                    $mockAvailabilityGroupPropertyValue = 'OnAnyQualifiedFailureCondition'
-
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -1587,19 +768,9 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].FailureConditionLevel = $defaultPresentParameters.FailureConditionLevel
                 }
 
                 It 'Should set the FailoverMode to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable -ParameterFilter { $SQLServer -eq 'Server1' }
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.FailoverMode = 'Automatic'
-                    $mockAvailabilityGroupReplicaProperty = 'FailoverMode'
-                    $mockAvailabilityGroupReplicaPropertyValue = 'Automatic'
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1612,19 +783,9 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].AvailabilityReplicas['Server1'].FailoverMode = $defaultPresentParameters.FailoverMode
                 }
 
                 It 'Should set the HealthCheckTimeout to the desired state' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $defaultPresentParametersIncorrectProperties = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectProperties.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectProperties.HealthCheckTimeout = 42
-                    $mockAvailabilityGroupProperty = 'HealthCheckTimeout'
-                    $mockAvailabilityGroupPropertyValue = 42
 
                     { Set-TargetResource @defaultPresentParametersIncorrectProperties } | Should Not Throw
 
@@ -1637,149 +798,213 @@ try
                     Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-
-                    $mockConnectSqlVersion12ServerObject.AvailabilityGroups['PresentAG'].HealthCheckTimeout = $defaultPresentParameters.HealthCheckTimeout
                 }
             }
         }
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Test-TargetResource" {
+            BeforeAll {
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
 
-            BeforeEach {
-                $mockLogins = $mockAllLoginsPresent
+                $mockDatabaseMirroringEndpointPresent = $true
+
+                #region test cases
+                    $versionsToTest = @(12,13)
+                    $absentTestCases = @(
+                        @{
+                            Ensure = 'Present'
+                            Name = $mockAvailabilityGroupAbsentName
+                            Result = $false
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Present'
+                            Name = $mockAvailabilityGroupAbsentName
+                            Result = $false
+                            Version = 13
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name = $mockAvailabilityGroupAbsentName
+                            Result = $true
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name = $mockAvailabilityGroupAbsentName
+                            Result = $true
+                            Version = 13
+                        }
+                    )
+
+                    $presentTestCases = @(
+                        @{
+                            Ensure = 'Present'
+                            Name =$mockAvailabilityGroup1Name
+                            Result = $true
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Present'
+                            Name =$mockAvailabilityGroup1Name
+                            Result = $true
+                            Version = 13
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name =$mockAvailabilityGroup1Name
+                            Result = $false
+                            Version = 12
+                        },
+                        @{
+                            Ensure = 'Absent'
+                            Name =$mockAvailabilityGroup1Name
+                            Result = $false
+                            Version = 13
+                        }
+                    )
+
+                    [array]$presentParameterTestCases = $versionsToTest | ForEach-Object -Process {
+                        $versionToTest = $_
+
+                        $mockResourceParameters.GetEnumerator() | ForEach-Object -Process {
+                            if ( @('Name','SQLServer','SQLInstanceName','DtcSupportEnabled') -notcontains $_.Key )
+                            {
+                                $currentParameter = $_.Key
+
+                                # Move on if we're testing a version less than 13 and it's a property that was only introduced in 13
+                                if ( ( $sql13AvailabilityGroupProperties -contains $currentParameter ) -and ( $versionToTest -lt 13 ) )
+                                {
+                                    # Move to the next parameter
+                                    return
+                                }
+
+                                # Get the current parameter object
+                                $currentParameterObject = ( Get-Command Test-TargetResource ).Parameters.$currentParameter
+
+                                switch ( $currentParameterObject.ParameterType.ToString() )
+                                {
+                                    'System.Boolean'
+                                    {
+                                        # Get the opposite value of what is supplied
+                                        $testCaseParameterValue = -not $mockResourceParameters.$currentParameter
+                                    }
+
+                                    'System.UInt32'
+                                    {
+                                        # Change the supplied number to something else. Absolute value is to protect against zero minus 1
+                                        $testCaseParameterValue = [System.Math]::Abs( ( $mockResourceParameters.$currentParameter -1 ) )
+                                    }
+
+                                    'System.String'
+                                    {
+                                        # Get the valid values for the current parameter
+                                        $currentParameterValidValues = $currentParameterObject.Attributes.ValidValues
+
+                                        # Select a value other than what is defined in the mocks
+                                        $testCaseParameterValue = $currentParameterValidValues | Where-Object -FilterScript { $_ -ne $mockResourceParameters.$currentParameter } | Select-Object -First 1
+
+                                        # If the value is null or empty, set it to something
+                                        if ( [string]::IsNullOrEmpty($testCaseParameterValue) )
+                                        {
+                                            $testCaseParameterValue = 'IncorrectValue'
+                                        }
+                                    }
+
+                                    default
+                                    {
+                                        $testCaseParameterValue = $null
+                                    }
+                                }
+
+                                return @{
+                                    Ensure = 'Present'
+                                    Result = $false
+                                    Parameter = $currentParameter
+                                    ParameterValue = $testCaseParameterValue
+                                    Version = $versionToTest
+                                }
+                            }
+                        }
+                    }
+                #endregion test cases
             }
 
             Context 'When the Availability Group is Absent' {
 
-                It 'Should be $false when the desired state is Present and the SQL version is 12' {
+                It 'Should be "<Result>" when the desired state is "<Ensure>" and the SQL version is "<Version>"' -TestCases $absentTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Name,
+                        $Result,
+                        $Version
+                    )
 
-                    $defaultAbsentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Ensure = $Ensure
+                    $currentTestParameters.Name = $Name
 
-                    Test-TargetResource @defaultAbsentParameters | Should Be $false
+                    Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $true when the desired state is Absent and the SQL version is 12' {
-
-                    $defaultAbsentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    Test-TargetResource @defaultAbsentParameters | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $false when the desired state is Present and the SQL version is 13' {
-
-                    $defaultAbsentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    Test-TargetResource @defaultAbsentParameters | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $true when the desired state is Absent and the SQL version is 13' {
-
-                    $defaultAbsentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    Test-TargetResource @defaultAbsentParameters | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
             }
 
             Context 'When the Availability Group is Present' {
 
-                It 'Should be $false when the desired state is Absent and the SQL version is 12' {
+                It 'Should be "<Result>" when the desired state is "<Ensure>" and the SQL version is "<Version>"' -TestCases $presentTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Name,
+                        $Result,
+                        $Version
+                    )
 
-                    $defaultPresentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Ensure = $Ensure
+                    $currentTestParameters.Name = $Name
 
-                    Test-TargetResource @defaultPresentParameters | Should Be $false
+                    Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
 
-                It 'Should be $true when the desired state is Present and the SQL version is 12' {
+                It 'Should be "<Result>" when the desired state is "<Ensure>", the parameter "<Parameter>" is not "<ParameterValue>", and the SQL version is "<Version>"' -TestCases $presentParameterTestCases {
+                    param
+                    (
+                        $Ensure,
+                        $Result,
+                        $Parameter,
+                        $ParameterValue,
+                        $Version
+                    )
 
-                    $defaultPresentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.$Parameter = $ParameterValue
 
-                    Test-TargetResource @defaultPresentParameters | Should Be $true
+                    Test-TargetResource @currentTestParameters | Should Be $Result
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
 
-                It 'Should be $false when the desired state is Present, there is a parameter not correctly set, and the SQL version is 12' {
+                <#It 'Should be $true when the desired state is Present and the Endpoint Host Name is not specified' {
 
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
+                    $currentTestParameters = $mockResourceParameters.Clone()
+                    $currentTestParameters.Remove('EndpointHostName')
 
-                    $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectParameter.AvailabilityMode = 'SynchronousCommit'
+                    Test-TargetResource @currentTestParameters | Should Be $true
 
-                    Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $false when the desired state is Absent and the SQL version is 13' {
-
-                    $defaultPresentParameters.Ensure = 'Absent'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    Test-TargetResource @defaultPresentParameters | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $true when the desired state is Present and the SQL version is 13' {
-
-                    $defaultPresentParameters.Ensure = 'Present'
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    Test-TargetResource @defaultPresentParameters | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $false when the desired state is Present, there is a parameter not correctly set, and the SQL version is 13' {
-
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion13 -Verifiable
-
-                    $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectParameter.AvailabilityMode = 'SynchronousCommit'
-                    $defaultPresentParametersIncorrectParameter.BasicAvailabilityGroup = $true
-                    $defaultPresentParametersIncorrectParameter.DatabaseHealthTrigger = $true
-                    $defaultPresentParametersIncorrectParameter.DtcSupportEnabled = $true
-
-                    Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
-
-                It 'Should be $true when the desired state is Present and the Endpoint Host Name is not specified' {
-                    $defaultPresentParametersEndpointHostNameNotSpecified = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersEndpointHostNameNotSpecified.Ensure = 'Present'
-                    $defaultPresentParametersEndpointHostNameNotSpecified.Remove('EndpointHostName')
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    Test-TargetResource @defaultPresentParametersEndpointHostNameNotSpecified | Should Be $true
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $SQLServer -eq $mockServer1Name }
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 }
 
                 It 'Should be $false when the desired state is Present and the Endpoint Hostname is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12 -Verifiable
-
-                    $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
-                    $defaultPresentParametersIncorrectParameter.EndpointHostName = 'server1.contoso.com'
 
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
@@ -1787,10 +1012,6 @@ try
                 }
 
                 It 'Should be $false when the desired state is Present and the Endpoint Protocol is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointProtocol -Verifiable
-
-                    $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
 
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
@@ -1798,35 +1019,34 @@ try
                 }
 
                 It 'Should be $false when the desired state is Present and the Endpoint Port is incorrectly configured' {
-                    Mock -CommandName Connect-SQL -MockWith $mockConnectSqlVersion12IncorrectEndpointPort -Verifiable
-
-                    $defaultPresentParametersIncorrectParameter = $defaultPresentParameters.Clone()
-                    $defaultPresentParametersIncorrectParameter.Ensure = 'Present'
 
                     Test-TargetResource @defaultPresentParametersIncorrectParameter | Should Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                }
+                }#>
             }
         }
 
         Describe "xSQLServerAlwaysOnAvailabilityGroup\Update-AvailabilityGroup" {
-            Mock -CommandName New-TerminatingError -MockWith { $ErrorType }
+            BeforeAll {
+                Mock -CommandName New-TerminatingError -MockWith { $ErrorType }
+
+                $mockAvailabilityGroup = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            }
 
             Context 'When the Availability Group is altered' {
                 It 'Should silently alter the Availability Group' {
-                    $ag = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroup
 
-                    { Update-AvailabilityGroup -AvailabilityGroup $ag } | Should Not Throw
+                    { Update-AvailabilityGroup -AvailabilityGroup $mockAvailabilityGroup } | Should Not Throw
 
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should throw the correct error, AlterAvailabilityGroupFailed, when altering the Availaiblity Group fails' {
-                    $ag = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroup
-                    $ag.Name = 'AlterFailed'
 
-                    { Update-AvailabilityGroup -AvailabilityGroup $ag } | Should Throw 'AlterAvailabilityGroupFailed'
+                    $mockAvailabilityGroup.Name = 'AlterFailed'
+
+                    { Update-AvailabilityGroup -AvailabilityGroup $mockAvailabilityGroup } | Should Throw 'AlterAvailabilityGroupFailed'
 
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                 }

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
@@ -57,14 +57,17 @@ try
             $mockServer1Name = 'Server1'
             $mockServer1NetName = $mockServer1Name
             $mockServer1IsHadrEnabled = $true
+            $mockServer1ServiceName = 'MSSQLSERVER'
 
             $mockServer2Name = 'Server2'
             $mockServer2NetName = $mockServer1Name
             $mockServer2IsHadrEnabled = $true
+            $mockServer2ServiceName = $mockServer1ServiceName
 
             $mockServer3Name = 'Server3'
             $mockServer3NetName = $mockServer3Name
             $mockServer3IsHadrEnabled = $true
+            $mockServer3ServiceName = $mockServer1ServiceName
 
         #endregion
 
@@ -92,36 +95,11 @@ try
 
         #endregion
 
-        #region Endpoint mocks
-
-            $mockDatabaseMirroringEndpoint = $true
+        #region Endpoint mock variables
 
             $mockEndpointPort = 5022
 
-            $mockDatabaseMirroringEndpointAbsent = @()
-
-            <#$mockDatabaseMirroringEndpointPresent = @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'EndpointType' -Value 'DatabaseMirroring' -PassThru |
-                        Add-Member ScriptProperty Protocol {
-                            return @(
-                                (
-                                    New-Object Object |
-                                        Add-Member -MemberType ScriptProperty -Name TCP {
-                                            return @(
-                                                (
-                                                    New-Object Object |
-                                                        Add-Member -MemberType NoteProperty -Name ListenerPort -Value $mockendpointPort -PassThru -Force
-                                                )
-                                            )
-                                        } -PassThru -Force
-                                )
-                            )
-                        } -PassThru -Force
-                )
-            )#>
-        #endregion
+        #endregion Endpoint mock variables
 
         #region Availability Group mock variables
 
@@ -193,95 +171,73 @@ try
                 $SQLInstanceName
             )
 
-            <#
-            $mock = @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockServer1Name -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'NetName' -Value $mockServer1NetName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsHadrEnabled' -Value $mockServer1IsHadrEnabled -PassThru |
-                        Add-Member ScriptProperty Logins {
-                            return $mockLogins
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty AvailabilityGroups {
-                            return @{
-                                $mockAvailabilityGroup1Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Secondary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica1Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica1Object.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
-                                        $mockAvailabilityGroupReplica1Object.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
-                                        $mockAvailabilityGroupReplica1Object.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
-                                        $mockAvailabilityGroupReplica1Object.Name = $mockAvailabilityGroupReplica1Name
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
-
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
-
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
-
-                                        if ( $mockAlternateEndpointPort )
-                                        {
-                                            $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
-                                            $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
-                                            $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
-                                        }
-
-                                        if ( $mockAlternateEndpointProtocol )
-                                        {
-                                            $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
-                                            $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
-                                            $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
-                                        }
-
-                                        return @{
-                                            $mockAvailabilityGroupReplica1Name = $mockAvailabilityGroupReplica1Object
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                            }
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty Endpoints {
-                            return $mockEndpoint
-                        } -PassThru -Force
-                )
-            )
-
-            # Type the mock as a server object
-            $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-            #>
-
-            $mockServerObject = New-Object Microsoft.SqlServer.Management.Smo.Server
+            # Mock the server object
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
             $mockServerObject.Name = $mockServer1Name
             $mockServerObject.NetName = $mockServer1NetName
             $mockServerObject.IsHadrEnabled = $mockServer1IsHadrEnabled
+            $mockServerObject.Logins = $mockLogins
+            $mockServerObject.ServiceName = $mockServer1ServiceName
 
+            # Mock the availability group replicas
+            $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
+            $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
+            $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
+            $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
+            $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
+
+            $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
+            $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
+            $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
+            $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
+            $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+
+            $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
+            $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
+            $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
+            $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
+            $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+
+            if ( $mockAlternateEndpointPort )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+            }
+
+            if ( $mockAlternateEndpointProtocol )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+            }
+
+            # Mock the availability groups
+            $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup1.Name = $mockAvailabilityGroup1Name
+            $mockAvailabilityGroup1.PrimaryReplicaServerName = $mockAvailabilityGroup1PrimaryReplicaServer
+            $mockAvailabilityGroup1.LocalReplicaRole = 'Secondary'
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica1)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1)
+
+            # Mock the mirroring endpoint if required
             if ( $mockDatabaseMirroringEndpoint )
             {
                 $mockEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
@@ -309,157 +265,103 @@ try
                 $SQLInstanceName
             )
 
-            $mock = @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockServer1Name -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'NetName' -Value $mockServer1NetName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsHadrEnabled' -Value $mockServer1IsHadrEnabled -PassThru |
-                        Add-Member ScriptProperty Logins {
-                            return $mockLogins
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty AvailabilityGroups {
-                            return @{
-                                $mockAvailabilityGroup1Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Primary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica1Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica1Object.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
-                                        $mockAvailabilityGroupReplica1Object.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
-                                        $mockAvailabilityGroupReplica1Object.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
-                                        $mockAvailabilityGroupReplica1Object.Name = $mockAvailabilityGroupReplica1Name
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
+            # Mock the server object
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $mockServerObject.Name = $mockServer2Name
+            $mockServerObject.NetName = $mockServer2NetName
+            $mockServerObject.IsHadrEnabled = $mockServer2IsHadrEnabled
+            $mockServerObject.Logins = $mockLogins
+            $mockServerObject.ServiceName = $mockServer2ServiceName
 
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            #region Mock the availability group replicas
+                $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
+                $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
+                $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
+                $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
+                $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
+                $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+                $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
+                $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
+                $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
+                $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
+                $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
+                $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
 
-                                        if ( $mockAlternateEndpointPort )
-                                        {
-                                            $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
-                                            $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
-                                            $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
-                                        }
+                $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
+                $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
+                $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
+                $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
+                $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
+                $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            #endregion Mock the availability group replicas
 
-                                        if ( $mockAlternateEndpointProtocol )
-                                        {
-                                            $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
-                                            $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
-                                            $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
-                                        }
+            if ( $mockAlternateEndpointPort )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+            }
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica1Name = $mockAvailabilityGroupReplica1Object
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                                $mockAvailabilityGroup2Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup2Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup2PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Primary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            if ( $mockAlternateEndpointProtocol )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+            }
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            # Mock the availability groups
+            $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup1.Name = $mockAvailabilityGroup1Name
+            $mockAvailabilityGroup1.PrimaryReplicaServerName = $mockAvailabilityGroup1PrimaryReplicaServer
+            $mockAvailabilityGroup1.LocalReplicaRole = 'Primary'
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica1)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1)
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                                $mockAvailabilityGroup3Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup3Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup3PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Secondary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            $mockAvailabilityGroup2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup2.Name = $mockAvailabilityGroup2Name
+            $mockAvailabilityGroup2.PrimaryReplicaServerName = $mockAvailabilityGroup2PrimaryReplicaServer
+            $mockAvailabilityGroup2.LocalReplicaRole = 'Primary'
+            $mockAvailabilityGroup2.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup2.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup2)
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            $mockAvailabilityGroup3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup3.Name = $mockAvailabilityGroup3Name
+            $mockAvailabilityGroup3.PrimaryReplicaServerName = $mockAvailabilityGroup3PrimaryReplicaServer
+            $mockAvailabilityGroup3.LocalReplicaRole = 'Secondary'
+            $mockAvailabilityGroup3.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup3.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup3)
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                            }
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty Endpoints {
-                            return $mockEndpoint
-                        } -PassThru -Force
-                )
-            )
+            # Mock the mirroring endpoint if required
+            if ( $mockDatabaseMirroringEndpoint )
+            {
+                $mockEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
+                $mockEndpoint.EndpointType = 'DatabaseMirroring'
+                $mockEndpoint.Protocol = @{
+                    TCP = @{
+                        ListenerPort = $mockendpointPort
+                    }
+                }
+                $mockServerObject.Endpoints.Add($mockEndpoint)
+            }
 
-            # Type the mock as a server object
-            $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-
-            return $mock
+            return $mockServerObject
         }
 
         $mockConnectSqlServer3 = {
@@ -474,143 +376,103 @@ try
                 $SQLInstanceName
             )
 
-            $mock = @(
-                (
-                    New-Object Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockServer1Name -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'NetName' -Value $mockServer1NetName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsHadrEnabled' -Value $mockServer1IsHadrEnabled -PassThru |
-                        Add-Member ScriptProperty Logins {
-                            return $mockLogins
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty AvailabilityGroups {
-                            return @{
-                                $mockAvailabilityGroup1Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup1Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup1PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Secondary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica1Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica1Object.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
-                                        $mockAvailabilityGroupReplica1Object.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica1Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica1Object.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
-                                        $mockAvailabilityGroupReplica1Object.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
-                                        $mockAvailabilityGroupReplica1Object.Name = $mockAvailabilityGroupReplica1Name
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica1Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
+            # Mock the server object
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $mockServerObject.Name = $mockServer3Name
+            $mockServerObject.NetName = $mockServer3NetName
+            $mockServerObject.IsHadrEnabled = $mockServer3IsHadrEnabled
+            $mockServerObject.Logins = $mockLogins
+            $mockServerObject.ServiceName = $mockServer3ServiceName
 
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            #region Mock the availability group replicas
+                $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
+                $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
+                $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
+                $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
+                $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
+                $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+                $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
+                $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
+                $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
+                $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
+                $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
+                $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica1Name = $mockAvailabilityGroupReplica1Object
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                                $mockAvailabilityGroup2Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup2Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup2PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Secondary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+                $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+                $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
+                $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
+                $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
+                $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
+                $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
+                $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
+                $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
+                $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            #endregion Mock the availability group replicas
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            if ( $mockAlternateEndpointPort )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+            }
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                                $mockAvailabilityGroup3Name = (
-                                    New-Object Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockAvailabilityGroup3Name -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'PrimaryReplicaServerName' -Value $mockAvailabilityGroup3PrimaryReplicaServer -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'LocalReplicaRole' -Value 'Primary' -PassThru |
-                                    Add-Member ScriptProperty AvailabilityReplicas {
-                                        $mockAvailabilityGroupReplica2Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica2Object.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                                        $mockAvailabilityGroupReplica2Object.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica2Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica2Object.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                                        $mockAvailabilityGroupReplica2Object.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                                        $mockAvailabilityGroupReplica2Object.Name = $mockAvailabilityGroupReplica2Name
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica2Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            if ( $mockAlternateEndpointProtocol )
+            {
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+            }
 
-                                        $mockAvailabilityGroupReplica3Object = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                                        $mockAvailabilityGroupReplica3Object.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                                        $mockAvailabilityGroupReplica3Object.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                                        $mockAvailabilityGroupReplica3Object.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                                        $mockAvailabilityGroupReplica3Object.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                                        $mockAvailabilityGroupReplica3Object.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                                        $mockAvailabilityGroupReplica3Object.Name = $mockAvailabilityGroupReplica3Name
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                                        $mockAvailabilityGroupReplica3Object.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            # Mock the availability groups
+            $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup1.Name = $mockAvailabilityGroup1Name
+            $mockAvailabilityGroup1.PrimaryReplicaServerName = $mockAvailabilityGroup1PrimaryReplicaServer
+            $mockAvailabilityGroup1.LocalReplicaRole = 'Secondary'
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica1)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup1.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup1)
 
-                                        return @{
-                                            $mockAvailabilityGroupReplica2Name = $mockAvailabilityGroupReplica2Object
-                                            $mockAvailabilityGroupReplica3Name = $mockAvailabilityGroupReplica3Object
-                                        }
-                                    } -PassThru -Force
-                                )
-                            }
-                        } -PassThru -Force |
-                        Add-Member ScriptProperty Endpoints {
-                            return $mockEndpoint
-                        } -PassThru -Force
-                )
-            )
+            $mockAvailabilityGroup2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup2.Name = $mockAvailabilityGroup2Name
+            $mockAvailabilityGroup2.PrimaryReplicaServerName = $mockAvailabilityGroup2PrimaryReplicaServer
+            $mockAvailabilityGroup2.LocalReplicaRole = 'Secondary'
+            $mockAvailabilityGroup2.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup2.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup2)
 
-            # Type the mock as a server object
-            $mock.PSObject.TypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
+            $mockAvailabilityGroup3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
+            $mockAvailabilityGroup3.Name = $mockAvailabilityGroup3Name
+            $mockAvailabilityGroup3.PrimaryReplicaServerName = $mockAvailabilityGroup3PrimaryReplicaServer
+            $mockAvailabilityGroup3.LocalReplicaRole = 'Primary'
+            $mockAvailabilityGroup3.AvailabilityReplicas.Add($mockAvailabilityGroupReplica2)
+            $mockAvailabilityGroup3.AvailabilityReplicas.Add($mockAvailabilityGroupReplica3)
+            $mockServerObject.AvailabilityGroups.Add($mockAvailabilityGroup3)
 
-            return $mock
+            # Mock the mirroring endpoint if required
+            if ( $mockDatabaseMirroringEndpoint )
+            {
+                $mockEndpoint = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Endpoint
+                $mockEndpoint.EndpointType = 'DatabaseMirroring'
+                $mockEndpoint.Protocol = @{
+                    TCP = @{
+                        ListenerPort = $mockendpointPort
+                    }
+                }
+                $mockServerObject.Endpoints.Add($mockEndpoint)
+            }
+
+            return $mockServerObject
         }
 
         $mockAvailabilityGroupReplicaPropertyName = '' # Set dynamically during runtime
@@ -717,7 +579,7 @@ try
             }
 
             BeforeEach {
-                $mockEndpoint = $mockDatabaseMirroringEndpointPresent
+                $mockDatabaseMirroringEndpoint = $true
                 $mockLogins = $mockNtServiceClusSvcPresent
                 $mockServer1IsHadrEnabled = $true
 
@@ -726,7 +588,7 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer3 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer3Name }
                 Mock -CommandName Join-SqlAvailabilityGroup -MockWith {} -Verifiable
                 Mock -CommandName New-SqlAvailabilityReplica {} -Verifiable
-                Mock -CommandName Test-LoginEffectivePermissions -MockWith { $true } -Verifiable
+                Mock -CommandName Test-ClusterPermissions -MockWith { $null } -Verifiable
             }
 
             Context 'When the desired state is absent' {
@@ -759,7 +621,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -777,7 +639,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
             }
@@ -823,15 +685,17 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error (ClusterPermissionsMissing) when the logins "NT SERVICE\ClusSvc" or "NT AUTHORITY\SYSTEM" are absent' {
+                It "Should throw when the logins '$($mockNtServiceClusSvcName)' or '$($mockNtAuthoritySystemName)' are absent or do not have permissions to manage availability groups" {
+
+                    Mock -CommandName Test-ClusterPermissions -MockWith { throw } -Verifiable
 
                     $mockLogins = $mockAllLoginsAbsent.Clone()
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ClusterPermissionsMissing'
+                    { Set-TargetResource @setTargetResourceParameters } | Should Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
@@ -839,33 +703,13 @@ try
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error (ClusterPermissionsMissing) when the logins "NT SERVICE\ClusSvc" and "NT AUTHORITY\SYSTEM" do not have permissions to manage availability groups' {
-
-                    $mockLogins = $mockAllLoginsPresent.Clone()
-
-                    Mock -CommandName Test-LoginEffectivePermissions -MockWith { $false } -Verifiable
-
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ClusterPermissionsMissing'
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 2 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should create the availability group replica when "NT SERVICE\ClusSvc" is present and has the permissions to manage availability groups' {
+                It "Should create the availability group replica when '$($mockNtServiceClusSvcName)' or '$($mockNtAuthoritySystemName)' is present and has the permissions to manage availability groups" {
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
@@ -877,31 +721,13 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
-                }
-
-                It 'Should create the availability group replica when "NT AUTHORITY\SYSTEM" is present and has the permissions to manage availability groups' {
-
-                    $mockLogins = $mockNtAuthoritySystemPresent
-
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should throw the correct error (DatabaseMirroringEndpointNotFound) when the database mirroring endpoint is not absent' {
 
-                    $mockEndpoint = $mockDatabaseMirroringEndpointAbsent
+                    $mockDatabaseMirroringEndpoint = $false
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
@@ -913,7 +739,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -931,7 +757,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -949,11 +775,11 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error (CreateAvailabilityGroupReplicaFailed) when the availability group replica fails to create' {
+                It 'Should throw the correct error when the availability group replica fails to create' {
 
                     Mock -CommandName New-SqlAvailabilityReplica { throw } -Verifiable
 
@@ -967,7 +793,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -985,7 +811,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -1003,7 +829,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
             }
@@ -1063,7 +889,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
@@ -1085,7 +911,7 @@ try
                         Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                         Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                         Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                        Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 #-Exactly
                     }
                 }
@@ -1104,7 +930,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
 
@@ -1124,7 +950,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
 
@@ -1144,7 +970,7 @@ try
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-TerminatingError -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ClusterPermissions -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 1 -Exactly
                 }
             }
@@ -1155,7 +981,7 @@ try
             BeforeEach {
                 $mockAlternateEndpointPort = $false
                 $mockAlternateEndpointProtocol = $false
-                $mockEndpoint = $mockDatabaseMirroringEndpointPresent
+                $mockDatabaseMirroringEndpoint = $true
 
                 $testTargetResourceParameters = @{
                     Name = $mockSqlServer

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -351,6 +351,11 @@ namespace Microsoft.SqlServer.Management.Smo
         public string MockName;
         public LoginType MockLoginType;
 
+        public Login( string name )
+        {
+            this.Name = name;
+        }
+
         public Login( Server server, string name )
         {
             this.Name = name;

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -698,8 +698,8 @@ namespace Microsoft.SqlServer.Management.Smo
         {}
 
         public string AutomatedBackupPreference;
-        public AvailabilityDatabaseCollection AvailabilityDatabases;
-        public AvailabilityReplicaCollection AvailabilityReplicas;
+        public AvailabilityDatabaseCollection AvailabilityDatabases = new AvailabilityDatabaseCollection();
+        public AvailabilityReplicaCollection AvailabilityReplicas = new AvailabilityReplicaCollection();
         public bool BasicAvailabilityGroup;
         public bool DatabaseHealthTrigger;
         public bool DtcSupportEnabled;

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -248,7 +248,7 @@ namespace Microsoft.SqlServer.Management.Smo
         public string InstanceName;
         public bool IsClustered = false;
         public bool IsHadrEnabled = false;
-        public Hashtable Logins;
+        public Hashtable Logins = new Hashtable();
         public string Name;
         public string NetName;
         public Hashtable Roles;

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -237,13 +237,13 @@ namespace Microsoft.SqlServer.Management.Smo
     {
         public string MockGranteeName;
 
-        public AvailabilityGroupCollection AvailabilityGroups;
+        public AvailabilityGroupCollection AvailabilityGroups = new AvailabilityGroupCollection();
         public ConnectionContext ConnectionContext;
         public string ComputerNamePhysicalNetBIOS;
-        public DatabaseCollection Databases;
+        public DatabaseCollection Databases = new DatabaseCollection();
         public string DisplayName;
         public string DomainInstanceName;
-        public EndpointCollection Endpoints;
+        public EndpointCollection Endpoints = new EndpointCollection();
         public string FilestreamLevel = "Disabled";
         public string InstanceName;
         public bool IsClustered = false;
@@ -251,9 +251,9 @@ namespace Microsoft.SqlServer.Management.Smo
         public Hashtable Logins = new Hashtable();
         public string Name;
         public string NetName;
-        public Hashtable Roles;
+        public Hashtable Roles = new Hashtable();
         public string ServiceName;
-        public Hashtable Version;
+        public Hashtable Version = new Hashtable();
 
         public Server(){}
         public Server(string name)

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -1533,20 +1533,30 @@ InModuleScope $script:moduleName {
 
     Describe 'Testing Test-ClusterPermissions' {
         BeforeAll {
-            Mock -CommandName Test-LoginEffectivePermissions -MockWith { $mockClusterServicePermissionsPresent } -Verifiable -ParameterFilter { $LoginName -eq $clusterServiceName }
-            Mock -CommandName Test-LoginEffectivePermissions -MockWith { $mockSystemPermissionsPresent } -Verifiable -ParameterFilter { $LoginName -eq $systemAccountName }
+            Mock -CommandName Test-LoginEffectivePermissions -MockWith {
+                $mockClusterServicePermissionsPresent
+            } -Verifiable -ParameterFilter {
+                $LoginName -eq $clusterServiceName
+            }
+
+            Mock -CommandName Test-LoginEffectivePermissions -MockWith {
+                $mockSystemPermissionsPresent
+            } -Verifiable -ParameterFilter {
+                $LoginName -eq $systemAccountName
+            }
 
             $clusterServiceName = 'NT SERVICE\ClusSvc'
             $systemAccountName= 'NT AUTHORITY\System'
         }
+
         BeforeEach {
             $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
             $mockServerObject.NetName = 'TestServer'
             $mockServerObject.ServiceName = 'MSSQLSERVER'
 
             $mockLogins = @{
-                $clusterServiceName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerObject,$clusterServiceName)
-                $systemAccountName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerObject,$systemAccountName)
+                $clusterServiceName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $mockServerObject,$clusterServiceName
+                $systemAccountName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $mockServerObject,$systemAccountName
             }
 
             $mockServerObject.Logins = $mockLogins
@@ -1561,15 +1571,23 @@ InModuleScope $script:moduleName {
 
                 { Test-ClusterPermissions -ServerObject $mockServerObject } | Should Throw ( "The cluster does not have permissions to manage the Availability Group on '{0}\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either '$($clusterServiceName)' or '$($systemAccountName)'." -f $mockServerObject.NetName,$mockServerObject.ServiceName )
 
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter {
+                    $LoginName -eq $clusterServiceName
+                }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter {
+                    $LoginName -eq $systemAccountName
+                }
             }
 
             It "Should throw the correct error when the logins '$($clusterServiceName)' and '$($systemAccountName)' do not have permissions to manage availability groups" {
                 { Test-ClusterPermissions -ServerObject $mockServerObject } | Should Throw ( "The cluster does not have permissions to manage the Availability Group on '{0}\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either '$($clusterServiceName)' or '$($systemAccountName)'." -f $mockServerObject.NetName,$mockServerObject.ServiceName )
 
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter {
+                    $LoginName -eq $clusterServiceName
+                }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter {
+                    $LoginName -eq $systemAccountName
+                }
             }
         }
 
@@ -1577,19 +1595,27 @@ InModuleScope $script:moduleName {
             It "Should return NullOrEmpty when '$($clusterServiceName)' is present and has the permissions to manage availability groups" {
                 $mockClusterServicePermissionsPresent = $true
 
-                Test-ClusterPermissions -ServerObject $mockServerObject | Should BeNullOrEmpty
+                Test-ClusterPermissions -ServerObject $mockServerObject | Should Be $true
 
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter {
+                    $LoginName -eq $clusterServiceName
+                }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter {
+                    $LoginName -eq $systemAccountName
+                }
             }
 
             It "Should return NullOrEmpty when '$($systemAccountName)' is present and has the permissions to manage availability groups" {
                 $mockSystemPermissionsPresent = $true
 
-                Test-ClusterPermissions -ServerObject $mockServerObject | Should BeNullOrEmpty
+                Test-ClusterPermissions -ServerObject $mockServerObject | Should Be $true
 
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
-                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter {
+                    $LoginName -eq $clusterServiceName
+                }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter {
+                    $LoginName -eq $systemAccountName
+                }
             }
         }
     }

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -1530,4 +1530,67 @@ InModuleScope $script:moduleName {
             }
         }
     }
+
+    Describe 'Testing Test-ClusterPermissions' {
+        BeforeAll {
+            Mock -CommandName Test-LoginEffectivePermissions -MockWith { $mockClusterServicePermissionsPresent } -Verifiable -ParameterFilter { $LoginName -eq $clusterServiceName }
+            Mock -CommandName Test-LoginEffectivePermissions -MockWith { $mockSystemPermissionsPresent } -Verifiable -ParameterFilter { $LoginName -eq $systemAccountName }
+
+            $clusterServiceName = 'NT SERVICE\ClusSvc'
+            $systemAccountName= 'NT AUTHORITY\System'
+        }
+        BeforeEach {
+            $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $mockServerObject.NetName = 'TestServer'
+            $mockServerObject.ServiceName = 'MSSQLSERVER'
+
+            $mockLogins = @{
+                $clusterServiceName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerObject,$clusterServiceName)
+                $systemAccountName = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockServerObject,$systemAccountName)
+            }
+
+            $mockServerObject.Logins = $mockLogins
+
+            $mockClusterServicePermissionsPresent = $false
+            $mockSystemPermissionsPresent = $false
+        }
+
+        Context 'When the cluster does not have permissions to the instance' {
+            It "Should throw the correct error when the logins '$($clusterServiceName)' or '$($systemAccountName)' are absent" {
+                $mockServerObject.Logins = @{}
+
+                { Test-ClusterPermissions -ServerObject $mockServerObject } | Should Throw ( "The cluster does not have permissions to manage the Availability Group on '{0}\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either '$($clusterServiceName)' or '$($systemAccountName)'." -f $mockServerObject.NetName,$mockServerObject.ServiceName )
+
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+            }
+
+            It "Should throw the correct error when the logins '$($clusterServiceName)' and '$($systemAccountName)' do not have permissions to manage availability groups" {
+                { Test-ClusterPermissions -ServerObject $mockServerObject } | Should Throw ( "The cluster does not have permissions to manage the Availability Group on '{0}\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either '$($clusterServiceName)' or '$($systemAccountName)'." -f $mockServerObject.NetName,$mockServerObject.ServiceName )
+
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+            }
+        }
+
+        Context 'When the cluster has permissions to the instance' {
+            It "Should return NullOrEmpty when '$($clusterServiceName)' is present and has the permissions to manage availability groups" {
+                $mockClusterServicePermissionsPresent = $true
+
+                Test-ClusterPermissions -ServerObject $mockServerObject | Should BeNullOrEmpty
+
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 0 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+            }
+
+            It "Should return NullOrEmpty when '$($systemAccountName)' is present and has the permissions to manage availability groups" {
+                $mockSystemPermissionsPresent = $true
+
+                Test-ClusterPermissions -ServerObject $mockServerObject | Should BeNullOrEmpty
+
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $clusterServiceName }
+                Assert-MockCalled -CommandName Test-LoginEffectivePermissions -Scope It -Times 1 -Exactly -ParameterFilter { $LoginName -eq $systemAccountName }
+            }
+        }
+    }
 }

--- a/en-US/xSQLServerHelper.strings.psd1
+++ b/en-US/xSQLServerHelper.strings.psd1
@@ -38,6 +38,9 @@ ConvertFrom-StringData @'
     ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.
     AlterAvailabilityGroupReplicaFailed = Failed to alter the availability group replica '{0}'.
     GetEffectivePermissionForLogin = Getting the effective permissions for the login '{0}' on '{1}'.
+    ClusterPermissionsMissing = The cluster does not have permissions to manage the Availability Group on '{0}\\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either 'NT SERVICE\\ClusSvc' or 'NT AUTHORITY\\SYSTEM'.
+    ClusterLoginMissing = The {0}login '{1}' is not present. {2}
+    ClusterLoginMissingPermissions = The {0}account '{1}' is missing one or more of the following permissions: {2}
 
     # - NOTE!
     # - Below strings are used by helper functions New-TerminatingError and New-WarningMessage.
@@ -108,7 +111,6 @@ ConvertFrom-StringData @'
     DropLoginFailed = Dropping the login '{0}' failed.
 
     # AlwaysOnAvailabilityGroup
-    ClusterPermissionsMissing = The cluster does not have permissions to manage the Availability Group on '{0}\\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either 'NT SERVICE\\ClusSvc' or 'NT AUTHORITY\\SYSTEM'.
     CreateAvailabilityGroupReplicaFailed = Creating the Availability Group Replica '{0}' failed on the instance '{1}'.
     CreateAvailabilityGroupFailed = Creating the availability group '{0}'.
     DatabaseMirroringEndpointNotFound = No database mirroring endpoint was found on '{0}\{1}'.

--- a/en-US/xSQLServerHelper.strings.psd1
+++ b/en-US/xSQLServerHelper.strings.psd1
@@ -39,8 +39,10 @@ ConvertFrom-StringData @'
     AlterAvailabilityGroupReplicaFailed = Failed to alter the availability group replica '{0}'.
     GetEffectivePermissionForLogin = Getting the effective permissions for the login '{0}' on '{1}'.
     ClusterPermissionsMissing = The cluster does not have permissions to manage the Availability Group on '{0}\\{1}'. Grant 'Connect SQL', 'Alter Any Availability Group', and 'View Server State' to either 'NT SERVICE\\ClusSvc' or 'NT AUTHORITY\\SYSTEM'.
-    ClusterLoginMissing = The {0}login '{1}' is not present. {2}
-    ClusterLoginMissingPermissions = The {0}account '{1}' is missing one or more of the following permissions: {2}
+    ClusterLoginMissing = The login '{0}' is not present. {1}
+    ClusterLoginMissingPermissions = The account '{0}' is missing one or more of the following permissions: {1}
+    ClusterLoginMissingRecommendedPermissions = The recommended account '{0}' is missing one or more of the following permissions: {1}
+    ClusterLoginPermissionsPresent = The cluster login '{0}' has the required permissions.
 
     # - NOTE!
     # - Below strings are used by helper functions New-TerminatingError and New-WarningMessage.

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -1198,6 +1198,8 @@ function Split-FullSQLInstanceName
 #>
 function Test-ClusterPermissions
 {
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -1233,14 +1235,18 @@ function Test-ClusterPermissions
                 {
                     $clusterServiceName
                     {
-                        Write-Verbose -Message ( $script:localizedData.ClusterLoginMissingPermissions -f 'recommended ',$loginName,( $availabilityGroupManagementPerms -join ', ' ) )
+                        Write-Verbose -Message ( $script:localizedData.ClusterLoginMissingRecommendedPermissions -f $loginName,( $availabilityGroupManagementPerms -join ', ' ) ) -Verbose
                     }
 
                     $ntAuthoritySystemName
                     {
-                        Write-Verbose -Message ( $script:localizedData.ClusterLoginMissingPermissions -f '',$loginName,( $availabilityGroupManagementPerms -join ', ' ) )
+                        Write-Verbose -Message ( $script:localizedData.ClusterLoginMissingPermissions -f $loginName,( $availabilityGroupManagementPerms -join ', ' ) ) -Verbose
                     }
                 }
+            }
+            else
+            {
+                Write-Verbose -Message ( $script:localizedData.ClusterLoginPermissionsPresent -f $loginName ) -Verbose
             }
         }
         elseif ( -not $clusterPermissionsPresent )
@@ -1249,12 +1255,12 @@ function Test-ClusterPermissions
             {
                 $clusterServiceName
                 {
-                    Write-Verbose -Message ($script:localizedData.ClusterLoginMissing -f 'recommended ',$loginName,"Trying with '$ntAuthoritySystemName'.")
+                    Write-Verbose -Message ($script:localizedData.ClusterLoginMissingRecommendedPermissions -f $loginName,"Trying with '$ntAuthoritySystemName'.") -Verbose
                 }
 
                 $ntAuthoritySystemName
                 {
-                    Write-Verbose -Message ( $script:localizedData.ClusterLoginMissing -f '',$loginName,'' )
+                    Write-Verbose -Message ( $script:localizedData.ClusterLoginMissing -f $loginName,'' ) -Verbose
                 }
             }
         }
@@ -1265,4 +1271,6 @@ function Test-ClusterPermissions
     {
         throw ($script:localizedData.ClusterPermissionsMissing -f $sqlServer,$sqlInstanceName )
     }
+
+    return $clusterPermissionsPresent
 }


### PR DESCRIPTION
**Pull Request (PR) description**
- Added new helper function "Test-ClusterPermissions".
- Changes to xSQLServerAlwaysOnAvailabilityGroup
  - Use the new helper function "Test-ClusterPermissions".
  - Refactored the unit tests to allow them to be more user friendly.
- Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
  - Use the new helper function "Test-ClusterPermissions".
- Changes to SMO.cs
  - Added default properties to the Server class
    - AvailabilityGroups
    - Databases
    - EndpointCollection
  - Added a new overload to the Login class
  - Added default properties to the AvailabilityReplicas class
    - AvailabilityDatabases
    - AvailabilityReplicas

**This Pull Request (PR) fixes the following issues:**
Fixes #446 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/830)
<!-- Reviewable:end -->
