### PR TITLE
xSQLServer: Fix running tests locally in PowerShell console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@
 - Added resource
   - xSQLServerDatabaseDefaultLocation
     ([issue #656](https://github.com/PowerShell/xSQLServer/issues/656))
+- Changes to xSQLServerEndpointPermission
+  - Fixed a problem when running the tests locally in a PowerShell console it
+    would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
+- Changes to xSQLServerAvailabilityGroupListener
+  - Fixed a problem when running the tests locally in a PowerShell console it
+    would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
 
 ## 8.2.0.0
 

--- a/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerAvailabilityGroupListener.Tests.ps1
@@ -95,7 +95,7 @@ try
 
         Describe 'xSQLServerAvailabilityGroupListener\Get-TargetResource' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -226,17 +226,15 @@ try
 
         Describe 'xSQLServerAvailabilityGroupListener\Test-TargetResource' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
             }
 
             Context 'When the system is not in the desired state (for static IP)' {
                 It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.10.45/255.255.252.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
 
@@ -263,9 +261,7 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -274,12 +270,10 @@ try
                 }
 
                 It 'Should return that desired state is absent when IP address is different' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.10.45/255.255.252.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -288,12 +282,10 @@ try
                 }
 
                 It 'Should return that desired state is absent when DHCP is absent but should be present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $true
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $true
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -302,9 +294,7 @@ try
                 }
 
                 It 'Should return that desired state is absent when DHCP is the only set parameter' {
-                    $testParameters += @{
-                        DHCP = $true
-                    }
+                    $testParameters['DHCP'] = $true
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -329,12 +319,10 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is absent when port is different' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -361,12 +349,10 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is absent when DHCP is present but should be absent' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.100/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.100/255.255.255.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -375,9 +361,7 @@ try
                 }
 
                 It 'Should return that desired state is absent when IP address is the only set parameter' {
-                    $testParameters += @{
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                    }
+                    $testParameters['IpAddress'] = '192.168.10.45/255.255.252.0'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -402,9 +386,7 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is absent when port is the only set parameter' {
-                    $testParameters += @{
-                        Port = 5030
-                    }
+                    $testParameters['Port'] = 5030
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -415,12 +397,10 @@ try
 
             Context 'When the system is in the desired state (for static IP)' {
                 It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Absent'
+                    $testParameters['IpAddress'] = '192.168.10.45/255.255.252.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     Mock -CommandName Get-SQLAlwaysOnAvailabilityGroupListener -MockWith {} -Verifiable
 
@@ -447,12 +427,10 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -461,9 +439,7 @@ try
                 }
 
                 It 'Should return that desired state is present when IP address is the only set parameter' {
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                    }
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -472,9 +448,7 @@ try
                 }
 
                 It 'Should return that desired state is present when port is the only set parameter' {
-                    $testParameters += @{
-                        Port = 5030
-                    }
+                    $testParameters['Port'] = 5030
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -501,12 +475,10 @@ try
                 } -Verifiable
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, with DHCP' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = 5030
-                        DHCP = $true
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $true
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -515,9 +487,7 @@ try
                 }
 
                 It 'Should return that desired state is present when DHCP is the only set parameter' {
-                    $testParameters += @{
-                        DHCP = $true
-                    }
+                    $testParameters['DHCP'] = $true
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -541,7 +511,7 @@ try
 
         Describe 'xSQLServerAvailabilityGroupListener\Set-TargetResource' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
                 Mock -CommandName New-SqlAvailabilityGroupListener -MockWith {} -Verifiable
@@ -553,12 +523,10 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state, when using Static IP' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.45/255.255.252.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.10.45/255.255.252.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -571,12 +539,10 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state, when using DHCP and specific DhcpSubnet' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.10.1/255.255.252.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $true
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.10.1/255.255.252.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $true
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -589,11 +555,9 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should call the cmdlet New-SqlAvailabilityGroupListener when system is not in desired state, when using DHCP and server default DhcpSubnet' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Port = $mockKnownPortNumber
-                        DHCP = $true
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $true
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -608,11 +572,9 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should throw when trying to change an existing IP address' {
-                    $testParameters += @{
-                        IpAddress = '10.0.0.1/255.255.252.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['IpAddress'] = '10.0.0.1/255.255.252.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     { Set-TargetResource @testParameters } | Should -Throw
 
@@ -627,11 +589,9 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should throw when trying to change from static IP to DHCP' {
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $true
-                    }
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $true
 
                     { Set-TargetResource @testParameters } | Should -Throw
 
@@ -646,11 +606,9 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should call the cmdlet Add-SqlAvailabilityGroupListenerStaticIp, when adding another IP address, and system is not in desired state' {
-                    $testParameters += @{
-                        IpAddress = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
-                        Port = 5030
-                        DHCP = $false
-                    }
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0','10.0.0.1/255.255.252.0')
+                    $testParameters['Port'] = 5030
+                    $testParameters['DHCP'] = $false
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -665,12 +623,10 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -684,9 +640,7 @@ try
                 $script:mockMethodDropRan = $false # This is set to $true when Drop() method is called. make sure we start the test with $false.
 
                 It 'Should not call the any cmdlet *-SqlAvailability* or the the Drop() method when system is in desired state and ensure is set to ''Absent''' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodDropRan | Should -Be $true # Should have made one call to the Drop() method.
@@ -701,12 +655,10 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should throw the correct error when availability group is not found and Ensure is set to ''Present''' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
@@ -718,9 +670,7 @@ try
                 }
 
                 It 'Should throw the correct error when availability group is not found and Ensure is set to ''Absent''' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
@@ -735,20 +685,16 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should throw the correct error when listener is not found and Ensure is set to ''Absent''' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
 
                     { Set-TargetResource @testParameters } | Should -Throw 'Trying to make a change to a listener that does not exist.'
                 }
 
                 It 'Should throw the correct error when listener is not found and Ensure is set to ''Present''' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
@@ -768,12 +714,10 @@ try
                 $mockDynamicListenerName = $mockUnknownListenerName
 
                 It 'Should throw the correct error when availability group is not found and Ensure is set to ''Present''' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                        DHCP = $false
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
+                    $testParameters['DHCP'] = $false
 
                     Mock -CommandName Get-TargetResource -MockWith {
                         return @{
@@ -796,11 +740,9 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -815,10 +757,8 @@ try
                 $mockDynamicPortNumber = $mockKnownPortNumber
 
                 It 'Should not call the any cmdlet *-SqlAvailability* when system is in desired state (without ensure parameter)' {
-                    $testParameters += @{
-                        IpAddress = '192.168.0.1/255.255.255.0'
-                        Port = $mockKnownPortNumber
-                    }
+                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['Port'] = $mockKnownPortNumber
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
 
@@ -832,9 +772,7 @@ try
                 $script:mockMethodDropRan = $false # This is set to $true when Drop() method is called. make sure we start the test with $false.
 
                 It 'Should not call the any cmdlet *-SqlAvailability* or the the Drop() method when system is in desired state and ensure is set to ''Absent''' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodDropRan | Should -Be $false # Should not have called Drop() method.

--- a/Tests/Unit/MSFT_xSQLServerEndpointPermission.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerEndpointPermission.Tests.ps1
@@ -93,7 +93,7 @@ try
 
         Describe 'MSFT_xSQLServerEndpointPermission\Get-TargetResource' -Tag 'Get' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -169,7 +169,7 @@ try
 
         Describe 'MSFT_xSQLServerEndpointPermission\Test-TargetResource' -Tag 'Test' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -178,10 +178,8 @@ try
                 $mockDynamicPrincipal = $mockOtherPrincipal
 
                 It 'Should return that desired state is absent when wanted desired state is to be Present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -192,10 +190,8 @@ try
                 $mockDynamicPrincipal = $mockPrincipal
 
                 It 'Should return that desired state is absent when wanted desired state is to be Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
@@ -208,10 +204,8 @@ try
                 $mockDynamicPrincipal = $mockPrincipal
 
                 It 'Should return that desired state is present when wanted desired state is to be Present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -222,10 +216,8 @@ try
                 $mockDynamicPrincipal = $mockOtherPrincipal
 
                 It 'Should return that desired state is present when wanted desired state is to be Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
@@ -239,7 +231,7 @@ try
 
         Describe 'MSFT_xSQLServerEndpointPermission\Set-TargetResource' -Tag 'Set' {
             BeforeEach {
-                $testParameters = $defaultParameters
+                $testParameters = $defaultParameters.Clone()
 
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSql -Verifiable
             }
@@ -250,10 +242,8 @@ try
                 $script:mockMethodRevokeRan = $false
 
                 It 'Should call the the method Grant when desired state is to be Present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodGrantRan | Should -Be $true
@@ -267,10 +257,8 @@ try
                 $script:mockMethodRevokeRan = $false
 
                 It 'Should call the the method Revoke when desired state is to be Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodGrantRan | Should -Be $false
@@ -304,10 +292,8 @@ try
                 $script:mockMethodRevokeRan = $false
 
                 It 'Should not call Grant() or Revoke() method when desired state is already Present' {
-                    $testParameters += @{
-                        Ensure = 'Present'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Present'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodGrantRan | Should -Be $false
@@ -321,10 +307,8 @@ try
                 $script:mockMethodRevokeRan = $false
 
                 It 'Should not call Grant() or Revoke() method when desired state is already Absent' {
-                    $testParameters += @{
-                        Ensure = 'Absent'
-                        Permission = 'CONNECT'
-                    }
+                    $testParameters['Ensure'] = 'Absent'
+                    $testParameters['Permission'] = 'CONNECT'
 
                     { Set-TargetResource @testParameters } | Should -Not -Throw
                     $script:mockMethodGrantRan | Should -Be $false


### PR DESCRIPTION
**Pull Request (PR) description**
- Changes to xSQLServerEndpointPermission
  - Fixed a problem when running the tests locally in a PowerShell console it
    would ask for parameters (issue #897).
- Changes to xSQLServerAvailabilityGroupListener
  - Fixed a problem when running the tests locally in a PowerShell console it
    would ask for parameters (issue #897).

**This Pull Request (PR) fixes the following issues:**
Fixes #897 

**Task list:**
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/898)
<!-- Reviewable:end -->
