### PR TITLE
xSQLServerAlwaysOnAvailabilityGroup: Added missing read-only properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@
     Group is created.
   - Use the new helper function "Test-ClusterPermissions".
   - Refactored the unit tests to allow them to be more user friendly.
+    Added the following read-only properties to the schema ([issue #476](https://github.com/PowerShell/xSQLServer/issues/476))
+    - EndpointPort
+    - EndpointURL
+    - SQLServerNetName
+    - Version
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.schema.mof
@@ -17,4 +17,8 @@ class MSFT_xSQLServerAlwaysOnAvailabilityGroup : OMI_BaseResource
     [Write, Description("Specifies the automatic failover behavior of the availability group."), ValueMap{"OnServerDown","OnServerUnresponsive","OnCriticalServerErrors","OnModerateServerErrors","OnAnyQualifiedFailureCondition"}, Values{"OnServerDown","OnServerUnresponsive","OnCriticalServerErrors","OnModerateServerErrors","OnAnyQualifiedFailureCondition"}] String FailureConditionLevel;
     [Write, Description("Specifies the failover mode. Default is 'Manual'."), ValueMap{"Automatic","Manual"}, Values{"Automatic","Manual"}] String FailoverMode;
     [Write, Description("Specifies the length of time, in milliseconds, after which AlwaysOn availability groups declare an unresponsive server to be unhealthy. Default is 30000.")] UInt32 HealthCheckTimeout;
+    [Read, Description("Gets the Endpoint URL of the availability group replica endpoint.")] String EndpointUrl;
+    [Read, Description("Gets the port the database mirroring endpoint is listening on.")] UInt32 EndpointPort;
+    [Read, Description("Gets the hostname the SQL Server Instance is listening on.")] String SQLServerNetName;
+    [Read, Description("Gets the major version of the SQL Server Instance.")] UInt32 Version;
 };

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.schema.mof
@@ -19,6 +19,6 @@ class MSFT_xSQLServerAlwaysOnAvailabilityGroup : OMI_BaseResource
     [Write, Description("Specifies the length of time, in milliseconds, after which AlwaysOn availability groups declare an unresponsive server to be unhealthy. Default is 30000.")] UInt32 HealthCheckTimeout;
     [Read, Description("Gets the Endpoint URL of the availability group replica endpoint.")] String EndpointUrl;
     [Read, Description("Gets the port the database mirroring endpoint is listening on.")] UInt32 EndpointPort;
-    [Read, Description("Gets the hostname the SQL Server Instance is listening on.")] String SQLServerNetName;
-    [Read, Description("Gets the major version of the SQL Server Instance.")] UInt32 Version;
+    [Read, Description("Gets the hostname the SQL Server instance is listening on.")] String SQLServerNetName;
+    [Read, Description("Gets the major version of the SQL Server instance.")] UInt32 Version;
 };

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ It will also manage the Availability Group replica on the specified node.
   Default is 'Manual'. { Automatic | *Manual* }
 * **`[Uint32]` HealthCheckTimeout** _(Write)_: Specifies the length of time, in
   milliseconds, after which AlwaysOn availability groups declare an unresponsive
+  server to be unhealthy. Default is 30000.
 
 #### Read-Only Properties from Get-TargetResource
 
-  server to be unhealthy. Default is 30000.
 * **`[String]` EndpointUrl** _(Read)_: Gets the Endpoint URL of the
   availability group replica endpoint.
 * **`[Uint32]` EndpointPort** _(Read)_: Gets the port the database mirroring

--- a/README.md
+++ b/README.md
@@ -242,15 +242,18 @@ It will also manage the Availability Group replica on the specified node.
   Default is 'Manual'. { Automatic | *Manual* }
 * **`[Uint32]` HealthCheckTimeout** _(Write)_: Specifies the length of time, in
   milliseconds, after which AlwaysOn availability groups declare an unresponsive
+
+#### Read-Only Properties from Get-TargetResource
+
   server to be unhealthy. Default is 30000.
 * **`[String]` EndpointUrl** _(Read)_: Gets the Endpoint URL of the
   availability group replica endpoint.
 * **`[Uint32]` EndpointPort** _(Read)_: Gets the port the database mirroring
   endpoint is listening on
 * **`[String]` SQLServerNetName** _(Read)_: Gets the hostname the SQL Server
-  Instance is listening on.
+  instance is listening on.
 * **`[Uint32]` Version** _(Read)_: Gets the major version of the SQL Server
-  Instance.
+  instance.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ It will also manage the Availability Group replica on the specified node.
 * **`[Uint32]` HealthCheckTimeout** _(Write)_: Specifies the length of time, in
   milliseconds, after which AlwaysOn availability groups declare an unresponsive
   server to be unhealthy. Default is 30000.
+* **`[String]` EndpointUrl** _(Read)_: Gets the Endpoint URL of the
+  availability group replica endpoint.
+* **`[Uint32]` EndpointPort** _(Read)_: Gets the port the database mirroring
+  endpoint is listening on
+* **`[String]` SQLServerNetName** _(Read)_: Gets the hostname the SQL Server
+  Instance is listening on.
+* **`[Uint32]` Version** _(Read)_: Gets the major version of the SQL Server
+  Instance.
 
 #### Examples
 


### PR DESCRIPTION
**Pull Request (PR) description**
Added missing read-only properties to the xSQLServerAlwaysOnAvailabilityGroup schema.

**This Pull Request (PR) fixes the following issues:**
Fixes #787 

**Task list:**
- [ ] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/838)
<!-- Reviewable:end -->
