### PR TITLE
xSQLServerMemory: Make Cluster Aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - Added the CommonTestHelper.psm1 to store common testing functions.
   - Added the Import-SQLModuleStub function to ensure the correct version of the
     module stubs are loaded ([issue #784](https://github.com/PowerShell/xSQLServer/issues/784)).
+- Changes to xSQLServerMemory
+  - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
+    the resource will only determine if a change is needed if the target node
+    is the active host of the SQL Server instance ([issue #867](https://github.com/PowerShell/xSQLServer/issues/867)).
 - Changes to xSQLServerNetwork
   - BREAKING CHANGE: Renamed parameter TcpDynamicPorts to TcpDynamicPort and
     changed type to Boolean ([issue #534](https://github.com/PowerShell/xSQLServer/issues/534)).

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -2,13 +2,13 @@ Import-Module -Name (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Pare
 
 <#
     .SYNOPSIS
-    This function gets the value of the min and max memory server configuration option.
+        This function gets the value of the min and max memory server configuration option.
 
     .PARAMETER SQLServer
-    The host name of the SQL Server to be configured.
+        The host name of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 #>
 
 function Get-TargetResource
@@ -35,6 +35,9 @@ function Get-TargetResource
         Write-Verbose -Message 'Getting the value for minimum and maximum SQL server memory.'
         $minMemory = $sqlServerObject.Configuration.MinServerMemory.ConfigValue
         $maxMemory = $sqlServerObject.Configuration.MaxServerMemory.ConfigValue
+
+        # Is this node actively hosting the SQL instance?
+        $isActiveNode = Test-ActiveNode -ServerObject $serverObject
     }
 
     $returnValue = @{
@@ -42,6 +45,7 @@ function Get-TargetResource
         SQLServer       = $SQLServer
         MinMemory       = $minMemory
         MaxMemory       = $maxMemory
+        IsActiveNode    = $isActiveNode
     }
 
     $returnValue
@@ -49,27 +53,31 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    This function sets the value for the min and max memory server configuration option.
+        This function sets the value for the min and max memory server configuration option.
 
     .PARAMETER SQLServer
-    The host name of the SQL Server to be configured.
+        The host name of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
-    When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true.
-    When set to 'Absent' min and max memory will be set to default values.
+        When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true.
+        When set to 'Absent' min and max memory will be set to default values.
 
     .PARAMETER DynamicAlloc
-    If set to $true then max memory will be dynamically configured.
-    When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured.
+        If set to $true then max memory will be dynamically configured.
+        When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured.
 
     .PARAMETER MinMemory
-    This is the minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+        This is the minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
 
     .PARAMETER MaxMemory
-    This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+        This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+
+    .PARAMETER ProcessOnlyOnActiveNode
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+        Not used in Set-TargetResource.
 #>
 function Set-TargetResource
 {
@@ -101,7 +109,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Int32]
-        $MaxMemory
+        $MaxMemory,
+
+        [Parameter()]
+        [Boolean]
+        $ProcessOnlyOnActiveNode
     )
 
     $sqlServerObject = Connect-SQL -SQLServer $SQLServer -SQLInstanceName $SQLInstanceName
@@ -170,27 +182,30 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    This function tests the value of the min and max memory server configuration option.
+        This function tests the value of the min and max memory server configuration option.
 
     .PARAMETER SQLServer
-    The host name of the SQL Server to be configured.
+        The host name of the SQL Server to be configured.
 
     .PARAMETER SQLInstanceName
-    The name of the SQL instance to be configured.
+        The name of the SQL instance to be configured.
 
     .PARAMETER Ensure
-    When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true.
-    When set to 'Absent' min and max memory will be set to default values.
+        When set to 'Present' then min and max memory will be set to either the value in parameter MinMemory and MaxMemory or dynamically configured when parameter DynamicAlloc is set to $true.
+        When set to 'Absent' min and max memory will be set to default values.
 
     .PARAMETER DynamicAlloc
-    If set to $true then max memory will be dynamically configured.
-    When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured.
+        If set to $true then max memory will be dynamically configured.
+        When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured.
 
     .PARAMETER MinMemory
-    This is the minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+        This is the minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
 
     .PARAMETER MaxMemory
-    This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+        This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
+
+    .PARAMETER ProcessOnlyOnActiveNode
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
 #>
 function Test-TargetResource
 {
@@ -223,7 +238,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Int32]
-        $MaxMemory
+        $MaxMemory,
+
+        [Parameter()]
+        [Boolean]
+        $ProcessOnlyOnActiveNode
     )
 
     Write-Verbose -Message 'Testing the values of the minimum and maximum memory server configuration option set to be used by the instance.'
@@ -234,6 +253,17 @@ function Test-TargetResource
     }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+    <#
+        If this is supposed to process only the active node, and this is not the
+        active node, don't bother evaluating the test.
+    #>
+    if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
+    {
+        # Use localization if the resource has been converted
+        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME,$SQLInstanceName )
+        return $result
+    }
 
     $currentMinMemory = $getTargetResourceResult.MinMemory
     $currentMaxMemory = $getTargetResourceResult.MaxMemory

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -76,7 +76,7 @@ function Get-TargetResource
         This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
 
     .PARAMETER ProcessOnlyOnActiveNode
-        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.
         Not used in Set-TargetResource.
 #>
 function Set-TargetResource
@@ -205,7 +205,7 @@ function Set-TargetResource
         This is the maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.
 
     .PARAMETER ProcessOnlyOnActiveNode
-        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.
 #>
 function Test-TargetResource
 {

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.psm1
@@ -37,7 +37,7 @@ function Get-TargetResource
         $maxMemory = $sqlServerObject.Configuration.MaxServerMemory.ConfigValue
 
         # Is this node actively hosting the SQL instance?
-        $isActiveNode = Test-ActiveNode -ServerObject $serverObject
+        $isActiveNode = Test-ActiveNode -ServerObject $sqlServerObject
     }
 
     $returnValue = @{
@@ -254,6 +254,10 @@ function Test-TargetResource
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
+    $currentMinMemory = $getTargetResourceResult.MinMemory
+    $currentMaxMemory = $getTargetResourceResult.MaxMemory
+    $isServerMemoryInDesiredState = $true
+
     <#
         If this is supposed to process only the active node, and this is not the
         active node, don't bother evaluating the test.
@@ -262,12 +266,8 @@ function Test-TargetResource
     {
         # Use localization if the resource has been converted
         New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME,$SQLInstanceName )
-        return $result
+        return $isServerMemoryInDesiredState
     }
-
-    $currentMinMemory = $getTargetResourceResult.MinMemory
-    $currentMaxMemory = $getTargetResourceResult.MaxMemory
-    $isServerMemoryInDesiredState = $true
 
     switch ($Ensure)
     {

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
@@ -7,6 +7,6 @@ class MSFT_xSQLServerMemory : OMI_BaseResource
     [Write, Description("If set to $true then max memory will be dynamically configured. When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured. Default value is $false.")] Boolean DynamicAlloc;
     [Write, Description("Minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.")] Sint32 MinMemory;
     [Write, Description("Maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.")] Sint32 MaxMemory;
-    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
     [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
+++ b/DSCResources/MSFT_xSQLServerMemory/MSFT_xSQLServerMemory.schema.mof
@@ -7,4 +7,6 @@ class MSFT_xSQLServerMemory : OMI_BaseResource
     [Write, Description("If set to $true then max memory will be dynamically configured. When this is set parameter is set to $true, the parameter MaxMemory must be set to $null or not be configured. Default value is $false.")] Boolean DynamicAlloc;
     [Write, Description("Minimum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.")] Sint32 MinMemory;
     [Write, Description("Maximum amount of memory, in MB, in the buffer pool used by the instance of SQL Server.")] Sint32 MaxMemory;
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/Examples/Resources/xSQLServerMemory/2-SetMaxMemoryToAuto.ps1
+++ b/Examples/Resources/xSQLServerMemory/2-SetMaxMemoryToAuto.ps1
@@ -6,7 +6,7 @@
     In the event this is applied to a Failover Cluster Instance (FCI), the
     ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
     to evaluate if any changes are needed if the node is actively hosting the
-    SQL Server Instance.
+    SQL Server instance.
 #>
 Configuration Example
 {

--- a/Examples/Resources/xSQLServerMemory/2-SetMaxMemoryToAuto.ps1
+++ b/Examples/Resources/xSQLServerMemory/2-SetMaxMemoryToAuto.ps1
@@ -2,6 +2,11 @@
 .EXAMPLE
     This example shows how to set the maximum memory
     configuration option with the automatic configuration.
+
+    In the event this is applied to a Failover Cluster Instance (FCI), the
+    ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+    to evaluate if any changes are needed if the node is actively hosting the
+    SQL Server Instance.
 #>
 Configuration Example
 {
@@ -19,11 +24,12 @@ Configuration Example
     {
         xSQLServerMemory Set_SQLServerMaxMemory_ToAuto
         {
-            Ensure               = 'Present'
-            DynamicAlloc         = $true
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            Ensure                  = 'Present'
+            DynamicAlloc            = $true
+            SQLServer               = 'SQLServer'
+            SQLInstanceName         = 'DSC'
+            PsDscRunAsCredential    = $SysAdminAccount
+            ProcessOnlyOnActiveNode = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) -
   pool used by the instance of SQL Server.
 * **`[Boolean]` ProcessOnlyOnActiveNode** _(Write)_: Specifies that the resource
   will only determine if a change is needed if the target node is the active
-  host of the SQL Server Instance.
+  host of the SQL Server instance.
 
 #### Read-Only Properties from Get-TargetResource
 

--- a/README.md
+++ b/README.md
@@ -956,6 +956,14 @@ SQL Max Memory = TotalPhysicalMemory - (NumOfSQLThreads\*ThreadStackSize) -
   pool used by the instance of SQL Server.
 * **`[Sint32]` MaxMemory** _(Write)_: Maximum amount of memory, in MB, in the buffer
   pool used by the instance of SQL Server.
+* **`[Boolean]` ProcessOnlyOnActiveNode** _(Write)_: Specifies that the resource
+  will only determine if a change is needed if the target node is the active
+  host of the SQL Server Instance.
+
+#### Read-Only Properties from Get-TargetResource
+
+* **`[Boolean]` IsActiveNode** _(Read)_: Determines if the current node is
+  actively hosting the SQL Server instance.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMemory.Tests.ps1
@@ -342,19 +342,19 @@ try
                     Assert-MockCalled Connect-SQL -Exactly -Times 1 -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
+                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_PhysicalMemory' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
                         $ClassName -eq 'Win32_PhysicalMemory'
                     } -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
+                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_Processor' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
                         $ClassName -eq 'Win32_Processor'
                     } -Scope Context
                 }
 
-                It 'Should call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
+                It 'Should not call the mock function Get-CimInstance with ClassName equal to Win32_operatingsystem' {
                     Assert-MockCalled Get-CimInstance -Exactly -Times 0 -ParameterFilter {
                         $ClassName -eq 'Win32_operatingsystem'
                     } -Scope Context


### PR DESCRIPTION
**Pull Request (PR) description**
Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified, the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance

**This Pull Request (PR) fixes the following issues:**
Fixes #867 

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [X] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [X] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/896)
<!-- Reviewable:end -->
