### PR TITLE
xSQLServerAlwaysOnAvailabilityGroup\Replica: Utilize the Get-PrimaryReplicaServerObject helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,14 @@
     - EndpointURL
     - SQLServerNetName
     - Version
+  - Use the Get-PrimaryReplicaServerObject helper function
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
     - EndpointPort
     - EndpointURL
   - Use the new helper function "Test-ClusterPermissions".
+  - Use the Get-PrimaryReplicaServerObject helper function
 - Changes to xSQLServerHelper
   - Fixed Connect-SQL by ensuring the Status property returns 'Online' prior to
     returning the SQL Server object ([issue #333](https://github.com/PowerShell/xSQLServer/issues/333)).

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -368,11 +368,8 @@ function Set-TargetResource
             else
             {
                 # Make sure we're communicating with the primary replica
-                if ( $availabilityGroup.LocalReplicaRole -ne 'Primary' )
-                {
-                    $primaryServerObject = Connect-SQL -SQLServer $availabilityGroup.PrimaryReplicaServerName
-                    $availabilityGroup = $primaryServerObject.AvailabilityGroups[$Name]
-                }
+                $primaryServerObject = Get-PrimaryReplicaServerObject -ServerObject $serverObject -AvailabilityGroup $availabilityGroup
+                $availabilityGroup = $primaryServerObject.AvailabilityGroups[$Name]
 
                 if ( $AutomatedBackupPreference -ne $availabilityGroup.AutomatedBackupPreference )
                 {

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.psm1
@@ -240,7 +240,7 @@ function Set-TargetResource
     {
         while ( $availabilityGroup.LocalReplicaRole -ne 'Primary' )
         {
-            $primaryServerObject = Connect-SQL -SQLServer $availabilityGroup.PrimaryReplicaServerName
+            $primaryServerObject = Get-PrimaryReplicaServerObject -ServerObject $serverObject -AvailabilityGroup $availabilityGroup
             $availabilityGroup = $primaryServerObject.AvailabilityGroups[$AvailabilityGroupName]
         }
     }
@@ -378,13 +378,8 @@ function Set-TargetResource
                 if ( $primaryReplicaAvailabilityGroup )
                 {
                     # Make sure the instance defined as the primary replica in the parameters is actually the primary replica
-                    if ( $primaryReplicaAvailabilityGroup.LocalReplicaRole -ne 'Primary' )
-                    {
-                        New-VerboseMessage -Message "The instance '$PrimaryReplicaSQLServer\$PrimaryReplicaSQLInstanceName' is not currently the primary replica. Connecting to '$($primaryReplicaAvailabilityGroup.PrimaryReplicaServerName)'."
-
-                        $primaryReplicaServerObject = Connect-SQL -SQLServer $primaryReplicaAvailabilityGroup.PrimaryReplicaServerName
-                        $primaryReplicaAvailabilityGroup = $primaryReplicaServerObject.AvailabilityGroups[$AvailabilityGroupName]
-                    }
+                    $primaryReplicaServerObject = Get-PrimaryReplicaServerObject -ServerObject $primaryReplicaServerObject -AvailabilityGroup $primaryReplicaAvailabilityGroup
+                    $availabilityGroup = $primaryReplicaServerObject.AvailabilityGroups[$AvailabilityGroupName]
 
                     # Build the endpoint URL
                     $endpointUrl = "TCP://$($EndpointHostName):$($endpointPort)"

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -109,7 +109,16 @@ try
 
                 [Parameter()]
                 [string]
-                $SQLInstanceName
+                $SQLInstanceName,
+
+                # The following two parameters are used to mock Get-PrimaryReplicaServerObject
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup,
+
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.Server]
+                $ServerObject
             )
 
             # Define the server object
@@ -188,7 +197,16 @@ try
 
                 [Parameter()]
                 [string]
-                $SQLInstanceName
+                $SQLInstanceName,
+
+                # The following two parameters are used to mock Get-PrimaryReplicaServerObject
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup,
+
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.Server]
+                $ServerObject
             )
 
             # Define the server object
@@ -477,6 +495,12 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
                     $SQLServer -eq $mockServer2Name
                 }
+                Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                }
+                Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                }
                 Mock -CommandName Invoke-Query -MockWith {} -Verifiable
                 Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
                 Mock -CommandName New-SqlAvailabilityGroup {} -Verifiable -ParameterFilter {
@@ -660,6 +684,12 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
                     }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
                         $Name -eq $mockAvailabilityGroupReplicaAbsentName
@@ -692,6 +722,12 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
                     }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
                         $Name -eq $mockAvailabilityGroupReplicaAbsentName
@@ -723,6 +759,12 @@ try
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
@@ -763,6 +805,12 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
                     }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly -ParameterFilter {
                         $Name -eq $mockAvailabilityGroupReplicaAbsentName
@@ -800,6 +848,12 @@ try
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
@@ -850,6 +904,12 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
                     }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
                         $Name -eq $mockAvailabilityGroupReplicaAbsentName
@@ -893,6 +953,12 @@ try
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
@@ -939,6 +1005,12 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
                     }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
                         $Name -eq $mockAvailabilityGroupReplicaAbsentName
@@ -975,11 +1047,17 @@ try
 
                     { Set-TargetResource @currentTestParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer1Name
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
@@ -1021,7 +1099,8 @@ try
                     # Define how many times each mock should be called
                     if ( $currentTestParameters.Ensure -eq 'Present' )
                     {
-                        $assertConnectSql = 2
+                        $assertConnectSql = 1
+                        $assertGetPrimaryReplicaServerObject = 1
                         $assertRemoveSqlAvailabilityGroup = 0
                         $assertTestClusterPermissions = 1
 
@@ -1047,6 +1126,7 @@ try
                     else
                     {
                         $assertConnectSql = 1
+                        $assertGetPrimaryReplicaServerObject = 0
                         $assertRemoveSqlAvailabilityGroup = 1
                         $assertTestClusterPermissions = 0
                         $assertUpdateAvailabilityGroup = 0
@@ -1060,6 +1140,12 @@ try
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time $assertGetPrimaryReplicaServerObject -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {
@@ -1099,11 +1185,17 @@ try
 
                     { Set-TargetResource @mockResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter {
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer1Name
                     }
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter {
                         $SQLServer -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
                     }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly -ParameterFilter {

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
@@ -3,9 +3,9 @@
 # Unit Test Template Version: 1.2.0
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module -Name ( Join-Path -Path ( Join-Path -Path $PSScriptRoot -ChildPath Stubs ) -ChildPath SQLPSStub.psm1 ) -Force -Global
@@ -19,9 +19,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {}
+function Invoke-TestSetup
+{
+}
 
-function Invoke-TestCleanup {
+function Invoke-TestCleanup
+{
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
 }
 
@@ -34,126 +37,126 @@ try
 
         #region parameter mocks
 
-            $mockSqlServer = 'Server1'
-            $mockSqlInstanceName = 'MSSQLSERVER'
-            $mockPrimaryReplicaSQLServer = 'Server2'
-            $mockPrimaryReplicaSQLInstanceName = 'MSSQLSERVER'
-            $mockAvailabilityGroupName = 'AG_AllServers'
-            $mockAvailabilityGroupReplicaName = $mockSqlServer
-            $mockEnsure = 'Present'
-            $mockAvailabilityMode = 'AsynchronousCommit'
-            $mockBackupPriority = 50
-            $mockConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockEndpointHostName = $mockSqlServer
-            $mockFailoverMode = 'Manual'
-            $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockSqlServer).domain.com:1433"
-            $mockReadOnlyRoutingList = @($mockSqlServer)
+        $mockSqlServer = 'Server1'
+        $mockSqlInstanceName = 'MSSQLSERVER'
+        $mockPrimaryReplicaSQLServer = 'Server2'
+        $mockPrimaryReplicaSQLInstanceName = 'MSSQLSERVER'
+        $mockAvailabilityGroupName = 'AG_AllServers'
+        $mockAvailabilityGroupReplicaName = $mockSqlServer
+        $mockEnsure = 'Present'
+        $mockAvailabilityMode = 'AsynchronousCommit'
+        $mockBackupPriority = 50
+        $mockConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockEndpointHostName = $mockSqlServer
+        $mockFailoverMode = 'Manual'
+        $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockSqlServer).domain.com:1433"
+        $mockReadOnlyRoutingList = @($mockSqlServer)
 
         #endregion
 
         #region server mock variables
 
-            $mockServer1Name = 'Server1'
-            $mockServer1NetName = $mockServer1Name
-            $mockServer1IsHadrEnabled = $true
-            $mockServer1ServiceName = 'MSSQLSERVER'
+        $mockServer1Name = 'Server1'
+        $mockServer1NetName = $mockServer1Name
+        $mockServer1IsHadrEnabled = $true
+        $mockServer1ServiceName = 'MSSQLSERVER'
 
-            $mockServer2Name = 'Server2'
-            $mockServer2NetName = $mockServer1Name
-            $mockServer2IsHadrEnabled = $true
-            $mockServer2ServiceName = $mockServer1ServiceName
+        $mockServer2Name = 'Server2'
+        $mockServer2NetName = $mockServer1Name
+        $mockServer2IsHadrEnabled = $true
+        $mockServer2ServiceName = $mockServer1ServiceName
 
-            $mockServer3Name = 'Server3'
-            $mockServer3NetName = $mockServer3Name
-            $mockServer3IsHadrEnabled = $true
-            $mockServer3ServiceName = $mockServer1ServiceName
+        $mockServer3Name = 'Server3'
+        $mockServer3NetName = $mockServer3Name
+        $mockServer3IsHadrEnabled = $true
+        $mockServer3ServiceName = $mockServer1ServiceName
 
         #endregion
 
         #region Login mocks
 
-            $mockLogins = @{} # Will be dynamically set during tests
+        $mockLogins = @{} # Will be dynamically set during tests
 
-            $mockNtServiceClusSvcName = 'NT SERVICE\ClusSvc'
-            $mockNtAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
+        $mockNtServiceClusSvcName = 'NT SERVICE\ClusSvc'
+        $mockNtAuthoritySystemName = 'NT AUTHORITY\SYSTEM'
 
-            $mockAllLoginsAbsent = @{}
+        $mockAllLoginsAbsent = @{}
 
-            $mockNtServiceClusSvcPresent = @{
-                $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtServiceClusSvcName) )
-            }
+        $mockNtServiceClusSvcPresent = @{
+            $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtServiceClusSvcName) )
+        }
 
-            $mockNtAuthoritySystemPresent = @{
-                $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtAuthoritySystemName) )
-            }
+        $mockNtAuthoritySystemPresent = @{
+            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtAuthoritySystemName) )
+        }
 
-            $mockAllLoginsPresent = @{
-                $mockNtServiceClusSvcName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtServiceClusSvcName) )
-                $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer,$mockNtAuthoritySystemName) )
-            }
+        $mockAllLoginsPresent = @{
+            $mockNtServiceClusSvcName  = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtServiceClusSvcName) )
+            $mockNtAuthoritySystemName = ( New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login($mockSqlServer, $mockNtAuthoritySystemName) )
+        }
 
         #endregion
 
         #region Endpoint mock variables
 
-            $mockEndpointPort = 5022
+        $mockEndpointPort = 5022
 
         #endregion Endpoint mock variables
 
         #region Availability Group mock variables
 
-            $mockAvailabilityGroup1Name = 'AG_AllServers'
-            $mockAvailabilityGroup1PrimaryReplicaServer = $mockServer2Name
+        $mockAvailabilityGroup1Name = 'AG_AllServers'
+        $mockAvailabilityGroup1PrimaryReplicaServer = $mockServer2Name
 
-            $mockAvailabilityGroup2Name = 'AG_PrimaryOnServer2'
-            $mockAvailabilityGroup2PrimaryReplicaServer = $mockServer2Name
+        $mockAvailabilityGroup2Name = 'AG_PrimaryOnServer2'
+        $mockAvailabilityGroup2PrimaryReplicaServer = $mockServer2Name
 
-            $mockAvailabilityGroup3Name = 'AG_PrimaryOnServer3'
-            $mockAvailabilityGroup3PrimaryReplicaServer = $mockServer3Name
+        $mockAvailabilityGroup3Name = 'AG_PrimaryOnServer3'
+        $mockAvailabilityGroup3PrimaryReplicaServer = $mockServer3Name
 
         #endregion
 
         #region Availability Group Replica mock variables
 
-            $mockAlternateEndpointPort = $false
-            $mockAlternateEndpointProtocol = $false
+        $mockAlternateEndpointPort = $false
+        $mockAlternateEndpointProtocol = $false
 
-            $mockAvailabilityGroupReplica1Name = $mockServer1Name
-            $mockAvailabilityGroupReplica1AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityGroupReplica1BackupPriority = 50
-            $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityGroupReplica1EndpointProtocol = 'TCP'
-            $mockAvailabilityGroupReplica1EndpointPort = $mockEndpointPort
-            $mockAvailabilityGroupReplica1EndpointUrl = "$($mockAvailabilityGroupReplica1EndpointProtocol)://$($mockServer1Name):$($mockAvailabilityGroupReplica1EndpointPort)"
-            $mockAvailabilityGroupReplica1FailoverMode = 'Manual'
-            $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer1Name).domain.com:1433"
-            $mockAvailabilityGroupReplica1ReadOnlyRoutingList = @($mockServer1Name)
+        $mockAvailabilityGroupReplica1Name = $mockServer1Name
+        $mockAvailabilityGroupReplica1AvailabilityMode = 'AsynchronousCommit'
+        $mockAvailabilityGroupReplica1BackupPriority = 50
+        $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockAvailabilityGroupReplica1EndpointProtocol = 'TCP'
+        $mockAvailabilityGroupReplica1EndpointPort = $mockEndpointPort
+        $mockAvailabilityGroupReplica1EndpointUrl = "$($mockAvailabilityGroupReplica1EndpointProtocol)://$($mockServer1Name):$($mockAvailabilityGroupReplica1EndpointPort)"
+        $mockAvailabilityGroupReplica1FailoverMode = 'Manual'
+        $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer1Name).domain.com:1433"
+        $mockAvailabilityGroupReplica1ReadOnlyRoutingList = @($mockServer1Name)
 
-            $mockAvailabilityGroupReplica2Name = $mockServer2Name
-            $mockAvailabilityGroupReplica2AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityGroupReplica2BackupPriority = 50
-            $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityGroupReplica2EndpointProtocol = 'TCP'
-            $mockAvailabilityGroupReplica2EndpointPort = $mockEndpointPort
-            $mockAvailabilityGroupReplica2EndpointUrl = "$($mockAvailabilityGroupReplica2EndpointProtocol)://$($mockServer2Name):$($mockAvailabilityGroupReplica2EndpointPort)"
-            $mockAvailabilityGroupReplica2FailoverMode = 'Manual'
-            $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer2Name).domain.com:1433"
-            $mockAvailabilityGroupReplica2ReadOnlyRoutingList = @($mockServer2Name)
+        $mockAvailabilityGroupReplica2Name = $mockServer2Name
+        $mockAvailabilityGroupReplica2AvailabilityMode = 'AsynchronousCommit'
+        $mockAvailabilityGroupReplica2BackupPriority = 50
+        $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockAvailabilityGroupReplica2EndpointProtocol = 'TCP'
+        $mockAvailabilityGroupReplica2EndpointPort = $mockEndpointPort
+        $mockAvailabilityGroupReplica2EndpointUrl = "$($mockAvailabilityGroupReplica2EndpointProtocol)://$($mockServer2Name):$($mockAvailabilityGroupReplica2EndpointPort)"
+        $mockAvailabilityGroupReplica2FailoverMode = 'Manual'
+        $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer2Name).domain.com:1433"
+        $mockAvailabilityGroupReplica2ReadOnlyRoutingList = @($mockServer2Name)
 
-            $mockAvailabilityGroupReplica3Name = $mockServer3Name
-            $mockAvailabilityGroupReplica3AvailabilityMode = 'AsynchronousCommit'
-            $mockAvailabilityGroupReplica3BackupPriority = 50
-            $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole = 'AllowAllConnections'
-            $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole = 'AllowNoConnections'
-            $mockAvailabilityGroupReplica3EndpointProtocol = 'TCP'
-            $mockAvailabilityGroupReplica3EndpointPort = $mockEndpointPort
-            $mockAvailabilityGroupReplica3EndpointUrl = "$($mockAvailabilityGroupReplica3EndpointProtocol)://$($mockServer3Name):$($mockAvailabilityGroupReplica3EndpointPort)"
-            $mockAvailabilityGroupReplica3FailoverMode = 'Manual'
-            $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer3Name).domain.com:1433"
-            $mockAvailabilityGroupReplica3ReadOnlyRoutingList = @($mockServer3Name)
+        $mockAvailabilityGroupReplica3Name = $mockServer3Name
+        $mockAvailabilityGroupReplica3AvailabilityMode = 'AsynchronousCommit'
+        $mockAvailabilityGroupReplica3BackupPriority = 50
+        $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole = 'AllowAllConnections'
+        $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole = 'AllowNoConnections'
+        $mockAvailabilityGroupReplica3EndpointProtocol = 'TCP'
+        $mockAvailabilityGroupReplica3EndpointPort = $mockEndpointPort
+        $mockAvailabilityGroupReplica3EndpointUrl = "$($mockAvailabilityGroupReplica3EndpointProtocol)://$($mockServer3Name):$($mockAvailabilityGroupReplica3EndpointPort)"
+        $mockAvailabilityGroupReplica3FailoverMode = 'Manual'
+        $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl = "TCP://$($mockServer3Name).domain.com:1433"
+        $mockAvailabilityGroupReplica3ReadOnlyRoutingList = @($mockServer3Name)
 
         #endregion
 
@@ -224,16 +227,16 @@ try
 
             if ( $mockAlternateEndpointPort )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort, '1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort, '1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort, '1234')
             }
 
             if ( $mockAlternateEndpointProtocol )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol, 'UDP')
             }
 
             # Mock the availability groups
@@ -292,52 +295,52 @@ try
             $mockServerObject.ServiceName = $mockServer2ServiceName
 
             #region Mock the availability group replicas
-                $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
-                $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
-                $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
-                $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
-                $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
-                $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
+            $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
+            $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
+            $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
+            $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
 
-                $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
-                $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
+            $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
+            $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
+            $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
+            $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
 
-                $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
-                $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
+            $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
+            $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
+            $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
+            $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
             #endregion Mock the availability group replicas
 
             if ( $mockAlternateEndpointPort )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort, '1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort, '1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort, '1234')
             }
 
             if ( $mockAlternateEndpointProtocol )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol, 'UDP')
             }
 
             # Mock the availability groups
@@ -412,52 +415,52 @@ try
             $mockServerObject.ServiceName = $mockServer3ServiceName
 
             #region Mock the availability group replicas
-                $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
-                $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
-                $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
-                $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
-                $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
-                $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica1.AvailabilityMode = $mockAvailabilityGroupReplica1AvailabilityMode
+            $mockAvailabilityGroupReplica1.BackupPriority = $mockAvailabilityGroupReplica1BackupPriority
+            $mockAvailabilityGroupReplica1.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica1ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica1.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica1ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl
+            $mockAvailabilityGroupReplica1.FailoverMode = $mockAvailabilityGroupReplica1FailoverMode
+            $mockAvailabilityGroupReplica1.Name = $mockAvailabilityGroupReplica1Name
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica1ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = $mockAvailabilityGroupReplica1ReadOnlyRoutingList
 
-                $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
-                $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
-                $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
-                $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
-                $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
-                $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica2.AvailabilityMode = $mockAvailabilityGroupReplica2AvailabilityMode
+            $mockAvailabilityGroupReplica2.BackupPriority = $mockAvailabilityGroupReplica2BackupPriority
+            $mockAvailabilityGroupReplica2.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica2ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica2.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica2ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl
+            $mockAvailabilityGroupReplica2.FailoverMode = $mockAvailabilityGroupReplica2FailoverMode
+            $mockAvailabilityGroupReplica2.Name = $mockAvailabilityGroupReplica2Name
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica2ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = $mockAvailabilityGroupReplica2ReadOnlyRoutingList
 
-                $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
-                $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
-                $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
-                $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
-                $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
-                $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
-                $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
-                $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
-                $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
+            $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
+            $mockAvailabilityGroupReplica3.AvailabilityMode = $mockAvailabilityGroupReplica3AvailabilityMode
+            $mockAvailabilityGroupReplica3.BackupPriority = $mockAvailabilityGroupReplica3BackupPriority
+            $mockAvailabilityGroupReplica3.ConnectionModeInPrimaryRole = $mockAvailabilityGroupReplica3ConnectionModeInPrimaryRole
+            $mockAvailabilityGroupReplica3.ConnectionModeInSecondaryRole = $mockAvailabilityGroupReplica3ConnectionModeInSecondaryRole
+            $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl
+            $mockAvailabilityGroupReplica3.FailoverMode = $mockAvailabilityGroupReplica3FailoverMode
+            $mockAvailabilityGroupReplica3.Name = $mockAvailabilityGroupReplica3Name
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = $mockAvailabilityGroupReplica3ReadOnlyRoutingConnectionUrl
+            $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = $mockAvailabilityGroupReplica3ReadOnlyRoutingList
             #endregion Mock the availability group replicas
 
             if ( $mockAlternateEndpointPort )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort,'1234')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort,'1234')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort,'1234')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointPort, '1234')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointPort, '1234')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointPort, '1234')
             }
 
             if ( $mockAlternateEndpointProtocol )
             {
-                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol,'UDP')
-                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol,'UDP')
+                $mockAvailabilityGroupReplica1.EndpointUrl = $mockAvailabilityGroupReplica1EndpointUrl.Replace($mockAvailabilityGroupReplica1EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica2.EndpointUrl = $mockAvailabilityGroupReplica2EndpointUrl.Replace($mockAvailabilityGroupReplica2EndpointProtocol, 'UDP')
+                $mockAvailabilityGroupReplica3.EndpointUrl = $mockAvailabilityGroupReplica3EndpointUrl.Replace($mockAvailabilityGroupReplica3EndpointProtocol, 'UDP')
             }
 
             # Mock the availability groups
@@ -529,10 +532,10 @@ try
         Describe 'xSQLServerAlwaysOnAvailabilityGroupReplica\Get-TargetResource' {
             BeforeEach {
                 $getTargetResourceParameters = @{
-                    Name = $mockAvailabilityGroupReplicaName
+                    Name                  = $mockAvailabilityGroupReplicaName
                     AvailabilityGroupName = $mockAvailabilityGroupName
-                    SQLServer = $mockSqlServer
-                    SQLInstanceName = $mockSqlInstanceName
+                    SQLServer             = $mockSqlServer
+                    SQLInstanceName       = $mockSqlInstanceName
                 }
 
                 $mockDatabaseMirroringEndpoint = $true
@@ -602,7 +605,9 @@ try
 
             BeforeAll {
                 Mock -CommandName Import-SQLPSModule -MockWith {} -Verifiable
-                Mock -CommandName New-TerminatingError { $ErrorType } -Verifiable
+                Mock -CommandName New-TerminatingError {
+                    $ErrorType
+                } -Verifiable
             }
 
             BeforeEach {
@@ -610,9 +615,15 @@ try
                 $mockLogins = $mockNtServiceClusSvcPresent
                 $mockServer1IsHadrEnabled = $true
 
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer3 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer3Name }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer1Name
+                }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer2Name
+                }
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer3 -Verifiable -ParameterFilter {
+                    $SQLServer -eq $mockServer3Name
+                }
                 Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                 }
@@ -624,7 +635,9 @@ try
                 }
                 Mock -CommandName Join-SqlAvailabilityGroup -MockWith {} -Verifiable
                 Mock -CommandName New-SqlAvailabilityReplica {} -Verifiable
-                Mock -CommandName Test-ClusterPermissions -MockWith { $null } -Verifiable
+                Mock -CommandName Test-ClusterPermissions -MockWith {
+                    $null
+                } -Verifiable
             }
 
             Context 'When the desired state is absent' {
@@ -635,11 +648,11 @@ try
 
                 BeforeEach {
                     $setTargetResourceParameters = @{
-                        Name = $mockSqlServer
+                        Name                  = $mockSqlServer
                         AvailabilityGroupName = $mockAvailabilityGroupName
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockSqlInstanceName
-                        Ensure = 'Absent'
+                        SQLServer             = $mockSqlServer
+                        SQLInstanceName       = $mockSqlInstanceName
+                        Ensure                = 'Absent'
                     }
                 }
 
@@ -649,9 +662,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -676,9 +695,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'RemoveAvailabilityGroupReplicaFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -707,21 +732,21 @@ try
 
                 BeforeEach {
                     $setTargetResourceParameters = @{
-                        Name = $mockSqlServer
-                        AvailabilityGroupName = $mockAvailabilityGroup2Name
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockSqlInstanceName
-                        PrimaryReplicaSQLServer = $mockPrimaryReplicaSQLServer
+                        Name                          = $mockSqlServer
+                        AvailabilityGroupName         = $mockAvailabilityGroup2Name
+                        SQLServer                     = $mockSqlServer
+                        SQLInstanceName               = $mockSqlInstanceName
+                        PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                         PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
-                        Ensure = $mockEnsure
-                        AvailabilityMode = $mockAvailabilityMode
-                        BackupPriority = $mockBackupPriority
-                        ConnectionModeInPrimaryRole = $mockConnectionModeInPrimaryRole
+                        Ensure                        = $mockEnsure
+                        AvailabilityMode              = $mockAvailabilityMode
+                        BackupPriority                = $mockBackupPriority
+                        ConnectionModeInPrimaryRole   = $mockConnectionModeInPrimaryRole
                         ConnectionModeInSecondaryRole = $mockConnectionModeInSecondaryRole
-                        EndpointHostName = $mockEndpointHostName
-                        FailoverMode = $mockFailoverMode
-                        ReadOnlyRoutingConnectionUrl = $mockReadOnlyRoutingConnectionUrl
-                        ReadOnlyRoutingList = $mockReadOnlyRoutingList
+                        EndpointHostName              = $mockEndpointHostName
+                        FailoverMode                  = $mockFailoverMode
+                        ReadOnlyRoutingConnectionUrl  = $mockReadOnlyRoutingConnectionUrl
+                        ReadOnlyRoutingList           = $mockReadOnlyRoutingList
                     }
                 }
 
@@ -731,9 +756,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'HadrNotEnabled'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -760,9 +791,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -785,9 +822,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -812,9 +855,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'DatabaseMirroringEndpointNotFound'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -839,9 +888,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -866,9 +921,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -893,9 +954,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'CreateAvailabilityGroupReplicaFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -920,9 +987,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'JoinAvailabilityGroupFailed'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -947,9 +1020,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'AvailabilityGroupNotFound'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -977,13 +1056,13 @@ try
 
                     # Create a hash table to provide test properties and values for the update tests
                     $mockTestProperties = @{
-                        AvailabilityMode = 'SynchronousCommit'
-                        BackupPriority = 75
-                        ConnectionModeInPrimaryRole = 'AllowReadWriteConnections'
+                        AvailabilityMode              = 'SynchronousCommit'
+                        BackupPriority                = 75
+                        ConnectionModeInPrimaryRole   = 'AllowReadWriteConnections'
                         ConnectionModeInSecondaryRole = 'AllowReadIntentConnectionsOnly'
-                        FailoverMode = 'Automatic'
-                        ReadOnlyRoutingConnectionUrl = 'TCP://TestHost.domain.com:1433'
-                        ReadOnlyRoutingList = @('Server1','Server2')
+                        FailoverMode                  = 'Automatic'
+                        ReadOnlyRoutingConnectionUrl  = 'TCP://TestHost.domain.com:1433'
+                        ReadOnlyRoutingList           = @('Server1', 'Server2')
                     }
                 }
 
@@ -992,21 +1071,21 @@ try
                     $mockAlternateEndpointProtocol = $false
 
                     $setTargetResourceParameters = @{
-                        Name = $mockSqlServer
-                        AvailabilityGroupName = $mockAvailabilityGroupName
-                        SQLServer = $mockSqlServer
-                        SQLInstanceName = $mockSqlInstanceName
-                        PrimaryReplicaSQLServer = $mockPrimaryReplicaSQLServer
+                        Name                          = $mockSqlServer
+                        AvailabilityGroupName         = $mockAvailabilityGroupName
+                        SQLServer                     = $mockSqlServer
+                        SQLInstanceName               = $mockSqlInstanceName
+                        PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                         PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
-                        Ensure = $mockEnsure
-                        AvailabilityMode = $mockAvailabilityMode
-                        BackupPriority = $mockBackupPriority
-                        ConnectionModeInPrimaryRole = $mockConnectionModeInPrimaryRole
+                        Ensure                        = $mockEnsure
+                        AvailabilityMode              = $mockAvailabilityMode
+                        BackupPriority                = $mockBackupPriority
+                        ConnectionModeInPrimaryRole   = $mockConnectionModeInPrimaryRole
                         ConnectionModeInSecondaryRole = $mockConnectionModeInSecondaryRole
-                        EndpointHostName = $mockEndpointHostName
-                        FailoverMode = $mockFailoverMode
-                        ReadOnlyRoutingConnectionUrl = $mockReadOnlyRoutingConnectionUrl
-                        ReadOnlyRoutingList = $mockReadOnlyRoutingList
+                        EndpointHostName              = $mockEndpointHostName
+                        FailoverMode                  = $mockFailoverMode
+                        ReadOnlyRoutingConnectionUrl  = $mockReadOnlyRoutingConnectionUrl
+                        ReadOnlyRoutingList           = $mockReadOnlyRoutingList
                     }
                 }
 
@@ -1016,9 +1095,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ReplicaNotFound'
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -1047,9 +1132,15 @@ try
 
                         { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                            $SQLServer -eq $mockServer1Name
+                        } -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                            $SQLServer -eq $mockServer2Name
+                        } -Times 0 -Exactly
+                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                            $SQLServer -eq $mockServer3Name
+                        } -Times 0 -Exactly
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                             $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                         }
@@ -1075,9 +1166,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -1104,9 +1201,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -1133,9 +1236,15 @@ try
 
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer1Name
+                    } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer2Name
+                    } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter {
+                        $SQLServer -eq $mockServer3Name
+                    } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
                         $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
                     }
@@ -1164,21 +1273,21 @@ try
                 $mockDatabaseMirroringEndpoint = $true
 
                 $testTargetResourceParameters = @{
-                    Name = $mockSqlServer
-                    AvailabilityGroupName = $mockAvailabilityGroupName
-                    SQLServer = $mockSqlServer
-                    SQLInstanceName = $mockSqlInstanceName
-                    PrimaryReplicaSQLServer = $mockPrimaryReplicaSQLServer
+                    Name                          = $mockSqlServer
+                    AvailabilityGroupName         = $mockAvailabilityGroupName
+                    SQLServer                     = $mockSqlServer
+                    SQLInstanceName               = $mockSqlInstanceName
+                    PrimaryReplicaSQLServer       = $mockPrimaryReplicaSQLServer
                     PrimaryReplicaSQLInstanceName = $mockPrimaryReplicaSQLInstanceName
-                    Ensure = $mockEnsure
-                    AvailabilityMode = $mockAvailabilityMode
-                    BackupPriority = $mockBackupPriority
-                    ConnectionModeInPrimaryRole = $mockConnectionModeInPrimaryRole
+                    Ensure                        = $mockEnsure
+                    AvailabilityMode              = $mockAvailabilityMode
+                    BackupPriority                = $mockBackupPriority
+                    ConnectionModeInPrimaryRole   = $mockConnectionModeInPrimaryRole
                     ConnectionModeInSecondaryRole = $mockConnectionModeInSecondaryRole
-                    EndpointHostName = $mockEndpointHostName
-                    FailoverMode = $mockFailoverMode
-                    ReadOnlyRoutingConnectionUrl = $mockReadOnlyRoutingConnectionUrl
-                    ReadOnlyRoutingList = $mockReadOnlyRoutingList
+                    EndpointHostName              = $mockEndpointHostName
+                    FailoverMode                  = $mockFailoverMode
+                    ReadOnlyRoutingConnectionUrl  = $mockReadOnlyRoutingConnectionUrl
+                    ReadOnlyRoutingList           = $mockReadOnlyRoutingList
                 }
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable
@@ -1211,13 +1320,13 @@ try
 
                 BeforeAll {
                     $propertiesToCheck = @{
-                        AvailabilityMode = 'SynchronousCommit'
-                        BackupPriority = 42
-                        ConnectionModeInPrimaryRole = 'AllowReadWriteConnections'
+                        AvailabilityMode              = 'SynchronousCommit'
+                        BackupPriority                = 42
+                        ConnectionModeInPrimaryRole   = 'AllowReadWriteConnections'
                         ConnectionModeInSecondaryRole = 'AllowReadIntentConnectionsOnly'
-                        FailoverMode = 'Automatic'
-                        ReadOnlyRoutingConnectionUrl = 'WrongUrl'
-                        ReadOnlyRoutingList = @('WrongServer')
+                        FailoverMode                  = 'Automatic'
+                        ReadOnlyRoutingConnectionUrl  = 'WrongUrl'
+                        ReadOnlyRoutingList           = @('WrongServer')
                     }
                 }
 

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
@@ -168,7 +168,16 @@ try
 
                 [Parameter()]
                 [string]
-                $SQLInstanceName
+                $SQLInstanceName,
+
+                # The following two parameters are used to mock Get-PrimaryReplicaServerObject
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup,
+
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.Server]
+                $ServerObject
             )
 
             # Mock the server object
@@ -262,7 +271,16 @@ try
 
                 [Parameter()]
                 [string]
-                $SQLInstanceName
+                $SQLInstanceName,
+
+                # The following two parameters are used to mock Get-PrimaryReplicaServerObject
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup,
+
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.Server]
+                $ServerObject
             )
 
             # Mock the server object
@@ -373,7 +391,16 @@ try
 
                 [Parameter()]
                 [string]
-                $SQLInstanceName
+                $SQLInstanceName,
+
+                # The following two parameters are used to mock Get-PrimaryReplicaServerObject
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.AvailabilityGroup]
+                $AvailabilityGroup,
+
+                [Parameter()]
+                [Microsoft.SqlServer.Management.Smo.Server]
+                $ServerObject
             )
 
             # Mock the server object
@@ -586,6 +613,15 @@ try
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer1Name }
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer2Name }
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer3 -Verifiable -ParameterFilter { $SQLServer -eq $mockServer3Name }
+                Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer1 -Verifiable -ParameterFilter {
+                    $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                }
+                Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer2 -Verifiable -ParameterFilter {
+                    $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                }
+                Mock -CommandName Get-PrimaryReplicaServerObject -MockWith $mockConnectSqlServer3 -Verifiable -ParameterFilter {
+                    $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                }
                 Mock -CommandName Join-SqlAvailabilityGroup -MockWith {} -Verifiable
                 Mock -CommandName New-SqlAvailabilityReplica {} -Verifiable
                 Mock -CommandName Test-ClusterPermissions -MockWith { $null } -Verifiable
@@ -614,8 +650,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -632,8 +677,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'RemoveAvailabilityGroupReplicaFailed'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -680,6 +734,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -700,6 +763,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -716,6 +788,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -725,7 +806,7 @@ try
                     Assert-MockCalled -CommandName Update-AvailabilityGroupReplica -Scope It -Times 0 -Exactly
                 }
 
-                It 'Should throw the correct error (DatabaseMirroringEndpointNotFound) when the database mirroring endpoint is not absent' {
+                It 'Should throw the correct error (DatabaseMirroringEndpointNotFound) when the database mirroring endpoint is absent' {
 
                     $mockDatabaseMirroringEndpoint = $false
 
@@ -734,6 +815,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -752,6 +842,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -768,8 +867,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -788,6 +896,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -806,6 +923,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 1 -Exactly
@@ -824,6 +950,15 @@ try
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -882,8 +1017,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Throw 'ReplicaNotFound'
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -904,8 +1048,17 @@ try
                         { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                        Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                            $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                        }
+                        Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                            $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                        }
+                        Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                            $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                        }
                         Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                         Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -923,8 +1076,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -943,8 +1105,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -963,8 +1134,17 @@ try
                     { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer1Name } -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer2Name } -Times 0 -Exactly
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -ParameterFilter { $SQLServer -eq $mockServer3Name } -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer1Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 1 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer2Name
+                    }
+                    Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Time 0 -Exactly -ParameterFilter {
+                        $AvailabilityGroup.PrimaryReplicaServerName -eq $mockServer3Name
+                    }
                     Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                     Assert-MockCalled -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly


### PR DESCRIPTION
**Pull Request (PR) description**
Updated xSQLServerAlwaysOnAvailabilityGroup and xSQLServerAlwaysOnAvailabilityGroupReplica to utilize the Get-PrimaryReplicaServerObject helper function.

**This Pull Request (PR) fixes the following issues:**
Fixes #630 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/842)
<!-- Reviewable:end -->
