### PR TITLE
xSQLServerRSConfig: Restart Reporting Services after initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@
     Services has not been initialized ([issue #822](https://github.com/PowerShell/xSQLServer/issues/822)).
   - Fixed so that when two Reporting Services are installed for the same major
     version the resource does not throw an error ([issue #819](https://github.com/PowerShell/xSQLServer/issues/819)).
+  - Now the resource will restart the Reporting Services service after
+    initializing ([issue #592](https://github.com/PowerShell/xSQLServer/issues/592)).
+    This will enable the Reports site to work.
 
 ## 8.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
+++ b/DSCResources/MSFT_xSQLServerRSConfig/MSFT_xSQLServerRSConfig.psm1
@@ -192,6 +192,8 @@ function Set-TargetResource
         Invoke-Sqlcmd -ServerInstance $reportingServicesConnection -Query $reportingServicesDatabaseRightsScript.Script
         $null = $reportingServicesConfiguration.SetDatabaseConnection($reportingServicesConnection, $reportingServicesDatabaseName, 2, '', '')
         $null = $reportingServicesConfiguration.InitializeReportServer($reportingServicesConfiguration.InstallationID)
+
+        Restart-ReportingServicesService -SQLInstanceName $InstanceName
     }
 
     if ( !(Test-TargetResource @PSBoundParameters) )

--- a/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerRSConfig.Tests.ps1
@@ -260,6 +260,7 @@ try
                 Mock -CommandName Import-SQLPSModule -Verifiable
                 Mock -CommandName Invoke-Sqlcmd -Verifiable
                 Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty -Verifiable
+                Mock -CommandName Restart-ReportingServicesService -Verifiable
             }
 
             Context 'When the system is not in the desired state' {
@@ -311,6 +312,7 @@ try
 
                         Assert-MockCalled -CommandName Get-WmiObject -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Restart-ReportingServicesService -Exactly -Times 1 -Scope It
                     }
 
                     Context 'When there is no Reporting Services instance after Set-TargetResource has been called' {
@@ -365,6 +367,7 @@ try
 
                         Assert-MockCalled -CommandName Get-WmiObject -Exactly -Times 2 -Scope It
                         Assert-MockCalled -CommandName Invoke-Sqlcmd -Exactly -Times 2 -Scope It
+                        Assert-MockCalled -CommandName Restart-ReportingServicesService -Exactly -Times 1 -Scope It
                     }
                 }
             }

--- a/Tests/Unit/xSQLServerHelper.Tests.ps1
+++ b/Tests/Unit/xSQLServerHelper.Tests.ps1
@@ -1619,4 +1619,68 @@ InModuleScope $script:moduleName {
             }
         }
     }
+
+    Describe 'Testing Restart-ReportingServicesService' {
+        Context 'When restarting a Report Services default instance' {
+            BeforeAll {
+                $mockServiceName = 'ReportServer'
+
+                Mock -CommandName Restart-Service -Verifiable
+                Mock -CommandName Start-Service -Verifiable
+                Mock -CommandName Get-Service -MockWith {
+                    return @{
+                        Name = $mockServiceName
+                        DependentServices = @(
+                            @{
+                                Name = 'DependentService'
+                                Status = 'Running'
+                                DependentServices = @()
+                            }
+                        )
+                    }
+                }
+            }
+
+            It 'Should restart the service and dependent service' {
+                { Restart-ReportingServicesService -SQLInstanceName 'MSSQLSERVER' } | Should Not Throw
+
+                Assert-MockCalled -CommandName Get-Service -ParameterFilter {
+                    $Name -eq $mockServiceName
+                } -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 1
+            }
+        }
+
+        Context 'When restarting a Report Services named instance' {
+            BeforeAll {
+                $mockServiceName = 'ReportServer$TEST'
+
+                Mock -CommandName Restart-Service -Verifiable
+                Mock -CommandName Start-Service -Verifiable
+                Mock -CommandName Get-Service -MockWith {
+                    return @{
+                        Name = $mockServiceName
+                        DependentServices = @(
+                            @{
+                                Name = 'DependentService'
+                                Status = 'Running'
+                                DependentServices = @()
+                            }
+                        )
+                    }
+                }
+            }
+
+            It 'Should restart the service and dependent service' {
+                { Restart-ReportingServicesService -SQLInstanceName 'TEST' } | Should Not Throw
+
+                Assert-MockCalled -CommandName Get-Service -ParameterFilter {
+                    $Name -eq $mockServiceName
+                } -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Restart-Service -Scope It -Exactly -Times 1
+                Assert-MockCalled -CommandName Start-Service -Scope It -Exactly -Times 1
+            }
+        }
+    }
 }

--- a/en-US/xSQLServerHelper.strings.psd1
+++ b/en-US/xSQLServerHelper.strings.psd1
@@ -31,8 +31,8 @@ ConvertFrom-StringData @'
     BringClusterResourcesOffline = Bringing the SQL Server resources {0} offline.
     BringSqlServerClusterResourcesOnline = Bringing the SQL Server resource back online.
     BringSqlServerAgentClusterResourcesOnline = Bringing the SQL Server Agent resource online.
-    GetSqlServerService = Getting SQL Server service information.
-    RestartSqlServerService = SQL Server service restarting.
+    GetServiceInformation = Getting {0} service information.
+    RestartService = {0} service restarting.
     StartingDependentService = Starting service {0}
     ExecuteQueryWithResultsFailed = Executing query with results failed on database '{0}'.
     ExecuteNonQueryFailed = Executing non-query failed on database '{0}'.

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -819,7 +819,7 @@ function Restart-SqlService
     }
     else
     {
-        Write-Verbose -Message ($script:localizedData.GetSqlServerService) -Verbose
+        Write-Verbose -Message ($script:localizedData.GetServiceInformation -f 'SQL Server') -Verbose
         $sqlService = Get-Service -DisplayName "SQL Server ($($serverObject.ServiceName))"
 
         <#
@@ -829,7 +829,7 @@ function Restart-SqlService
         $agentService = $sqlService.DependentServices | Where-Object -FilterScript { $_.Status -eq 'Running' }
 
         # Restart the SQL Server service
-        Write-Verbose -Message ($script:localizedData.RestartSqlServerService) -Verbose
+        Write-Verbose -Message ($script:localizedData.RestartService -f 'SQL Server') -Verbose
         $sqlService | Restart-Service -Force
 
         # Start dependent services
@@ -837,6 +837,55 @@ function Restart-SqlService
             Write-Verbose -Message ($script:localizedData.StartingDependentService -f $_.DisplayName) -Verbose
             $_ | Start-Service
         }
+    }
+}
+
+<#
+    .SYNOPSIS
+    Restarts a SQL Server instance and associated services
+
+    .PARAMETER SQLServer
+    Hostname of the SQL Server to be configured
+
+    .PARAMETER SQLInstanceName
+    Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
+#>
+function Restart-ReportingServicesService
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $SQLInstanceName = 'MSSQLSERVER'
+    )
+
+    $ServiceName = 'ReportServer'
+
+    if (-not ($SQLInstanceName -eq 'MSSQLSERVER'))
+    {
+        $ServiceName += '${0}' -f $SQLInstanceName
+    }
+
+    Write-Verbose -Message ($script:localizedData.GetServiceInformation -f 'Reporting Services') -Verbose
+    $reportingServicesService = Get-Service -Name $ServiceName
+
+    <#
+        Get all dependent services that are running.
+        There are scenarios where an automatic service is stopped and should
+        not be restarted automatically.
+    #>
+    $dependentService = $reportingServicesService.DependentServices | Where-Object -FilterScript {
+        $_.Status -eq 'Running'
+    }
+
+    Write-Verbose -Message ($script:localizedData.RestartService -f 'Reporting Services') -Verbose
+    $reportingServicesService | Restart-Service -Force
+
+    # Start dependent services
+    $dependentService | ForEach-Object {
+        Write-Verbose -Message ($script:localizedData.StartingDependentService -f $_.DisplayName) -Verbose
+        $_ | Start-Service
     }
 }
 

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -842,13 +842,11 @@ function Restart-SqlService
 
 <#
     .SYNOPSIS
-    Restarts a SQL Server instance and associated services
-
-    .PARAMETER SQLServer
-    Hostname of the SQL Server to be configured
+    Restarts a Reporting Services instance and associated services
 
     .PARAMETER SQLInstanceName
-    Name of the SQL instance to be configured. Default is 'MSSQLSERVER'
+    Name of the instance to be restarted. Default is 'MSSQLSERVER'
+    (the default instance).
 #>
 function Restart-ReportingServicesService
 {


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerRSConfig
  - Now the resource will restart the Reporting Services service after
    initializing (issue #592). This will enable the Reports site to work.

**This Pull Request (PR) fixes the following issues:**
Fixes #592 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/837)
<!-- Reviewable:end -->
