### PR TITLE
BREAKING CHANGE: xSQLServerNetwork: Support for configuring SQL Server to use a static port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - Added the CommonTestHelper.psm1 to store common testing functions.
   - Added the Import-SQLModuleStub function to ensure the correct version of the
     module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
+- Changes to xSQLServerNetwork
+  - Renamed parameter TcpDynamicPorts to TcpDynamicPort and changed type to Boolean
+  - Resolved issue where switching from dynamic to static port
+    configuration ([issue #534](https://github.com/PowerShell/xSQLServer/issues/534))
+  - Added localization (en-US) for all strings in resource and unit tests
+  - Updated examples to reflect new parameters.
 
 ## 8.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
   - Added the Import-SQLModuleStub function to ensure the correct version of the
     module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
 - Changes to xSQLServerNetwork
-  - Renamed parameter TcpDynamicPorts to TcpDynamicPort and changed type to Boolean
-  - Resolved issue where switching from dynamic to static port
-    configuration ([issue #534](https://github.com/PowerShell/xSQLServer/issues/534))
+  - BREAKING CHANGE: Renamed parameter TcpDynamicPorts to TcpDynamicPort and
+    changed type to Boolean.
+  - Resolved issue when switching from dynamic to static port.
+    configuration ([issue #534](https://github.com/PowerShell/xSQLServer/issues/534)).
   - Added localization (en-US) for all strings in resource and unit tests
+    ([issue #618](https://github.com/PowerShell/xSQLServer/issues/618)).
   - Updated examples to reflect new parameters.
 
 ## 8.2.0.0

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.psm1
@@ -10,7 +10,7 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xSQLServerNetwork'
     .SYNOPSIS
     Returns the current state of the SQL Server network properties.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER ProtocolName
@@ -70,7 +70,7 @@ function Get-TargetResource
     .PARAMETER SQLServer
     The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER ProtocolName
@@ -241,7 +241,7 @@ function Set-TargetResource
 
     Not used in Test-TargetResource.
 
-    .PARAMETER SQLInstanceName
+    .PARAMETER InstanceName
     The name of the SQL instance to be configured.
 
     .PARAMETER ProtocolName

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -1,12 +1,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerNetwork")]
 class MSFT_xSQLServerNetwork : OMI_BaseResource
 {
-    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
+    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
     [Required, Description("The name of network protocol to be configured. Only tcp is currently supported."), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
     [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;
-    [Write, Description("Set the value to '0' if dynamic ports should be used. If static port should be used set this to a empty string value. Value can not be set to '0' if TcpPort is also set to a value."), ValueMap{"0",""}, Values{"0",""}] String TcpDynamicPorts;
-    [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to the value '' (empty string).")] String TcpPort;
+    [Write, Description("Specifies whether the SQL Server instance should use a dynamic port. Value cannot be set to 'True' if TcpPort is set to a non-empty string.")] Boolean TcpDynamicPort;
+    [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to 'False'] String TcpPort;
     [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean RestartService;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -6,7 +6,7 @@ class MSFT_xSQLServerNetwork : OMI_BaseResource
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
     [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;
     [Write, Description("Specifies whether the SQL Server instance should use a dynamic port. Value cannot be set to 'True' if TcpPort is set to a non-empty string.")] Boolean TcpDynamicPort;
-    [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to 'False'] String TcpPort;
+    [Write, Description("The TCP port(s) that SQL Server should be listening on. If the IP address should listen on more than one port, list all ports separated with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to 'False'.")] String TcpPort;
     [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean RestartService;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
 };

--- a/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
+++ b/DSCResources/MSFT_xSQLServerNetwork/MSFT_xSQLServerNetwork.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xSQLServerNetwork")]
 class MSFT_xSQLServerNetwork : OMI_BaseResource
 {
-    [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Key, Description("The name of the SQL instance to be configured.")] String InstanceName;
     [Required, Description("The name of network protocol to be configured. Only tcp is currently supported."), ValueMap{"Tcp"}, Values{"Tcp"}] String ProtocolName;
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
     [Write, Description("Enables or disables the network protocol.")] Boolean IsEnabled;

--- a/DSCResources/MSFT_xSQLServerNetwork/en-US/MSFT_xSQLServerNetwork.strings.psd1
+++ b/DSCResources/MSFT_xSQLServerNetwork/en-US/MSFT_xSQLServerNetwork.strings.psd1
@@ -1,0 +1,12 @@
+# Localized resources for xSQLServerNetwork
+
+ConvertFrom-StringData @'
+    GetNetworkProtocol = Getting network protocol [{0}] for SQL instance [{1}].
+    ReadingNetworkProperties = Reading current network properties.
+    CheckingProperty = Checking [{0}] property.
+    UpdatingProperty = Updating property [{0}] from [{1}] to [{2}].
+    ExpectedPropertyValue = Expected property [{0}] value to be [{1}] but was [{2}].
+    CompareStates = Comparing desired state with current state.
+    InDesiredState = System is in the desired state.
+    ErrorDynamicAndStaticPortSpecified = Unable to set both tcp dynamic port and tcp static port. Only one can be set.
+'@

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -22,7 +22,7 @@ Configuration Example
             SQLInstanceName = 'MSSQLSERVER'
             ProtocolName    = 'Tcp'
             IsEnabled       = $true
-            TCPDynamicPorts = $false
+            TCPDynamicPort  = $false
             TCPPort         = 4509
             RestartService  = $true
         }

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -19,10 +19,10 @@ Configuration Example
     {
         xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            InstanceName    = 'MSSQLSERVER'
+            SQLInstanceName = 'MSSQLSERVER'
             ProtocolName    = 'Tcp'
             IsEnabled       = $true
-            TCPDynamicPorts = ''
+            TCPDynamicPorts = $false
             TCPPort         = 4509
             RestartService  = $true
         }

--- a/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/1-EnableTcpIpWithStaticPort.ps1
@@ -19,12 +19,12 @@ Configuration Example
     {
         xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            SQLInstanceName = 'MSSQLSERVER'
-            ProtocolName    = 'Tcp'
-            IsEnabled       = $true
-            TCPDynamicPort  = $false
-            TCPPort         = 4509
-            RestartService  = $true
+            InstanceName   = 'MSSQLSERVER'
+            ProtocolName   = 'Tcp'
+            IsEnabled      = $true
+            TCPDynamicPort = $false
+            TCPPort        = 4509
+            RestartService = $true
         }
     }
 }

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -19,10 +19,10 @@ Configuration Example
     {
         xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            InstanceName    = 'MSSQLSERVER'
+            SQLInstanceName = 'MSSQLSERVER'
             ProtocolName    = 'Tcp'
             IsEnabled       = $true
-            TCPDynamicPorts = '0'
+            TCPDynamicPorts = $true
             RestartService  = $true
         }
     }

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -22,7 +22,7 @@ Configuration Example
             SQLInstanceName = 'MSSQLSERVER'
             ProtocolName    = 'Tcp'
             IsEnabled       = $true
-            TCPDynamicPorts = $true
+            TCPDynamicPort  = $true
             RestartService  = $true
         }
     }

--- a/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
+++ b/Examples/Resources/xSQLServerNetwork/2-EnableTcpIpWithDynamicPort.ps1
@@ -19,11 +19,11 @@ Configuration Example
     {
         xSQLServerNetwork 'ChangeTcpIpOnDefaultInstance'
         {
-            SQLInstanceName = 'MSSQLSERVER'
-            ProtocolName    = 'Tcp'
-            IsEnabled       = $true
-            TCPDynamicPort  = $true
-            RestartService  = $true
+            InstanceName   = 'MSSQLSERVER'
+            ProtocolName   = 'Tcp'
+            IsEnabled      = $true
+            TCPDynamicPort = $true
+            RestartService = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ Read more about the network settings in the article
   is set to a non-empty string.
 * **`[String]` TcpPort** _(Write)_: The TCP port(s) that SQL Server should be listening
   on. If the IP address should listen on more than one port, list all ports separated
-  with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to
+  with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPort to
   $false.
 * **`[Boolean]` RestartService** _(Write)_: If set to $true then SQL Server and
   dependent services will be restarted if a change to the configuration is made.

--- a/README.md
+++ b/README.md
@@ -976,9 +976,9 @@ Read more about the network settings in the article
 * **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[Boolean]` IsEnabled** _(Write)_: Enables or disables the network protocol.
-* **`[String]` TcpDynamicPorts** _(Write)_: Set the value to '0' if dynamic ports
-  should be used. If static port should be used set this to a empty string value.
-  Value can not be set to '0' if TcpPort is also set to a value. { '0','' }.
+* **`[Boolean]` TcpDynamicPorts** _(Write)_: Specifies whether the SQL Server
+  instance should use a dynamic port. Value cannot be set to $true if TcpPort
+  is set to a non-empty string.
 * **`[String]` TcpPort** _(Write)_: The TCP port(s) that SQL Server should be listening
   on. If the IP address should listen on more than one port, list all ports separated
   with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to

--- a/README.md
+++ b/README.md
@@ -976,13 +976,13 @@ Read more about the network settings in the article
 * **`[String]` SQLServer** _(Write)_: The host name of the SQL Server to be configured.
   Default value is $env:COMPUTERNAME.
 * **`[Boolean]` IsEnabled** _(Write)_: Enables or disables the network protocol.
-* **`[Boolean]` TcpDynamicPorts** _(Write)_: Specifies whether the SQL Server
+* **`[Boolean]` TcpDynamicPort** _(Write)_: Specifies whether the SQL Server
   instance should use a dynamic port. Value cannot be set to $true if TcpPort
   is set to a non-empty string.
 * **`[String]` TcpPort** _(Write)_: The TCP port(s) that SQL Server should be listening
   on. If the IP address should listen on more than one port, list all ports separated
   with a comma ('1433,1500,1501'). To use this parameter set TcpDynamicPorts to
-  the value '' (empty string).
+  $false.
 * **`[Boolean]` RestartService** _(Write)_: If set to $true then SQL Server and
   dependent services will be restarted if a change to the configuration is made.
   The default value is $false.

--- a/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
@@ -36,6 +36,7 @@ try
         $mockInstanceName = 'TEST'
         $mockTcpProtocolName = 'Tcp'
         $mockNamedPipesProtocolName = 'NP'
+        $mockTcpDynamicPortNumber = '24680'
 
         $script:WasMethodAlterCalled = $false
 
@@ -54,7 +55,7 @@ try
                                                         Add-Member -MemberType ScriptProperty -Name 'IPAddressProperties' {
                                                             return @{
                                                                 'TcpDynamicPorts' = New-Object -TypeName Object |
-                                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpDynamicPorts -PassThru -Force
+                                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpDynamicPort -PassThru -Force
                                                                 'TcpPort' = New-Object -TypeName Object |
                                                                     Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicValue_TcpPort -PassThru -Force
                                                             }
@@ -94,7 +95,7 @@ try
         }
 
         $mockDefaultParameters = @{
-            InstanceName = $mockInstanceName
+            SQLInstanceName = $mockInstanceName
             ProtocolName = $mockTcpProtocolName
         }
 
@@ -115,14 +116,14 @@ try
                 BeforeEach {
                     $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                     $mockDynamicValue_IsEnabled = $true
-                    $mockDynamicValue_TcpDynamicPorts = '0'
+                    $mockDynamicValue_TcpDynamicPort = ''
                     $mockDynamicValue_TcpPort = '4509'
                 }
 
                 It 'Should return the correct values' {
                     $result = Get-TargetResource @testParameters
                     $result.IsEnabled | Should Be $mockDynamicValue_IsEnabled
-                    $result.TcpDynamicPorts | Should Be $mockDynamicValue_TcpDynamicPorts
+                    $result.TcpDynamicPort | Should Be $false
                     $result.TcpPort | Should Be $mockDynamicValue_TcpPort
 
                     Assert-MockCalled -CommandName Register-SqlWmiManagement -Exactly -Times 1 -Scope It
@@ -132,7 +133,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.InstanceName | Should Be $testParameters.InstanceName
+                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
                     $result.ProtocolName | Should Be $testParameters.ProtocolName
                 }
             }
@@ -157,7 +158,7 @@ try
                 BeforeEach {
                     $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                     $mockDynamicValue_IsEnabled = $true
-                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpDynamicPort = ''
                     $mockDynamicValue_TcpPort = '4509'
                 }
 
@@ -170,7 +171,7 @@ try
                     BeforeEach {
                         $testParameters += @{
                             IsEnabled = $true
-                            TcpDynamicPorts = ''
+                            TcpDynamicPort = $false
                             TcpPort = '4509'
                         }
 
@@ -188,7 +189,7 @@ try
                     BeforeEach {
                         $testParameters += @{
                             IsEnabled = $false
-                            TcpDynamicPorts = ''
+                            TcpDynamicPort = $false
                             TcpPort = '4509'
                         }
                     }
@@ -200,10 +201,10 @@ try
                 }
 
                 Context 'When current state is using static tcp port' {
-                    Context 'When TcpDynamicPorts is not in desired state' {
+                    Context 'When TcpDynamicPort is not in desired state' {
                         BeforeEach {
                             $testParameters += @{
-                                TcpDynamicPorts = '0'
+                                TcpDynamicPort = $true
                                 IsEnabled = $false
                             }
                         }
@@ -233,7 +234,7 @@ try
                     BeforeEach {
                         $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                         $mockDynamicValue_IsEnabled = $true
-                        $mockDynamicValue_TcpDynamicPorts = '0'
+                        $mockDynamicValue_TcpDynamicPort = $mockTcpDynamicPortNumber
                         $mockDynamicValue_TcpPort = ''
                     }
 
@@ -252,10 +253,10 @@ try
                     }
                 }
 
-                Context 'When both TcpDynamicPorts and TcpPort is being set' {
+                Context 'When both TcpDynamicPort and TcpPort are being set' {
                     BeforeEach {
                         $testParameters += @{
-                            TcpDynamicPorts = '0'
+                            TcpDynamicPort = $true
                             TcpPort = '1433'
                             IsEnabled = $false
                         }
@@ -271,7 +272,7 @@ try
                 BeforeEach {
                     $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                     $mockDynamicValue_IsEnabled = $true
-                    $mockDynamicValue_TcpDynamicPorts = '0'
+                    $mockDynamicValue_TcpDynamicPort = $mockTcpDynamicPortNumber
                     $mockDynamicValue_TcpPort = '1433'
                 }
 
@@ -289,10 +290,10 @@ try
                     }
                 }
 
-                Context 'When TcpDynamicPorts is in desired state' {
+                Context 'When TcpDynamicPort is in desired state' {
                     BeforeEach {
                         $testParameters += @{
-                            TcpDynamicPorts = '0'
+                            TcpDynamicPort = $true
                             IsEnabled = $true
                         }
                     }
@@ -329,7 +330,7 @@ try
                     # This is the values the mock will return
                     $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                     $mockDynamicValue_IsEnabled = $true
-                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpDynamicPort = ''
                     $mockDynamicValue_TcpPort = '4509'
 
                     <#
@@ -345,7 +346,7 @@ try
                     BeforeEach {
                         $testParameters += @{
                             IsEnabled = $false
-                            TcpDynamicPorts = ''
+                            TcpDynamicPort = $false
                             TcpPort = '4509'
                             RestartService = $true
                         }
@@ -362,11 +363,11 @@ try
                 }
 
                 Context 'When current state is using static tcp port' {
-                    Context 'When TcpDynamicPorts is not in desired state' {
+                    Context 'When TcpDynamicPort is not in desired state' {
                         BeforeEach {
                             $testParameters += @{
                                 IsEnabled = $true
-                                TcpDynamicPorts = '0'
+                                TcpDynamicPort = $true
                             }
                         }
 
@@ -382,7 +383,7 @@ try
                         BeforeEach {
                             $testParameters += @{
                                 IsEnabled = $true
-                                TcpDynamicPorts = ''
+                                TcpDynamicPort = $false
                                 TcpPort = '4508'
                             }
                         }
@@ -401,7 +402,7 @@ try
                         # This is the values the mock will return
                         $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                         $mockDynamicValue_IsEnabled = $true
-                        $mockDynamicValue_TcpDynamicPorts = '0'
+                        $mockDynamicValue_TcpDynamicPort = $mockTcpDynamicPortNumber
                         $mockDynamicValue_TcpPort = ''
 
                         <#
@@ -417,7 +418,7 @@ try
                         BeforeEach {
                             $testParameters += @{
                                 IsEnabled = $true
-                                TcpDynamicPorts = ''
+                                TcpDynamicPort = $false
                                 TcpPort = '4508'
                             }
                         }
@@ -431,10 +432,10 @@ try
                     }
                 }
 
-                Context 'When both TcpDynamicPorts and TcpPort is being set' {
+                Context 'When both TcpDynamicPort and TcpPort are being set' {
                     BeforeEach {
                         $testParameters += @{
-                            TcpDynamicPorts = '0'
+                            TcpDynamicPort = $true
                             TcpPort = '1433'
                             IsEnabled = $false
                         }
@@ -451,7 +452,7 @@ try
                     # This is the values the mock will return
                     $mockDynamicValue_TcpProtocolName = $mockTcpProtocolName
                     $mockDynamicValue_IsEnabled = $true
-                    $mockDynamicValue_TcpDynamicPorts = ''
+                    $mockDynamicValue_TcpDynamicPort = ''
                     $mockDynamicValue_TcpPort = '4509'
 
                     <#
@@ -462,7 +463,7 @@ try
 
                     $testParameters += @{
                         IsEnabled = $true
-                        TcpDynamicPorts = ''
+                        TcpDynamicPort = $false
                         TcpPort = '4509'
                     }
                 }

--- a/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
@@ -263,7 +263,8 @@ try
                     }
 
                     It 'Should throw the correct error message' {
-                        { Test-TargetResource @testParameters } | Should -Throw 'Unable to set both tcp dynamic port and tcp static port. Only one can be set.'
+                        $testErrorMessage = $script:localizedData.ErrorDynamicAndStaticPortSpecified
+                        { Test-TargetResource @testParameters } | Should -Throw $testErrorMessage
                     }
                 }
             }
@@ -442,7 +443,8 @@ try
                     }
 
                     It 'Should throw the correct error message' {
-                        { Set-TargetResource @testParameters } | Should -Throw 'Unable to set both tcp dynamic port and tcp static port. Only one can be set.'
+                        $testErrorMessage = ($script:localizedData.ErrorDynamicAndStaticPortSpecified)
+                        { Set-TargetResource @testParameters } | Should -Throw $testErrorMessage
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerNetwork.Tests.ps1
@@ -95,7 +95,7 @@ try
         }
 
         $mockDefaultParameters = @{
-            SQLInstanceName = $mockInstanceName
+            InstanceName = $mockInstanceName
             ProtocolName = $mockTcpProtocolName
         }
 
@@ -133,7 +133,7 @@ try
 
                 It 'Should return the same values as passed as parameters' {
                     $result = Get-TargetResource @testParameters
-                    $result.SQLInstanceName | Should Be $testParameters.SQLInstanceName
+                    $result.InstanceName | Should Be $testParameters.InstanceName
                     $result.ProtocolName | Should Be $testParameters.ProtocolName
                 }
             }


### PR DESCRIPTION
**Pull Request (PR) description**
Corrects an issue where changing from a dynamic to a static TCP port is not possible. This PR renamed the parameter TcpDynamicPorts to TcpDynamicPort and changed its type to Boolean. Additionally, localization for en-US was added in support of the ([localization project](https://github.com/PowerShell/xSQLServer/projects/3)).

**This Pull Request (PR) fixes the following issues:**
- Fixes #534
- Fixes #618 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/887)
<!-- Reviewable:end -->
