### PR TITLE
xSQLServerAlwaysOnAvailabilityGroup: Resolved FQDN and Logic Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
   - Refactored the unit tests to allow them to be more user friendly and to test
     additional SQLServer variations.
     - Each test will utilize the Import-SQLModuleStub to ensure the correct
-      module is loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784))
+      module is loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
   - Added the following read-only properties to the schema ([issue #476](https://github.com/PowerShell/xSQLServer/issues/476))
     - EndpointPort
     - EndpointURL
@@ -78,10 +78,10 @@
     - Version
   - Use the Get-PrimaryReplicaServerObject helper function.
   - Fixed an issue when setting the SQLServer parameter to a Fully Qualified
-    Domain Name (FQDN). ([issue #468](https://github.com/PowerShell/xSQLServer/issues/468))
+    Domain Name (FQDN) ([issue #468](https://github.com/PowerShell/xSQLServer/issues/468)).
   - Fixed the logic so that if a parameter is not supplied to the resource, the
-    resource will not attempt to apply the defaults on subsequent checks.
-    ([issue #517](https://github.com/PowerShell/xSQLServer/issues/517))
+    resource will not attempt to apply the defaults on subsequent checks
+    ([issue #517](https://github.com/PowerShell/xSQLServer/issues/517)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
@@ -127,7 +127,7 @@
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
 - Added the CommonTestHelper.psm1 to store common testing functions.
   - Added the Import-SQLModuleStub function to ensure the correct version of the
-    module stubs are loaded. ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784))
+    module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
       because SQLPS was not found after installation because the PSModulePath
       environment variable in the (LCM) PowerShell session did not contain the new
       module path.
-  - Added new helper function "Test-ClusterPermissions" ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446).
+  - Added new helper function "Test-ClusterPermissions" ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446)).
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' property
     ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,13 +67,21 @@
     later only). The feature currently can't be altered once the Availability
     Group is created.
   - Use the new helper function "Test-ClusterPermissions".
-  - Refactored the unit tests to allow them to be more user friendly.
-    Added the following read-only properties to the schema ([issue #476](https://github.com/PowerShell/xSQLServer/issues/476))
+  - Refactored the unit tests to allow them to be more user friendly and to test
+    additional SQLServer variations.
+    - Each test will utilize the Import-SQLModuleStub to ensure the correct
+      module is loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784))
+  - Added the following read-only properties to the schema ([issue #476](https://github.com/PowerShell/xSQLServer/issues/476))
     - EndpointPort
     - EndpointURL
     - SQLServerNetName
     - Version
-  - Use the Get-PrimaryReplicaServerObject helper function
+  - Use the Get-PrimaryReplicaServerObject helper function.
+  - Fixed an issue when setting the SQLServer parameter to a Fully Qualified
+    Domain Name (FQDN). ([issue #468](https://github.com/PowerShell/xSQLServer/issues/468))
+  - Fixed the logic so that if a parameter is not supplied to the resource, the
+    resource will not attempt to apply the defaults on subsequent checks.
+    ([issue #517](https://github.com/PowerShell/xSQLServer/issues/517))
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
@@ -117,6 +125,9 @@
   - Added integration test ([issue #753](https://github.com/PowerShell/xSQLServer/issues/753)).
   - Added support for configuring URL reservations and virtual directory names
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
+- Added the CommonTestHelper.psm1 to store common testing functions.
+  - Added the Import-SQLModuleStub function to ensure the correct version of the
+    module stubs are loaded. ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784))
 
 ## 8.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,7 @@
     later only). The feature currently can't be altered once the Availability
     Group is created.
   - Use the new helper function "Test-ClusterPermissions".
-  - Refactored the unit tests to allow them to be more user friendly and to test
-    additional SQLServer variations.
-    - Each test will utilize the Import-SQLModuleStub to ensure the correct
-      module is loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
+  - Refactored the unit tests to allow them to be more user friendly.
   - Added the following read-only properties to the schema ([issue #476](https://github.com/PowerShell/xSQLServer/issues/476))
     - EndpointPort
     - EndpointURL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
     collation ([issue #767](https://github.com/PowerShell/xSQLServer/issues/767)).
   - Fixed unit tests for Get-TargetResource to ensure correctly testing return
     values ([issue #849](https://github.com/PowerShell/xSQLServer/issues/849))
+- Changes to xSQLServerAlwaysOnAvailabilityGroup
+  - Refactored the unit tests to allow them to be more user friendly and to test
+    additional SQLServer variations.
+    - Each test will utilize the Import-SQLModuleStub to ensure the correct
+      module is loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
+  - Fixed an issue when setting the SQLServer parameter to a Fully Qualified
+    Domain Name (FQDN) ([issue #468](https://github.com/PowerShell/xSQLServer/issues/468)).
+  - Fixed the logic so that if a parameter is not supplied to the resource, the
+    resource will not attempt to apply the defaults on subsequent checks
+    ([issue #517](https://github.com/PowerShell/xSQLServer/issues/517)).
+- Added the CommonTestHelper.psm1 to store common testing functions.
+  - Added the Import-SQLModuleStub function to ensure the correct version of the
+    module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
 
 ## 8.2.0.0
 
@@ -31,7 +44,7 @@
       because SQLPS was not found after installation because the PSModulePath
       environment variable in the (LCM) PowerShell session did not contain the new
       module path.
-  - Added new helper function "Test-ClusterPermissions" ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446)).
+  - Added new helper function "Test-ClusterPermissions" ([issue #446](https://github.com/PowerShell/xSQLServer/issues/446).
 - Changes to xSQLServerSetup
   - Fixed an issue with trailing slashes in the 'UpdateSource' property
     ([issue #720](https://github.com/PowerShell/xSQLServer/issues/720)).
@@ -77,11 +90,6 @@
     - SQLServerNetName
     - Version
   - Use the Get-PrimaryReplicaServerObject helper function.
-  - Fixed an issue when setting the SQLServer parameter to a Fully Qualified
-    Domain Name (FQDN) ([issue #468](https://github.com/PowerShell/xSQLServer/issues/468)).
-  - Fixed the logic so that if a parameter is not supplied to the resource, the
-    resource will not attempt to apply the defaults on subsequent checks
-    ([issue #517](https://github.com/PowerShell/xSQLServer/issues/517)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Fixed the formatting for the AvailabilityGroupNotFound error.
   - Added the following read-only properties to the schema ([issue #477](https://github.com/PowerShell/xSQLServer/issues/477))
@@ -125,9 +133,6 @@
   - Added integration test ([issue #753](https://github.com/PowerShell/xSQLServer/issues/753)).
   - Added support for configuring URL reservations and virtual directory names
     ([issue #570](https://github.com/PowerShell/xSQLServer/issues/570))
-- Added the CommonTestHelper.psm1 to store common testing functions.
-  - Added the Import-SQLModuleStub function to ensure the correct version of the
-    module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
 
 ## 8.1.0.0
 

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -647,8 +647,11 @@ function Test-TargetResource
 
             if ( $getTargetResourceResult.Ensure -eq 'Present' )
             {
-                # PsBoundParameters won't work here because it doesn't account for default values
-                foreach ( $parameter in $MyInvocation.MyCommand.Parameters.GetEnumerator() )
+                # Use $PSBoundParameters rather than $MyInvocation.MyCommand.Parameters.GetEnumerator()
+                # This allows us to only validate the supplied parameters
+                # If the parameter is not defined by the configuration, we don't care what
+                # it gets set to.
+                foreach ( $parameter in $PSBoundParameters.GetEnumerator() )
                 {
                     $parameterName = $parameter.Key
                     $parameterValue = Get-Variable -Name $parameterName -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Value

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -59,14 +59,14 @@ function Get-TargetResource
             SQLInstanceName               = $SQLInstanceName
             Ensure                        = 'Present'
             AutomatedBackupPreference     = $availabilityGroup.AutomatedBackupPreference
-            AvailabilityMode              = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].AvailabilityMode
-            BackupPriority                = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].BackupPriority
-            ConnectionModeInPrimaryRole   = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInPrimaryRole
-            ConnectionModeInSecondaryRole = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInSecondaryRole
+            AvailabilityMode              = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode
+            BackupPriority                = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority
+            ConnectionModeInPrimaryRole   = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole
+            ConnectionModeInSecondaryRole = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole
             FailureConditionLevel         = $availabilityGroup.FailureConditionLevel
-            FailoverMode                  = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].FailoverMode
+            FailoverMode                  = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode
             HealthCheckTimeout            = $availabilityGroup.HealthCheckTimeout
-            EndpointURL                   = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl
+            EndpointURL                   = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl
             EndpointPort                  = $endpointPort
             SQLServerNetName              = $serverObject.NetName
             Version                       = $sqlMajorVersion
@@ -252,7 +252,7 @@ function Set-TargetResource
             if ( $availabilityGroup )
             {
                 # If the primary replica is currently on this instance
-                if ( $availabilityGroup.PrimaryReplicaServerName -eq $serverObject.Name )
+                if ( $availabilityGroup.PrimaryReplicaServerName -eq $serverObject.DomainInstanceName )
                 {
                     try
                     {
@@ -292,7 +292,7 @@ function Set-TargetResource
             {
                 # Set up the parameters to create the AG Replica
                 $newReplicaParams = @{
-                    Name             = $serverObject.Name
+                    Name             = $serverObject.DomainInstanceName
                     Version          = $sqlMajorVersion
                     AsTemplate       = $true
                     AvailabilityMode = $AvailabilityMode
@@ -377,16 +377,16 @@ function Set-TargetResource
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
-                if ( $AvailabilityMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].AvailabilityMode )
+                if ( $AvailabilityMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].AvailabilityMode = $AvailabilityMode
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode = $AvailabilityMode
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
-                if ( $BackupPriority -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].BackupPriority )
+                if ( $BackupPriority -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].BackupPriority = $BackupPriority
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority = $BackupPriority
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 if ( ( $sqlMajorVersion -ge 13 ) -and ( $BasicAvailabilityGroup -ne $availabilityGroup.BasicAvailabilityGroup ) )
@@ -402,41 +402,41 @@ function Set-TargetResource
                 }
 
                 # Make sure ConnectionModeInPrimaryRole has a value in order to avoid false positive matches when the parameter is not defined
-                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInPrimaryRole) ) -and ( $ConnectionModeInPrimaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInPrimaryRole ) )
+                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInPrimaryRole) ) -and ( $ConnectionModeInPrimaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole ) )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInPrimaryRole = $ConnectionModeInPrimaryRole
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole = $ConnectionModeInPrimaryRole
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 # Make sure ConnectionModeInSecondaryRole has a value in order to avoid false positive matches when the parameter is not defined
-                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInSecondaryRole) ) -and ( $ConnectionModeInSecondaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInSecondaryRole ) )
+                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInSecondaryRole) ) -and ( $ConnectionModeInSecondaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole ) )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].ConnectionModeInSecondaryRole = $ConnectionModeInSecondaryRole
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole = $ConnectionModeInSecondaryRole
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 # Break out the EndpointUrl properties
-                $currentEndpointProtocol, $currentEndpointHostName, $currentEndpointPort = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl.Replace('//', '').Split(':')
+                $currentEndpointProtocol, $currentEndpointHostName, $currentEndpointPort = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl.Replace('//', '').Split(':')
 
                 if ( $endpoint.Protocol.Tcp.ListenerPort -ne $currentEndpointPort )
                 {
-                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl.Replace($currentEndpointPort, $endpoint.Protocol.Tcp.ListenerPort)
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl = $newEndpointUrl
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl.Replace($currentEndpointPort, $endpoint.Protocol.Tcp.ListenerPort)
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl = $newEndpointUrl
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 if ( $EndpointHostName -ne $currentEndpointHostName )
                 {
-                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl.Replace($currentEndpointHostName, $EndpointHostName)
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl = $newEndpointUrl
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl.Replace($currentEndpointHostName, $EndpointHostName)
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl = $newEndpointUrl
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 if ( $currentEndpointProtocol -ne 'TCP' )
                 {
-                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl.Replace($currentEndpointProtocol, 'TCP')
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].EndpointUrl = $newEndpointUrl
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl.Replace($currentEndpointProtocol, 'TCP')
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl = $newEndpointUrl
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 # Make sure FailureConditionLevel has a value in order to avoid false positive matches when the parameter is not defined
@@ -446,10 +446,10 @@ function Set-TargetResource
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
-                if ( $FailoverMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.Name].FailoverMode )
+                if ( $FailoverMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode )
                 {
-                    $availabilityGroup.AvailabilityReplicas[$serverObject.Name].FailoverMode = $FailoverMode
-                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.Name]
+                    $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode = $FailoverMode
+                    Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 if ( $HealthCheckTimeout -ne $availabilityGroup.HealthCheckTimeout )

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -368,7 +368,7 @@ function Set-TargetResource
             else
             {
                 # Get the parameters that were submitted to the function
-                [System.Array]$submittedParameters = $PSBoundParameters.Keys
+                [System.Array] $submittedParameters = $PSBoundParameters.Keys
 
                 # Make sure we're communicating with the primary replica
                 $primaryServerObject = Get-PrimaryReplicaServerObject -ServerObject $serverObject -AvailabilityGroup $availabilityGroup

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -367,49 +367,52 @@ function Set-TargetResource
             # Otherwise let's check each of the parameters passed and update the Availability Group accordingly
             else
             {
+                # Get the parameters that were submitted to the function
+                [array]$submittedParameters = $PSBoundParameters.Keys
+
                 # Make sure we're communicating with the primary replica
                 $primaryServerObject = Get-PrimaryReplicaServerObject -ServerObject $serverObject -AvailabilityGroup $availabilityGroup
                 $availabilityGroup = $primaryServerObject.AvailabilityGroups[$Name]
 
-                if ( $AutomatedBackupPreference -ne $availabilityGroup.AutomatedBackupPreference )
+                if ( ( $submittedParameters -contains 'AutomatedBackupPreference' ) -and ( $AutomatedBackupPreference -ne $availabilityGroup.AutomatedBackupPreference ) )
                 {
                     $availabilityGroup.AutomatedBackupPreference = $AutomatedBackupPreference
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
-                if ( $AvailabilityMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode )
+                if ( ( $submittedParameters -contains 'AvailabilityMode' ) -and ( $AvailabilityMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode ) )
                 {
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].AvailabilityMode = $AvailabilityMode
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
-                if ( $BackupPriority -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority )
+                if ( ( $submittedParameters -contains 'BackupPriority' ) -and ( $BackupPriority -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority ) )
                 {
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].BackupPriority = $BackupPriority
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
-                if ( ( $sqlMajorVersion -ge 13 ) -and ( $BasicAvailabilityGroup -ne $availabilityGroup.BasicAvailabilityGroup ) )
+                if ( ( $submittedParameters -contains 'BasicAvailabilityGroup' ) -and ( $sqlMajorVersion -ge 13 ) -and ( $BasicAvailabilityGroup -ne $availabilityGroup.BasicAvailabilityGroup ) )
                 {
                     $availabilityGroup.BasicAvailabilityGroup = $BasicAvailabilityGroup
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
-                if ( ( $sqlMajorVersion -ge 13 ) -and ( $DatabaseHealthTrigger -ne $availabilityGroup.DatabaseHealthTrigger ) )
+                if ( ( $submittedParameters -contains 'DatabaseHealthTrigger' ) -and ( $sqlMajorVersion -ge 13 ) -and ( $DatabaseHealthTrigger -ne $availabilityGroup.DatabaseHealthTrigger ) )
                 {
                     $availabilityGroup.DatabaseHealthTrigger = $DatabaseHealthTrigger
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
                 # Make sure ConnectionModeInPrimaryRole has a value in order to avoid false positive matches when the parameter is not defined
-                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInPrimaryRole) ) -and ( $ConnectionModeInPrimaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole ) )
+                if ( ( $submittedParameters -contains 'ConnectionModeInPrimaryRole' ) -and ( -not [string]::IsNullOrEmpty($ConnectionModeInPrimaryRole) ) -and ( $ConnectionModeInPrimaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole ) )
                 {
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInPrimaryRole = $ConnectionModeInPrimaryRole
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
                 # Make sure ConnectionModeInSecondaryRole has a value in order to avoid false positive matches when the parameter is not defined
-                if ( ( -not [string]::IsNullOrEmpty($ConnectionModeInSecondaryRole) ) -and ( $ConnectionModeInSecondaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole ) )
+                if ( ( $submittedParameters -contains 'ConnectionModeInSecondaryRole' ) -and ( -not [string]::IsNullOrEmpty($ConnectionModeInSecondaryRole) ) -and ( $ConnectionModeInSecondaryRole -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole ) )
                 {
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].ConnectionModeInSecondaryRole = $ConnectionModeInSecondaryRole
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
@@ -425,7 +428,7 @@ function Set-TargetResource
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
-                if ( $EndpointHostName -ne $currentEndpointHostName )
+                if ( ( $submittedParameters -contains 'EndpointHostName' ) -and ( $EndpointHostName -ne $currentEndpointHostName ) )
                 {
                     $newEndpointUrl = $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl.Replace($currentEndpointHostName, $EndpointHostName)
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].EndpointUrl = $newEndpointUrl
@@ -440,19 +443,19 @@ function Set-TargetResource
                 }
 
                 # Make sure FailureConditionLevel has a value in order to avoid false positive matches when the parameter is not defined
-                if ( ( -not [string]::IsNullOrEmpty($FailureConditionLevel) ) -and ( $FailureConditionLevel -ne $availabilityGroup.FailureConditionLevel ) )
+                if ( ( $submittedParameters -contains 'FailureConditionLevel' ) -and ( -not [string]::IsNullOrEmpty($FailureConditionLevel) ) -and ( $FailureConditionLevel -ne $availabilityGroup.FailureConditionLevel ) )
                 {
                     $availabilityGroup.FailureConditionLevel = $FailureConditionLevel
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup
                 }
 
-                if ( $FailoverMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode )
+                if ( ( $submittedParameters -contains 'FailoverMode' ) -and ( $FailoverMode -ne $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode ) )
                 {
                     $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName].FailoverMode = $FailoverMode
                     Update-AvailabilityGroupReplica -AvailabilityGroupReplica $availabilityGroup.AvailabilityReplicas[$serverObject.DomainInstanceName]
                 }
 
-                if ( $HealthCheckTimeout -ne $availabilityGroup.HealthCheckTimeout )
+                if ( ( $submittedParameters -contains 'HealthCheckTimeout' ) -and ( $HealthCheckTimeout -ne $availabilityGroup.HealthCheckTimeout ) )
                 {
                     $availabilityGroup.HealthCheckTimeout = $HealthCheckTimeout
                     Update-AvailabilityGroup -AvailabilityGroup $availabilityGroup

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroup/MSFT_xSQLServerAlwaysOnAvailabilityGroup.psm1
@@ -368,7 +368,7 @@ function Set-TargetResource
             else
             {
                 # Get the parameters that were submitted to the function
-                [array]$submittedParameters = $PSBoundParameters.Keys
+                [System.Array]$submittedParameters = $PSBoundParameters.Keys
 
                 # Make sure we're communicating with the primary replica
                 $primaryServerObject = Get-PrimaryReplicaServerObject -ServerObject $serverObject -AvailabilityGroup $availabilityGroup

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -14,12 +14,12 @@ function Import-SQLModuleStub
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'Version')]
-        [UInt32]
+        [System.UInt32]
         $SQLVersion,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Module')]
+        [Parameter(ParameterSetName = 'Module')]
         [ValidateSet('SQLPS','SQLServer')]
-        [String]
+        [System.String]
         $ModuleName = 'SQLServer'
     )
 
@@ -46,13 +46,11 @@ function Import-SQLModuleStub
     $stubModuleName = $modulesAndStubs.$ModuleName
 
     # Ensure none of the other stub modules are loaded
-    [array]$otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
+    [System.Array]$otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
 
-    $otherStubModules | Foreach-Object -Process {
-        if ( Get-Module -Name $_ )
-        {
-            Remove-Module -Name $_
-        }
+    if ( Get-Module -Name $otherStubModules )
+    {
+        Remove-Module -Name $otherStubModules
     }
 
     # If the desired module is not loaded, load it now

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -1,0 +1,66 @@
+<#
+    .SYNOPSIS
+        Ensure the correct module stubs are loaded.
+
+    .PARAMETER SQLVersion
+        The major version of the SQL instance.
+
+    .PARAMETER ModuleName
+        The name of the module to load the stubs for. Default is 'SQLServer'.
+#>
+function Import-SQLModuleStub
+{
+    [CmdletBinding(DefaultParameterSetName = 'Module')]
+    param
+    (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Version')]
+        [UInt32]
+        $SQLVersion,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Module')]
+        [ValidateSet('SQLPS','SQLServer')]
+        [String]
+        $ModuleName = 'SQLServer'
+    )
+
+    # Translate the module names to their appropriate stub name
+    $modulesAndStubs = @{
+        SQLPS = 'SQLPSStub'
+        SQLServer = 'SQLServerStub'
+    }
+
+    # Determine which module to ensure is loaded based on the parameters passed
+    if ( $PsCmdlet.ParameterSetName -eq 'Version' )
+    {
+        if ( $SQLVersion -le 12 )
+        {
+            $ModuleName = 'SQLPS'
+        }
+        elseif ( $SQLVersion -ge 13 )
+        {
+            $ModuleName = 'SQLServer'
+        }
+    }
+
+    # Get the stub name
+    $stubModuleName = $modulesAndStubs.$ModuleName
+
+    # Ensure none of the other stub modules are loaded
+    [array]$otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
+
+    $otherStubModules | Foreach-Object -Process {
+        if ( Get-Module -Name $_ )
+        {
+            Remove-Module -Name $_
+        }
+    }
+
+    # If the desired module is not loaded, load it now
+    if ( -not ( Get-Module -Name $stubModuleName ) )
+    {
+        # Build the path to the module stub
+        $moduleStubPath = Join-Path -Path ( Join-Path -Path ( Join-Path -Path ( Split-Path -Path $PSScriptRoot -Parent ) -ChildPath Unit ) -ChildPath Stubs ) -ChildPath "$($stubModuleName).psm1"
+
+        Import-Module -Name $moduleStubPath -Force -Global
+    }
+}

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -46,7 +46,7 @@ function Import-SQLModuleStub
     $stubModuleName = $modulesAndStubs.$ModuleName
 
     # Ensure none of the other stub modules are loaded
-    [System.Array]$otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
+    [System.Array] $otherStubModules = $modulesAndStubs.Values | Where-Object -FilterScript { $_ -ne $stubModuleName }
 
     if ( Get-Module -Name $otherStubModules )
     {

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -466,6 +466,10 @@ try
 
             # Determine which SQL Server mock data we will use
             $mockSqlServer = ( $mockSqlServerParameters.GetEnumerator() | Where-Object -FilterScript { $_.Value.Values -contains $SQLServer } ).Name
+            if ( [string]::IsNullOrEmpty($mockSqlServer) )
+            {
+                $mockSqlServer = $SQLServer
+            }
             $mockCurrentServerObjectProperties = $mockServerObjectProperies.$mockSqlServer
 
             # Build the domain instance name
@@ -907,7 +911,8 @@ try
                         $assertUpdateAvailbilityGroupReplicaMockCalled = 1
                     }
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    Set-TargetResource @setTargetResourceParameters
+                    #{ Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -52,13 +52,13 @@ try
         $mockSqlServerParameters = @{
             Server1 = @{
                 FQDN = 'Server1.contoso.com'
-                IP = '192.168.1.1'
-                NetBIOS = 'Server1'
+                #IP = '192.168.1.1'
+                #NetBIOS = 'Server1'
             }
             Server2 = @{
                 FQDN = 'Server2.contoso.com'
-                IP = '192.168.1.2'
-                NetBIOS = 'Server2'
+                #IP = '192.168.1.2'
+                #NetBIOS = 'Server2'
             }
         }
 

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroup.Tests.ps1
@@ -55,6 +55,7 @@ try
                 #IP = '192.168.1.1'
                 #NetBIOS = 'Server1'
             }
+
             Server2 = @{
                 FQDN = 'Server2.contoso.com'
                 #IP = '192.168.1.2'
@@ -79,6 +80,7 @@ try
             Server1 = @{
                 NetName = 'Server1'
             }
+
             Server2 = @{
                 NetName = 'Server2'
             }
@@ -108,6 +110,7 @@ try
                 Name = $mockServerObjectProperies.Server1.NetName
                 Role = 'Primary'
             }
+
             Server2 = @{
                 AvailabilityMode = 'SynchronousCommit' # Not the default parameter value
                 BackupPriority = 49 # Not the default parameter value


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerAlwaysOnAvailabilityGroup
  - Refactored the unit tests to allow them to be more user friendly and to test
    additional SQLServer variations.
    - Each test will utilize the Import-SQLModuleStub to ensure the correct module is loaded.
  - Fixed an issue when setting the SQLServer parameter to a Fully Qualified Domain Name (FQDN).
  - Fixed the logic so that if a parameter is not supplied to the resource, the resource will not attempt to apply the defaults on subsequent checks.
- Added the CommonTestHelper.psm1 to store common testing functions.
  - Added the Import-SQLModuleStub function to ensure the correct version of the module stubs are loaded.

**This Pull Request (PR) fixes the following issues:**
Fixes #468 
Fixes #784 
Fixes some of #517 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/853)
<!-- Reviewable:end -->
