### PR TITLE
xSQLServerAlwaysOnAvailabilityGroupReplica: Make Cluster Aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
     the resource will only determine if a change is needed if the target node
     is the active host of the SQL Server instance ([issue #868](https://github.com/PowerShell/xSQLServer/issues/868)).
+- Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
+  - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
+    the resource will only determine if a change is needed if the target node
+    is the active host of the SQL Server instance ([issue #870](https://github.com/PowerShell/xSQLServer/issues/870)).
 - Added the CommonTestHelper.psm1 to store common testing functions.
   - Added the Import-SQLModuleStub function to ensure the correct version of the
     module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
     is the active host of the SQL Server instance ([issue #868](https://github.com/PowerShell/xSQLServer/issues/868)).
 - Changes to xSQLServerAlwaysOnAvailabilityGroupReplica
   - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
-    the resource will only determine if a change is needed if the target node
-    is the active host of the SQL Server instance ([issue #870](https://github.com/PowerShell/xSQLServer/issues/870)).
+    the resource will only determine if a change is needed if the target node is
+    the active host of the SQL Server instance ([issue #870](https://github.com/PowerShell/xSQLServer/issues/870)).
 - Added the CommonTestHelper.psm1 to store common testing functions.
   - Added the Import-SQLModuleStub function to ensure the correct version of the
     module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
@@ -16,7 +16,9 @@ class MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica : OMI_BaseResource
     [Write, Description("Specifies the failover mode. Default is 'Manual'."), ValueMap{"Automatic","Manual"}, Values{"Automatic","Manual"}] String FailoverMode;
     [Write, Description("Specifies the fully-qualified domain name (FQDN) and port to use when routing to the replica for read only connections.")] String ReadOnlyRoutingConnectionUrl;
     [Write, Description("Specifies an ordered list of replica server names that represent the probe sequence for connection director to use when redirecting read-only connections through this availability replica. This parameter applies if the availability replica is the current primary replica of the availability group.")] String ReadOnlyRoutingList[];
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Output the network port the endpoint is listening on. Used by Get-TargetResource.")] Uint16 EndpointPort;
     [Read, Description("Output the endpoint URL of the Availability Group Replica. Used by Get-TargetResource.")] String EndpointUrl;
     [Read, Description("Output the NetName property from the SQL Server object. Used by Get-TargetResource.")] String SqlServerNetName;
+    [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
+++ b/DSCResources/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.schema.mof
@@ -16,7 +16,7 @@ class MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica : OMI_BaseResource
     [Write, Description("Specifies the failover mode. Default is 'Manual'."), ValueMap{"Automatic","Manual"}, Values{"Automatic","Manual"}] String FailoverMode;
     [Write, Description("Specifies the fully-qualified domain name (FQDN) and port to use when routing to the replica for read only connections.")] String ReadOnlyRoutingConnectionUrl;
     [Write, Description("Specifies an ordered list of replica server names that represent the probe sequence for connection director to use when redirecting read-only connections through this availability replica. This parameter applies if the availability replica is the current primary replica of the availability group.")] String ReadOnlyRoutingList[];
-    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Output the network port the endpoint is listening on. Used by Get-TargetResource.")] Uint16 EndpointPort;
     [Read, Description("Output the endpoint URL of the Availability Group Replica. Used by Get-TargetResource.")] String EndpointUrl;
     [Read, Description("Output the NetName property from the SQL Server object. Used by Get-TargetResource.")] String SqlServerNetName;

--- a/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/1-CreateAvailabilityGroupReplica.ps1
+++ b/Examples/Resources/xSQLServerAlwaysOnAvailabilityGroupReplica/1-CreateAvailabilityGroupReplica.ps1
@@ -1,14 +1,21 @@
 <#
 .EXAMPLE
     This example shows how to ensure that the Availability Group Replica 'SQL2' exists in the Availability Group 'TestAG'.
+
+    In the event this is applied to a Failover Cluster Instance (FCI), the
+    ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+    to evaluate if any changes are needed if the node is actively hosting the
+    SQL Server Instance.
 #>
 
 $ConfigurationData = @{
     AllNodes = @(
         @{
-            NodeName              = '*'
-            SQLInstanceName       = 'MSSQLSERVER'
-            AvailabilityGroupName = 'TestAG'
+            NodeName                = '*'
+            SQLInstanceName         = 'MSSQLSERVER'
+            AvailabilityGroupName   = 'TestAG'
+            ProcessOnlyOnActiveNode = $true
+
         },
 
         @{
@@ -94,6 +101,7 @@ Configuration Example
                 SQLInstanceName               = $Node.SQLInstanceName
                 PrimaryReplicaSQLServer       = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).NodeName
                 PrimaryReplicaSQLInstanceName = ( $AllNodes | Where-Object { $_.Role -eq 'PrimaryReplica' } ).SQLInstanceName
+                ProcessOnlyOnActiveNode       = $Node.ProcessOnlyOnActiveNode
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Always On Availability Group Replica.
   the availability group.
 * **`[Boolean]` ProcessOnlyOnActiveNode** _(Write)_: Specifies that the resource
   will only determine if a change is needed if the target node is the active
-  host of the SQL Server Instance.
+  host of the SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ Always On Availability Group Replica.
   when redirecting read-only connections through this availability replica. This
   parameter applies if the availability replica is the current primary replica of
   the availability group.
+* **`[Boolean]` ProcessOnlyOnActiveNode** _(Write)_: Specifies that the resource
+  will only determine if a change is needed if the target node is the active
+  host of the SQL Server Instance.
 
 #### Read-Only Properties from Get-TargetResource
 
@@ -373,6 +376,8 @@ Always On Availability Group Replica.
   Availability Group Replica. Used by Get-TargetResource.
 * **`[String]` SQLServerNetName** _(Read)_: Output the NetName property from the
   SQL Server object.
+* **`[Boolean]` IsActiveNode** _(Read)_: Determines if the current node is
+  actively hosting the SQL Server instance.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAlwaysOnAvailabilityGroupReplica.Tests.ps1
@@ -52,6 +52,7 @@ try
         $mockFailoverMode = 'Manual'
         $mockReadOnlyRoutingConnectionUrl = "TCP://$($mockSqlServer).domain.com:1433"
         $mockReadOnlyRoutingList = @($mockSqlServer)
+        $mockProcessOnlyOnActiveNode = $false
 
         #endregion
 
@@ -1288,9 +1289,13 @@ try
                     FailoverMode                  = $mockFailoverMode
                     ReadOnlyRoutingConnectionUrl  = $mockReadOnlyRoutingConnectionUrl
                     ReadOnlyRoutingList           = $mockReadOnlyRoutingList
+                    ProcessOnlyOnActiveNode       = $mockProcessOnlyOnActiveNode
                 }
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -Verifiable
+                Mock -CommandName Test-ActiveNode -MockWith {
+                    return -not $mockProcessOnlyOnActiveNode
+                } -Verifiable
             }
 
             Context 'When the desired state is absent' {
@@ -1338,6 +1343,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $true when the Availability Replica is present' {
@@ -1345,6 +1351,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 foreach ( $propertyToCheck in $propertiesToCheck.GetEnumerator() )
@@ -1355,6 +1362,7 @@ try
                         Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                     }
                 }
 
@@ -1365,6 +1373,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $true when the Availability Replica is present and the Endpoint Hostname is not specified' {
@@ -1374,6 +1383,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is present and the Endpoint Hostname is not in the desired state' {
@@ -1383,6 +1393,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is present and the Endpoint Protocol is not in the desired state' {
@@ -1392,6 +1403,7 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
 
                 It 'Should return $false when the Availability Replica is present and the Endpoint Port is not in the desired state' {
@@ -1401,6 +1413,20 @@ try
                     Test-TargetResource @testTargetResourceParameters | Should -Be $false
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
+
+                    $mockAlternateEndpointPort = $false
+                }
+
+                It 'Should return $true when ProcessOnlyOnActiveNode is "$true" and the current node is not actively hosting the instance' {
+                    $mockProcessOnlyOnActiveNode = $true
+
+                    $testTargetResourceParameters.ProcessOnlyOnActiveNode = $mockProcessOnlyOnActiveNode
+
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Test-ActiveNode -Scope It -Times 1 -Exactly
                 }
             }
         }


### PR DESCRIPTION
**Pull Request (PR) description**
Added the parameter `ProcessOnlyOnActiveNode` to allow the end user to specify that the resource should not attempt to run if the current node is not actively hosting the SQL Instance.

**This Pull Request (PR) fixes the following issues:**
Fixes #870 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [X] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/892)
<!-- Reviewable:end -->
