### PR TITLE
xSQLServerMaxDop: Added Cluster Aware code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 - Changes to xSQLServerAvailabilityGroupListener
   - Fixed a problem when running the tests locally in a PowerShell console it
     would ask for parameters ([issue #897](https://github.com/PowerShell/xSQLServer/issues/897)).
+- Changes to xSQLServerMaxDop
+  - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
+    the resource will only determine if a change is needed if the target node
+    is the active host of the SQL Server instance ([issue #882](https://github.com/PowerShell/xSQLServer/issues/882)).
 
 ## 8.2.0.0
 

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.psm1
@@ -235,7 +235,7 @@ function Test-TargetResource
     #>
     if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
     {
-        Write-Verbose -Message ($script:localizedData.NotActiveClusterNode -f $env:COMPUTERNAME,$SQLInstanceName )
+        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME,$SQLInstanceName )
         return $isMaxDopInDesiredState
     }
 

--- a/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.schema.mof
+++ b/DSCResources/MSFT_xSQLServerMaxDop/MSFT_xSQLServerMaxDop.schema.mof
@@ -6,4 +6,6 @@ class MSFT_xSQLServerMaxDop : OMI_BaseResource
     [Write, Description("A numeric value to limit the number of processors used in parallel plan execution.")] Sint32 MaxDop;
     [Write, Description("The host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String SQLServer;
     [Key, Description("The name of the SQL instance to be configured.")] String SQLInstanceName;
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };

--- a/Examples/Resources/xSQLServerMaxDop/2-SetMaxDopToAuto.ps1
+++ b/Examples/Resources/xSQLServerMaxDop/2-SetMaxDopToAuto.ps1
@@ -2,6 +2,11 @@
 .EXAMPLE
     This example shows how to set max degree of parallelism server
     configuration option with the automatic configuration.
+
+    In the event this is applied to a Failover Cluster Instance (FCI), the
+    ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+    to evaluate if any changes are needed if the node is actively hosting the
+    SQL Server instance.
 #>
 Configuration Example
 {
@@ -19,11 +24,12 @@ Configuration Example
     {
         xSQLServerMaxDop Set_SQLServerMaxDop_ToAuto
         {
-            Ensure               = 'Present'
-            DynamicAlloc         = $true
-            SQLServer            = 'SQLServer'
-            SQLInstanceName      = 'DSC'
-            PsDscRunAsCredential = $SysAdminAccount
+            Ensure                  = 'Present'
+            DynamicAlloc            = $true
+            SQLServer               = 'SQLServer'
+            SQLInstanceName         = 'DSC'
+            PsDscRunAsCredential    = $SysAdminAccount
+            ProcessOnlyOnActiveNode = $true
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -935,6 +935,14 @@ Read more about max degree of parallelism in this article
   parameter MaxDop must be set to $null or not be configured.
 * **`[Sint32]` MaxDop** _(Write)_: A numeric value to limit the number of processors
   used in parallel plan execution.
+* **`[Boolean]` ProcessOnlyOnActiveNode** _(Write)_: Specifies that the resource
+  will only determine if a change is needed if the target node is the active
+  host of the SQL Server instance.
+
+#### Read-Only Property from Get-TargetResource
+
+* **`[Boolean]` IsActiveNode** _(Read)_: Determines if the current node is
+  actively hosting the SQL Server instance.
 
 #### Examples
 

--- a/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
+++ b/Tests/Unit/MSFT_xSQLServerMaxDop.Tests.ps1
@@ -303,7 +303,7 @@ try
                 }
             }
 
-            Context 'When the system is not in the desired state and Ensure is set to absent and ProcessOnlyOnActiveNode is set to true' {
+            Context 'When the ProcessOnlyOnActiveNode parameter is passed' {
                 AfterAll {
                     $mockProcessOnlyOnActiveNode = $true
                 }
@@ -318,7 +318,7 @@ try
                     $mockProcessOnlyOnActiveNode = $false
                 }
 
-                It 'Should return the state as true' {
+                It 'Should return $true when ProcessOnlyOnActiveNode is "$true" and the current node is not actively hosting the instance' {
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true
                 }


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project.
Your contribution to this project is greatly appreciated!

Please make sure you have read the contributing section
at https://github.com/PowerShell/xSQLServer#contributing.

Please prefix the PR title with the resource name,
i.e. 'xSQLServerSetup: My short description'
If this is a breaking change, then also prefix the PR title
with 'BREAKING CHANGE:',
i.e. 'BREAKING CHANGE: xSQLServerSetup: My short description'
-->
**Pull Request (PR) description**
Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified, the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance

**This Pull Request (PR) fixes the following issues:**
Fixes #882 
<!--
To aid community reviewers in reviewing and merging your pull request (PR), please take
the time to run through the below checklist.
Change to [x] for each task in the task list that applies to your pull request (PR).
-->
**Task List:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsqlserver/901)
<!-- Reviewable:end -->
