### PR TITLE
xSQLServerDatabase: Add Collation as a property when defining a Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
 - Changes to xSQLServerDatabase
   - Added parameter to specify collation for a database to be different from server
-    collation([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
+    collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
   - Fixed unit tests for Get-TargetResource to ensure correctly testing return
     values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@
   - Added integration test ([issue #753](https://github.com/PowerShell/xSQLServer/issues/753)).
   - Added support for configuring URL reservations and virtual directory names
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
+- Changes to xSQLServerDatabase
+  - Added parameter to specify collation for a database to be different from server
+    collation([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
+  - Fixed unit tests for Get-TargetResource to ensure correctly testing return values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,8 @@
 - Changes to xSQLServerDatabase
   - Added parameter to specify collation for a database to be different from server
     collation([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
-  - Fixed unit tests for Get-TargetResource to ensure correctly testing return values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
+  - Fixed unit tests for Get-TargetResource to ensure correctly testing return
+    values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Changes to xSQLServerDatabase
+  - Added parameter to specify collation for a database to be different from server
+    collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
+  - Fixed unit tests for Get-TargetResource to ensure correctly testing return
+    values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
+
 ## 8.2.0.0
 
 - Changes to xSQLServer
@@ -111,11 +117,6 @@
   - Added integration test ([issue #753](https://github.com/PowerShell/xSQLServer/issues/753)).
   - Added support for configuring URL reservations and virtual directory names
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
-- Changes to xSQLServerDatabase
-  - Added parameter to specify collation for a database to be different from server
-    collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
-  - Fixed unit tests for Get-TargetResource to ensure correctly testing return
-    values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
 
 ## 8.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -44,7 +44,12 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $SQLInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Collation
     )
 
     $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
@@ -59,6 +64,7 @@ function Get-TargetResource
         {
             Write-Verbose -Message "SQL Database name $Name is present"
             $Ensure = 'Present'
+            $sqlDatabaseCollation = $sqlDatabaseObject.Collation
         }
         else
         {
@@ -72,6 +78,7 @@ function Get-TargetResource
         Ensure          = $Ensure
         SQLServer       = $SQLServer
         SQLInstanceName = $SQLInstanceName
+        Collation       = $sqlDatabaseCollation
     }
 
     $returnValue
@@ -210,7 +217,12 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $SQLInstanceName
+        $SQLInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Collation
     )
 
     Write-Verbose -Message "Checking if database named $Name is present or absent"

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -59,6 +59,7 @@ function Get-TargetResource
 
     if ($sqlServerObject)
     {
+        $sqlDatabaseCollation = $sqlServerObject.Collation
         Write-Verbose -Message 'Getting SQL Databases'
         # Check database exists
         $sqlDatabaseObject = $sqlServerObject.Databases[$Name]
@@ -235,6 +236,11 @@ function Test-TargetResource
 
     $getTargetResourceResult = Get-TargetResource @PSBoundParameters
     $isDatabaseInDesiredState = $true
+
+    if ([string]::IsNullOrWhiteSpace($Collation))
+    {
+        $Collation = $getTargetResourceResult.Collation
+    }
 
     switch ($Ensure)
     {

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -17,6 +17,9 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
     .PARAMETER SQLInstanceName
     The name of the SQL instance to be configured.
+
+    .PARAMETER Collation
+    The name of the SQL collation to use for the new database.
 #>
 
 function Get-TargetResource
@@ -191,6 +194,9 @@ function Set-TargetResource
 
     .PARAMETER SQLInstanceName
     The name of the SQL instance to be configured.
+
+    .PARAMETER Collation
+    The name of the SQL collation to use for the new database.
 #>
 function Test-TargetResource
 {
@@ -246,6 +252,11 @@ function Test-TargetResource
             if ($getTargetResourceResult.Ensure -ne 'Present')
             {
                 New-VerboseMessage -Message "Ensure is set to Present. The database $Name should be created"
+                $isDatabaseInDesiredState = $false
+            }
+            elseif ($getTargetResourceResult.Collation -ne $Collation)
+            {
+                New-VerboseMessage -Message "Database exists but is incorrect collation."
                 $isDatabaseInDesiredState = $false
             }
         }

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -147,7 +147,7 @@ function Set-TargetResource
 
         if ($Ensure -eq 'Present')
         {
-            if ([string]::IsNullOrWhiteSpace($Collation))
+            if (-not $PSBoundParameters.ContainsKey('Collation'))
             {
                 $Collation = $sqlServerObject.Collation
             }
@@ -157,15 +157,17 @@ function Set-TargetResource
                     -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Collation) `
                     -ErrorCategory InvalidOperation
             }
+
             $sqlDatabaseObject = $sqlServerObject.Databases[$Name]
+
             if ($sqlDatabaseObject)
             {
                 try
                 {
-                    Write-Verbose -Message "Updating the database $Name with specified settings"
+                    Write-Verbose -Message "Updating the database $Name with specified settings."
                     $sqlDatabaseObject.Collation = $Collation
                     $sqlDatabaseObject.Alter()
-                    New-VerboseMessage -Message "Updated Database $Name"
+                    New-VerboseMessage -Message "Updated Database $Name."
                 }
                 catch
                 {
@@ -182,10 +184,10 @@ function Set-TargetResource
                     $sqlDatabaseObjectToCreate = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database -ArgumentList $sqlServerObject, $Name
                     if ($sqlDatabaseObjectToCreate)
                     {
-                        Write-Verbose -Message "Adding to SQL the database $Name"
+                        Write-Verbose -Message "Adding to SQL the database $Name."
                         $sqlDatabaseObjectToCreate.Collation = $Collation
                         $sqlDatabaseObjectToCreate.Create()
-                        New-VerboseMessage -Message "Created Database $Name"
+                        New-VerboseMessage -Message "Created Database $Name."
                     }
                 }
                 catch
@@ -204,9 +206,9 @@ function Set-TargetResource
                 $sqlDatabaseObjectToDrop = $sqlServerObject.Databases[$Name]
                 if ($sqlDatabaseObjectToDrop)
                 {
-                    Write-Verbose -Message "Deleting to SQL the database $Name"
+                    Write-Verbose -Message "Deleting to SQL the database $Name."
                     $sqlDatabaseObjectToDrop.Drop()
-                    New-VerboseMessage -Message "Dropped Database $Name"
+                    New-VerboseMessage -Message "Dropped Database $Name."
                 }
             }
             catch
@@ -278,7 +280,7 @@ function Test-TargetResource
     $getTargetResourceResult = Get-TargetResource @PSBoundParameters
     $isDatabaseInDesiredState = $true
 
-    if ([string]::IsNullOrWhiteSpace($Collation))
+    if (-not $PSBoundParameters.ContainsKey('Collation'))
     {
         $Collation = $getTargetResourceResult.Collation
     }
@@ -303,7 +305,7 @@ function Test-TargetResource
             }
             elseif ($getTargetResourceResult.Collation -ne $Collation)
             {
-                New-VerboseMessage -Message "Database exists but is incorrect collation."
+                New-VerboseMessage -Message 'Database exist but has the wrong collation.'
                 $isDatabaseInDesiredState = $false
             }
         }

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -20,6 +20,7 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
     .PARAMETER Collation
     The name of the SQL collation to use for the new database.
+    Defaults to server collation.
 #>
 
 function Get-TargetResource
@@ -107,6 +108,7 @@ function Get-TargetResource
 
     .PARAMETER Collation
     The name of the SQL collation to use for the new database.
+    Defaults to server collation.
 #>
 function Set-TargetResource
 {
@@ -241,6 +243,7 @@ function Set-TargetResource
 
     .PARAMETER Collation
     The name of the SQL collation to use for the new database.
+    Defaults to server collation.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.psm1
@@ -157,7 +157,7 @@ function Set-TargetResource
                     -FormatArgs @($SQLServer, $SQLInstanceName, $Name, $Collation) `
                     -ErrorCategory InvalidOperation
             }
-            $sqlDatabaseObject = $sqlServerObject.Databases.Where({$_.Name -eq $Name})
+            $sqlDatabaseObject = $sqlServerObject.Databases[$Name]
             if ($sqlDatabaseObject)
             {
                 try

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.schema.mof
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xSQLServerDatabase : OMI_BaseResource
     [Write, Description("An enumerated value that describes if the database is added (Present) or dropped (Absent). Valid values are 'Present' or 'Absent'. Default Value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
-    [Write, Description("The name of the SQL collation to use for the new database.")] String Collation;
+    [Write, Description("The name of the SQL collation to use for the new database. Defaults to server collation.")] String Collation;
 };

--- a/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.schema.mof
+++ b/DSCResources/MSFT_xSQLServerDatabase/MSFT_xSQLServerDatabase.schema.mof
@@ -5,4 +5,5 @@ class MSFT_xSQLServerDatabase : OMI_BaseResource
     [Write, Description("An enumerated value that describes if the database is added (Present) or dropped (Absent). Valid values are 'Present' or 'Absent'. Default Value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Key, Description("The host name of the SQL Server to be configured.")] String SQLServer;
     [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("The name of the SQL collation to use for the new database.")] String Collation;
 };

--- a/Examples/Resources/xSQLServerDatabase/1-CreateDatabase.ps1
+++ b/Examples/Resources/xSQLServerDatabase/1-CreateDatabase.ps1
@@ -2,6 +2,9 @@
 .EXAMPLE
     This example shows how to create a database with
     the database name equal to 'Contoso'.
+
+    The second example shows how to create a database
+    with a different collation.
 #>
 Configuration Example
 {
@@ -23,6 +26,15 @@ Configuration Example
             SQLServer       = 'SQLServer'
             SQLInstanceName = 'DSC'
             Name            = 'Contoso'
+        }
+
+        xSQLServerDatabase Create_Database_with_different_collation
+        {
+            Ensure          = 'Present'
+            SQLServer       = 'SQLServer'
+            SQLInstanceName = 'DSC'
+            Name            = 'AdventureWorks'
+            Collation       = 'SQL_Latin1_General_Pref_CP850_CI_AS'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -496,8 +496,7 @@ database, please read:
 * **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
 * **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
-* **`[String]` Collation** _(Write)_: Collation to set for the database.
-  Defaults to server collation.
+* **`[String]` Collation** _(Write)_: The name of the SQL collation to use for the new database.
 * **`[String]` Ensure** _(Write)_: When set to 'Present', the database will be created.
   When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,8 @@ database, please read:
 * **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
 * **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
-* **`[String]` Collation** _(Write)_: Collation to set for the database. Defaults to server collation.
+* **`[String]` Collation** _(Write)_: Collation to set for the database.
+  Defaults to server collation.
 * **`[String]` Ensure** _(Write)_: When set to 'Present', the database will be created.
   When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,8 @@ database, please read:
 * **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
 * **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
-* **`[String]` Collation** _(Write)_: The name of the SQL collation to use for the new database.
+* **`[String]` Collation** _(Write)_: The name of the SQL collation to use
+  for the new database.
 * **`[String]` Ensure** _(Write)_: When set to 'Present', the database will be created.
   When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ database, please read:
 * **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
 * **`[String]` Collation** _(Write)_: The name of the SQL collation to use
-  for the new database.
+  for the new database. Defaults to server collation.
 * **`[String]` Ensure** _(Write)_: When set to 'Present', the database will be created.
   When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 

--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ database, please read:
 * **`[String]` SQLServer** _(Key)_: The host name of the SQL Server to be configured.
 * **`[String]` SQLInstanceName** _(Key)_: The name of the SQL instance to be configured.
 * **`[String]` Name** _(Key)_: The name of database to be created or dropped.
+* **`[String]` Collation** _(Write)_: Collation to set for the database. Defaults to server collation.
 * **`[String]` Ensure** _(Write)_: When set to 'Present', the database will be created.
   When set to 'Absent', the database will be dropped. { *Present* | Absent }.
 

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -41,6 +41,7 @@ try
         $mockInvalidOperationForDropMethod   = $false
         $mockExpectedDatabaseNameToCreate    = 'Contoso'
         $mockExpectedDatabaseNameToDrop      = 'Sales'
+        $mockSqlDatabaseCollation            = 'SQL_Latin1_General_CP1_CI_AS'
 
         # Default parameters that are used for the It-blocks
         $mockDefaultParameters = @{
@@ -72,7 +73,7 @@ try
                                                   -f $mockExpectedDatabaseNameToDrop, $this.Name
                                         }
                                     } -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name Collation -Value 'SQL_Latin1_General_CP1_CI_AS' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru
                                     )
                                 }
                             } -PassThru -Force
@@ -173,6 +174,19 @@ try
                     $testParameters += @{
                         Name    = 'UnknownDatabase'
                         Ensure  = 'Present'
+                        Collation = 'SQL_Latin1_General_CP1_CS_AS'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $false
+                }
+
+                It 'Should return the state as false when desired database exists but is the incorrect collation' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name    = 'AdventureWorks'
+                        Ensure  = 'Present'
+                        Collation = 'SQL_Latin1_General_CP1_CS_AS'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -180,7 +194,7 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope Context
                 }
             }
 
@@ -207,6 +221,19 @@ try
                     $testParameters += @{
                         Name    = 'AdventureWorks'
                         Ensure  = 'Present'
+                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should Be $true
+                }
+
+                It 'Should return the state as true when desired database exists and is correct collation' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        Name    = 'AdventureWorks'
+                        Ensure  = 'Present'
+                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
                     }
 
                     $result = Test-TargetResource @testParameters
@@ -214,7 +241,7 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope Context
                 }
             }
 

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -57,6 +57,7 @@ try
                     New-Object Object |
                         Add-Member -MemberType NoteProperty -Name InstanceName -Value $mockSqlServerInstanceName -PassThru |
                         Add-Member -MemberType NoteProperty -Name ComputerNamePhysicalNetBIOS -Value $mockSqlServerName -PassThru |
+                        Add-Member -MemberType NoteProperty -Name Collation -Value $mockSqlDatabaseCollation -PassThru |
                         Add-Member -MemberType ScriptProperty -Name Databases -Value {
                             return @{
                                 $mockSqlDatabaseName = ( New-Object Object |
@@ -125,7 +126,7 @@ try
                     $result.SQLServer | Should Be $testParameters.SQLServer
                     $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.Name | Should Be $testParameters.Name
-                    $result.Collation | Should Be $null
+                    $result.Collation | Should Be $testParameters.Collation
                 }
 
 

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -250,7 +250,7 @@ try
                     $result | Should Be $true
                 }
 
-                It 'Should return the state as true when desired database exists and has correct collation' {
+                It 'Should return the state as true when desired database exists and has the correct collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         Name    = 'AdventureWorks'

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -311,7 +311,7 @@ try
                 It 'Should not throw when changing the database collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'AdventureWorks'
+                        Name    = 'Contoso'
                         Ensure  = 'Present'
                         Collation = 'SQL_Latin1_General_CP1_CS_AS'
                     }
@@ -324,7 +324,7 @@ try
                 }
 
                 It 'Should call the mock function New-Object with TypeName equal to Microsoft.SqlServer.Management.Smo.Database' {
-                    Assert-MockCalled New-Object -Exactly -Times 2 -ParameterFilter {
+                    Assert-MockCalled New-Object -Exactly -Times 1 -ParameterFilter {
                         $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Database'
                     } -Scope Context
                 }

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -71,7 +71,8 @@ try
                                             throw "Called mocked Drop() method without dropping the right database. Expected '{0}'. But was '{1}'." `
                                                   -f $mockExpectedDatabaseNameToDrop, $this.Name
                                         }
-                                    } -PassThru
+                                    } -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name Collation -Value 'SQL_Latin1_General_CP1_CI_AS' -PassThru
                                     )
                                 }
                             } -PassThru -Force
@@ -107,43 +108,46 @@ try
             }
 
             Context 'When the system is not in the desired state' {
-                It 'Should return the state as absent' {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        Name = 'UnknownDatabase'
-                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
-                    }
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name = 'UnknownDatabase'
+                    Collation = 'SQL_Latin1_General_CP1_CI_AS'
+                }
 
+                It 'Should return the state as absent' {
                     $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Absent'
                 }
 
                 It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
                     $result.SQLServer | Should Be $testParameters.SQLServer
                     $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.Name | Should Be $testParameters.Name
-                    $result.Collation | Should Be $testParameters.Collation
+                    $result.Collation | Should Be $null
                 }
 
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope Context
                 }
             }
 
             Context 'When the system is in the desired state for a database' {
-                It 'Should return the state as present' {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        Name = 'AdventureWorks'
-                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
-                    }
 
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    Name = 'AdventureWorks'
+                    Collation = 'SQL_Latin1_General_CP1_CI_AS'
+                }
+
+                It 'Should return the state as present' {
                     $result = Get-TargetResource @testParameters
                     $result.Ensure | Should Be 'Present'
                 }
 
                 It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
                     $result.SQLServer | Should Be $testParameters.SQLServer
                     $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.Name | Should Be $testParameters.Name
@@ -151,7 +155,7 @@ try
                 }
 
                 It 'Should call the mock function Connect-SQL' {
-                    Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
+                    Assert-MockCalled Connect-SQL -Exactly -Times 2 -Scope Context
                 }
             }
 

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -111,6 +111,7 @@ try
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         Name = 'UnknownDatabase'
+                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
                     }
 
                     $result = Get-TargetResource @testParameters
@@ -121,7 +122,9 @@ try
                     $result.SQLServer | Should Be $testParameters.SQLServer
                     $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.Name | Should Be $testParameters.Name
+                    $result.Collation | Should Be $testParameters.Collation
                 }
+
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
@@ -133,6 +136,7 @@ try
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         Name = 'AdventureWorks'
+                        Collation = 'SQL_Latin1_General_CP1_CI_AS'
                     }
 
                     $result = Get-TargetResource @testParameters
@@ -143,6 +147,7 @@ try
                     $result.SQLServer | Should Be $testParameters.SQLServer
                     $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.Name | Should Be $testParameters.Name
+                    $result.Collation | Should Be $testParameters.Collation
                 }
 
                 It 'Should call the mock function Connect-SQL' {

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -375,7 +375,7 @@ try
                         Collation = 'InvalidCollation'
                     }
 
-                    $throwInvalidOperation = ('Collation specified {3} is not a valid collation for database {2} on {0}\{1}.' -f $mockSqlServerName, $mockSqlServerInstanceName, $testParameters.Name, $testParameters.Collation)
+                    $throwInvalidOperation = ("The specified collation '{3}' is not a valid collation for database {2} on {0}\{1}." -f $mockSqlServerName, $mockSqlServerInstanceName, $testParameters.Name, $testParameters.Collation)
 
                     { Set-TargetResource @testParameters } | Should Throw $throwInvalidOperation
                 }

--- a/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerDatabase.Tests.ps1
@@ -39,6 +39,7 @@ try
         $mockSqlDatabaseName                 = 'AdventureWorks'
         $mockInvalidOperationForCreateMethod = $false
         $mockInvalidOperationForDropMethod   = $false
+        $mockInvalidOperationForAlterMethod  = $false
         $mockExpectedDatabaseNameToCreate    = 'Contoso'
         $mockExpectedDatabaseNameToDrop      = 'Sales'
         $mockSqlDatabaseCollation            = 'SQL_Latin1_General_CP1_CI_AS'
@@ -202,7 +203,7 @@ try
                     $result | Should Be $false
                 }
 
-                It 'Should return the state as false when desired database exists but is the incorrect collation' {
+                It 'Should return the state as false when desired database exists but has the incorrect collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         Name    = 'AdventureWorks'
@@ -249,7 +250,7 @@ try
                     $result | Should Be $true
                 }
 
-                It 'Should return the state as true when desired database exists and is correct collation' {
+                It 'Should return the state as true when desired database exists and has correct collation' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         Name    = 'AdventureWorks'
@@ -369,7 +370,7 @@ try
                 It 'Should throw the correct error when invalid collation is specified' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
-                        Name    = 'NewDatabase'
+                        Name    = 'Sales'
                         Ensure  = 'Present'
                         Collation = 'InvalidCollation'
                     }

--- a/en-US/xSQLServerHelper.strings.psd1
+++ b/en-US/xSQLServerHelper.strings.psd1
@@ -142,7 +142,7 @@ ConvertFrom-StringData @'
     FailedToSetPermissionDatabase = Failed to set permission for login named {0} of the database named {1} on {2}\\{3}.
     FailedToEnumDatabasePermissions = Failed to get permission for login named {0} of the database named {1} on {2}\\{3}.
     UpdateDatabaseSetError = Failed to update database {1} on {0}\\{1} with specified changes.
-    InvalidCollationError = Collation specified {3} is not a valid collation for database {2} on {0}\\{1}.
+    InvalidCollationError = The specified collation '{3}' is not a valid collation for database {2} on {0}\\{1}.
 
     # SQLServerRole
     EnumMemberNamesServerRoleGetError = Failed to enumerate members of the server role named {2} on {0}\\{1}.

--- a/en-US/xSQLServerHelper.strings.psd1
+++ b/en-US/xSQLServerHelper.strings.psd1
@@ -141,6 +141,8 @@ ConvertFrom-StringData @'
     FailedToSetOwnerDatabase = Failed to set owner named {0} of the database named {1} on {2}\\{3}.
     FailedToSetPermissionDatabase = Failed to set permission for login named {0} of the database named {1} on {2}\\{3}.
     FailedToEnumDatabasePermissions = Failed to get permission for login named {0} of the database named {1} on {2}\\{3}.
+    UpdateDatabaseSetError = Failed to update database {1} on {0}\\{1} with specified changes.
+    InvalidCollationError = Collation specified {3} is not a valid collation for database {2} on {0}\\{1}.
 
     # SQLServerRole
     EnumMemberNamesServerRoleGetError = Failed to enumerate members of the server role named {2} on {0}\\{1}.


### PR DESCRIPTION
**Pull Request (PR) description**
Setting collation of a database to be different to the server is sometimes necessary. This adds that functionality and also fixes an issue with the Get-TargetResource tests that was incorrectly doing `$null | should be $null` (#849).

**This Pull Request (PR) fixes the following issues:**
Fixes #767 
Fixes #849

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [X] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/850)
<!-- Reviewable:end -->
